### PR TITLE
Add style section to CONTRIBUTING.md.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,9 +27,12 @@ accept your pull requests.
    Contributor License Agreement (see details above).
 1. Fork the desired repo, develop and test your code changes.
 1. Ensure that your code adheres to the existing style in the sample to which
-   you are contributing. Refer to the
-   [Google Cloud Platform Samples Style Guide]
-   (https://github.com/GoogleCloudPlatform/Template/wiki/style.html) for the
-   recommended coding standards for this organization.
+   you are contributing.
 1. Ensure that your code has an appropriate set of unit tests which all pass.
 1. Submit a pull request.
+
+## Style
+
+Samples in this repository follow the [framework coding
+style](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/coding-style.md).
+This is enforced using [CodeFormatter](https://github.com/dotnet/codeformatter).


### PR DESCRIPTION
I'd like to point https://github.com/GoogleCloudPlatform/Template/wiki/style.html back to the repositories where the samples should go.