### PR TITLE
Keep retrying for longer.

### DIFF
--- a/storage/api-veneer/QuickStartTest/QuickStartTest.cs
+++ b/storage/api-veneer/QuickStartTest/QuickStartTest.cs
@@ -177,7 +177,7 @@ namespace GoogleCloudSamples
                     action();
                     return;
                 }
-                catch (Xunit.Sdk.XunitException) when (i < 4)
+                catch (Xunit.Sdk.XunitException) when (i < 6)
                 {
                     Thread.Sleep(delayMs);
                     delayMs *= 2;


### PR DESCRIPTION
2 tests failed over the weekend because the timeout of 10+ seconds was not
long enough.