### PR TITLE
Fix flaky test

### DIFF
--- a/logging/api/App.config
+++ b/logging/api/App.config
@@ -7,15 +7,19 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Google.Apis.Auth" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.16.0.0" newVersion="1.16.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.18.0.0" newVersion="1.18.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Google.Apis.Auth.PlatformServices" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.16.0.0" newVersion="1.16.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.18.0.0" newVersion="1.18.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.2.15.0" newVersion="1.2.15.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Interactive.Async" publicKeyToken="94bc3704cddfc263" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.1000.0" newVersion="3.0.1000.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/logging/api/LoggingSample.csproj
+++ b/logging/api/LoggingSample.csproj
@@ -40,43 +40,47 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Api.CommonProtos, Version=1.0.0.0, Culture=neutral, PublicKeyToken=3ec5ea7f18953e47, processorArchitecture=MSIL">
-      <HintPath>packages\Google.Api.CommonProtos.1.0.0-beta02\lib\net45\Google.Api.CommonProtos.dll</HintPath>
+      <HintPath>packages\Google.Api.CommonProtos.1.0.0-beta04\lib\net45\Google.Api.CommonProtos.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Api.Gax, Version=1.0.0.0, Culture=neutral, PublicKeyToken=3ec5ea7f18953e47, processorArchitecture=MSIL">
-      <HintPath>packages\Google.Api.Gax.1.0.0-beta02\lib\net45\Google.Api.Gax.dll</HintPath>
+      <HintPath>packages\Google.Api.Gax.1.0.0-beta04\lib\net45\Google.Api.Gax.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis, Version=1.16.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>packages\Google.Apis.1.16.0\lib\net45\Google.Apis.dll</HintPath>
+    <Reference Include="Google.Api.Gax.Grpc, Version=1.0.0.0, Culture=neutral, PublicKeyToken=3ec5ea7f18953e47, processorArchitecture=MSIL">
+      <HintPath>packages\Google.Api.Gax.Grpc.1.0.0-beta04\lib\net45\Google.Api.Gax.Grpc.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.Auth, Version=1.16.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>packages\Google.Apis.Auth.1.16.0\lib\net45\Google.Apis.Auth.dll</HintPath>
+    <Reference Include="Google.Apis, Version=1.18.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>packages\Google.Apis.1.18.0\lib\net45\Google.Apis.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.Auth.PlatformServices, Version=1.16.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>packages\Google.Apis.Auth.1.16.0\lib\net45\Google.Apis.Auth.PlatformServices.dll</HintPath>
+    <Reference Include="Google.Apis.Auth, Version=1.18.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>packages\Google.Apis.Auth.1.18.0\lib\net45\Google.Apis.Auth.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.Core, Version=1.16.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>packages\Google.Apis.Core.1.16.0\lib\net45\Google.Apis.Core.dll</HintPath>
+    <Reference Include="Google.Apis.Auth.PlatformServices, Version=1.18.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>packages\Google.Apis.Auth.1.18.0\lib\net45\Google.Apis.Auth.PlatformServices.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.PlatformServices, Version=1.16.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>packages\Google.Apis.1.16.0\lib\net45\Google.Apis.PlatformServices.dll</HintPath>
+    <Reference Include="Google.Apis.Core, Version=1.18.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>packages\Google.Apis.Core.1.18.0\lib\net45\Google.Apis.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Google.Apis.PlatformServices, Version=1.18.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>packages\Google.Apis.1.18.0\lib\net45\Google.Apis.PlatformServices.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Logging.Log4Net, Version=1.0.0.0, Culture=neutral, PublicKeyToken=185c282632e132a0, processorArchitecture=MSIL">
-      <HintPath>packages\Google.Logging.Log4Net.1.0.0-beta02\lib\net45\Google.Logging.Log4Net.dll</HintPath>
+      <HintPath>packages\Google.Logging.Log4Net.1.0.0-beta04\lib\net45\Google.Logging.Log4Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Logging.Type, Version=1.0.0.0, Culture=neutral, PublicKeyToken=185c282632e132a0, processorArchitecture=MSIL">
-      <HintPath>packages\Google.Logging.Type.1.0.0-beta02\lib\net45\Google.Logging.Type.dll</HintPath>
+      <HintPath>packages\Google.Logging.Type.1.0.0-beta04\lib\net45\Google.Logging.Type.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Logging.V2, Version=1.0.0.0, Culture=neutral, PublicKeyToken=185c282632e132a0, processorArchitecture=MSIL">
-      <HintPath>packages\Google.Logging.V2.1.0.0-beta02\lib\net45\Google.Logging.V2.dll</HintPath>
+      <HintPath>packages\Google.Logging.V2.1.0.0-beta04\lib\net45\Google.Logging.V2.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Protobuf, Version=3.0.0.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604, processorArchitecture=MSIL">
@@ -84,11 +88,11 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Grpc.Auth, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d754f35622e28bad, processorArchitecture=MSIL">
-      <HintPath>packages\Grpc.Auth.1.0.0\lib\net45\Grpc.Auth.dll</HintPath>
+      <HintPath>packages\Grpc.Auth.1.0.1\lib\net45\Grpc.Auth.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Grpc.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d754f35622e28bad, processorArchitecture=MSIL">
-      <HintPath>packages\Grpc.Core.1.0.0\lib\net45\Grpc.Core.dll</HintPath>
+      <HintPath>packages\Grpc.Core.1.0.1\lib\net45\Grpc.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="log4net, Version=1.2.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
@@ -112,11 +116,13 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Interactive.Async, Version=3.0.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
-      <HintPath>packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+    <Reference Include="System.Interactive.Async, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>packages\System.Interactive.Async.3.1.0-rc2\lib\net45\System.Interactive.Async.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
@@ -127,6 +133,11 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Runtime.InteropServices.RuntimeInformation.4.0.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -163,17 +174,17 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="packages\Grpc.Core.1.0.0\build\net45\Grpc.Core.targets" Condition="Exists('packages\Grpc.Core.1.0.0\build\net45\Grpc.Core.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('packages\Grpc.Core.1.0.0\build\net45\Grpc.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Grpc.Core.1.0.0\build\net45\Grpc.Core.targets'))" />
-  </Target>
   <Import Project="packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
   <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
     <Error Condition="!Exists('packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
     <Error Condition="Exists('packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
+  </Target>
+  <Import Project="packages\Grpc.Core.1.0.1\build\net45\Grpc.Core.targets" Condition="Exists('packages\Grpc.Core.1.0.1\build\net45\Grpc.Core.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('packages\Grpc.Core.1.0.1\build\net45\Grpc.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Grpc.Core.1.0.1\build\net45\Grpc.Core.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/logging/api/LoggingTest/LoggingTest.csproj
+++ b/logging/api/LoggingTest/LoggingTest.csproj
@@ -38,43 +38,47 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Api.CommonProtos, Version=1.0.0.0, Culture=neutral, PublicKeyToken=3ec5ea7f18953e47, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Api.CommonProtos.1.0.0-beta02\lib\net45\Google.Api.CommonProtos.dll</HintPath>
+      <HintPath>..\packages\Google.Api.CommonProtos.1.0.0-beta04\lib\net45\Google.Api.CommonProtos.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Api.Gax, Version=1.0.0.0, Culture=neutral, PublicKeyToken=3ec5ea7f18953e47, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Api.Gax.1.0.0-beta02\lib\net45\Google.Api.Gax.dll</HintPath>
+      <HintPath>..\packages\Google.Api.Gax.1.0.0-beta04\lib\net45\Google.Api.Gax.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis, Version=1.16.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.1.16.0\lib\net45\Google.Apis.dll</HintPath>
+    <Reference Include="Google.Api.Gax.Grpc, Version=1.0.0.0, Culture=neutral, PublicKeyToken=3ec5ea7f18953e47, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Api.Gax.Grpc.1.0.0-beta04\lib\net45\Google.Api.Gax.Grpc.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.Auth, Version=1.16.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.Auth.1.16.0\lib\net45\Google.Apis.Auth.dll</HintPath>
+    <Reference Include="Google.Apis, Version=1.18.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.1.18.0\lib\net45\Google.Apis.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.Auth.PlatformServices, Version=1.16.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.Auth.1.16.0\lib\net45\Google.Apis.Auth.PlatformServices.dll</HintPath>
+    <Reference Include="Google.Apis.Auth, Version=1.18.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.Auth.1.18.0\lib\net45\Google.Apis.Auth.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.Core, Version=1.16.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.Core.1.16.0\lib\net45\Google.Apis.Core.dll</HintPath>
+    <Reference Include="Google.Apis.Auth.PlatformServices, Version=1.18.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.Auth.1.18.0\lib\net45\Google.Apis.Auth.PlatformServices.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.PlatformServices, Version=1.16.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.1.16.0\lib\net45\Google.Apis.PlatformServices.dll</HintPath>
+    <Reference Include="Google.Apis.Core, Version=1.18.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.Core.1.18.0\lib\net45\Google.Apis.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Google.Apis.PlatformServices, Version=1.18.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.1.18.0\lib\net45\Google.Apis.PlatformServices.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Logging.Log4Net, Version=1.0.0.0, Culture=neutral, PublicKeyToken=185c282632e132a0, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Logging.Log4Net.1.0.0-beta02\lib\net45\Google.Logging.Log4Net.dll</HintPath>
+      <HintPath>..\packages\Google.Logging.Log4Net.1.0.0-beta04\lib\net45\Google.Logging.Log4Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Logging.Type, Version=1.0.0.0, Culture=neutral, PublicKeyToken=185c282632e132a0, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Logging.Type.1.0.0-beta02\lib\net45\Google.Logging.Type.dll</HintPath>
+      <HintPath>..\packages\Google.Logging.Type.1.0.0-beta04\lib\net45\Google.Logging.Type.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Logging.V2, Version=1.0.0.0, Culture=neutral, PublicKeyToken=185c282632e132a0, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Logging.V2.1.0.0-beta02\lib\net45\Google.Logging.V2.dll</HintPath>
+      <HintPath>..\packages\Google.Logging.V2.1.0.0-beta04\lib\net45\Google.Logging.V2.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Protobuf, Version=3.0.0.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604, processorArchitecture=MSIL">
@@ -82,11 +86,11 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Grpc.Auth, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d754f35622e28bad, processorArchitecture=MSIL">
-      <HintPath>..\packages\Grpc.Auth.1.0.0\lib\net45\Grpc.Auth.dll</HintPath>
+      <HintPath>..\packages\Grpc.Auth.1.0.1\lib\net45\Grpc.Auth.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Grpc.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d754f35622e28bad, processorArchitecture=MSIL">
-      <HintPath>..\packages\Grpc.Core.1.0.0\lib\net45\Grpc.Core.dll</HintPath>
+      <HintPath>..\packages\Grpc.Core.1.0.1\lib\net45\Grpc.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="log4net, Version=1.2.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
@@ -110,11 +114,13 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Interactive.Async, Version=3.0.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+    <Reference Include="System.Interactive.Async, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Interactive.Async.3.1.0-rc2\lib\net45\System.Interactive.Async.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
@@ -125,6 +131,11 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.0.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -177,19 +188,19 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Grpc.Core.1.0.0\build\net45\Grpc.Core.targets" Condition="Exists('..\packages\Grpc.Core.1.0.0\build\net45\Grpc.Core.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Grpc.Core.1.0.0\build\net45\Grpc.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Grpc.Core.1.0.0\build\net45\Grpc.Core.targets'))" />
     <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\packages\Grpc.Core.1.0.1\build\net45\Grpc.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Grpc.Core.1.0.1\build\net45\Grpc.Core.targets'))" />
   </Target>
   <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
   <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
     <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
     <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
   </Target>
+  <Import Project="..\packages\Grpc.Core.1.0.1\build\net45\Grpc.Core.targets" Condition="Exists('..\packages\Grpc.Core.1.0.1\build\net45\Grpc.Core.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/logging/api/LoggingTest/app.config
+++ b/logging/api/LoggingTest/app.config
@@ -4,15 +4,19 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Google.Apis.Auth" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.16.0.0" newVersion="1.16.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.18.0.0" newVersion="1.18.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Google.Apis.Auth.PlatformServices" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.16.0.0" newVersion="1.16.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.18.0.0" newVersion="1.18.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.2.15.0" newVersion="1.2.15.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Interactive.Async" publicKeyToken="94bc3704cddfc263" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.1000.0" newVersion="3.0.1000.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/logging/api/LoggingTest/packages.config
+++ b/logging/api/LoggingTest/packages.config
@@ -1,24 +1,57 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="BouncyCastle" version="1.7.0" targetFramework="net452" />
-  <package id="Google.Api.CommonProtos" version="1.0.0-beta02" targetFramework="net452" />
-  <package id="Google.Api.Gax" version="1.0.0-beta02" targetFramework="net452" />
-  <package id="Google.Apis" version="1.16.0" targetFramework="net452" />
-  <package id="Google.Apis.Auth" version="1.16.0" targetFramework="net452" />
-  <package id="Google.Apis.Core" version="1.16.0" targetFramework="net452" />
-  <package id="Google.Logging.Log4Net" version="1.0.0-beta02" targetFramework="net452" />
-  <package id="Google.Logging.Type" version="1.0.0-beta02" targetFramework="net452" />
-  <package id="Google.Logging.V2" version="1.0.0-beta02" targetFramework="net452" />
+  <package id="Google.Api.CommonProtos" version="1.0.0-beta04" targetFramework="net452" />
+  <package id="Google.Api.Gax" version="1.0.0-beta04" targetFramework="net452" />
+  <package id="Google.Api.Gax.Grpc" version="1.0.0-beta04" targetFramework="net452" />
+  <package id="Google.Apis" version="1.18.0" targetFramework="net452" />
+  <package id="Google.Apis.Auth" version="1.18.0" targetFramework="net452" />
+  <package id="Google.Apis.Core" version="1.18.0" targetFramework="net452" />
+  <package id="Google.Logging.Log4Net" version="1.0.0-beta04" targetFramework="net452" />
+  <package id="Google.Logging.Type" version="1.0.0-beta04" targetFramework="net452" />
+  <package id="Google.Logging.V2" version="1.0.0-beta04" targetFramework="net452" />
   <package id="Google.Protobuf" version="3.0.0" targetFramework="net452" />
-  <package id="Grpc.Auth" version="1.0.0" targetFramework="net452" />
-  <package id="Grpc.Core" version="1.0.0" targetFramework="net452" />
+  <package id="Grpc.Auth" version="1.0.1" targetFramework="net452" />
+  <package id="Grpc.Core" version="1.0.1" targetFramework="net452" />
   <package id="log4net" version="2.0.5" targetFramework="net452" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net452" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net452" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net452" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net452" />
+  <package id="Microsoft.NETCore.Platforms" version="1.0.1" targetFramework="net452" />
+  <package id="NETStandard.Library" version="1.6.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
-  <package id="System.Interactive.Async" version="3.0.0" targetFramework="net452" />
+  <package id="System.Collections" version="4.0.11" targetFramework="net452" />
+  <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net452" />
+  <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net452" />
+  <package id="System.Diagnostics.Tools" version="4.0.1" targetFramework="net452" />
+  <package id="System.Diagnostics.Tracing" version="4.1.0" targetFramework="net452" />
+  <package id="System.Globalization" version="4.0.11" targetFramework="net452" />
+  <package id="System.Interactive.Async" version="3.1.0-rc2" targetFramework="net452" />
+  <package id="System.IO" version="4.1.0" targetFramework="net452" />
+  <package id="System.IO.Compression" version="4.1.0" targetFramework="net452" />
+  <package id="System.Linq" version="4.1.0" targetFramework="net452" />
+  <package id="System.Linq.Expressions" version="4.1.0" targetFramework="net452" />
+  <package id="System.Net.Http" version="4.1.0" targetFramework="net452" />
+  <package id="System.Net.Primitives" version="4.0.11" targetFramework="net452" />
+  <package id="System.ObjectModel" version="4.0.12" targetFramework="net452" />
+  <package id="System.Reflection" version="4.1.0" targetFramework="net452" />
+  <package id="System.Reflection.Extensions" version="4.0.1" targetFramework="net452" />
+  <package id="System.Reflection.Primitives" version="4.0.1" targetFramework="net452" />
+  <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net452" />
+  <package id="System.Runtime" version="4.1.0" targetFramework="net452" />
+  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net452" />
+  <package id="System.Runtime.InteropServices" version="4.1.0" targetFramework="net452" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" targetFramework="net452" />
+  <package id="System.Runtime.Numerics" version="4.0.1" targetFramework="net452" />
+  <package id="System.Text.Encoding" version="4.0.11" targetFramework="net452" />
+  <package id="System.Text.Encoding.Extensions" version="4.0.11" targetFramework="net452" />
+  <package id="System.Text.RegularExpressions" version="4.1.0" targetFramework="net452" />
+  <package id="System.Threading" version="4.0.11" targetFramework="net452" />
+  <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net452" />
+  <package id="System.Threading.Timer" version="4.0.1" targetFramework="net452" />
+  <package id="System.Xml.ReaderWriter" version="4.0.11" targetFramework="net452" />
+  <package id="System.Xml.XDocument" version="4.0.11" targetFramework="net452" />
   <package id="xunit" version="2.1.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net452" />

--- a/logging/api/Program.cs
+++ b/logging/api/Program.cs
@@ -43,9 +43,12 @@ namespace GoogleCloudSamples
         {
             get
             {
-                return CallSettings.FromCallTiming(CallTiming.FromExpiration(
-                    Google.Api.Gax.Expiration.FromTimeout(
-                        TimeSpan.FromSeconds(20))));
+                return CallSettings.FromCallTiming(CallTiming.FromRetry(new RetrySettings(
+                    new BackoffSettings(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(10), 2.0),
+                    new BackoffSettings(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10)),
+                    Google.Api.Gax.Expiration.FromTimeout(TimeSpan.FromSeconds(30)),
+                    (Grpc.Core.RpcException e) => e.Status.StatusCode == Grpc.Core.StatusCode.Internal
+                    )));
             }
         }
 

--- a/logging/api/QuickStart/App.config
+++ b/logging/api/QuickStart/App.config
@@ -7,15 +7,19 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Google.Apis.Auth" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.16.0.0" newVersion="1.16.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.18.0.0" newVersion="1.18.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Google.Apis.Auth.PlatformServices" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.16.0.0" newVersion="1.16.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.18.0.0" newVersion="1.18.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="log4net" publicKeyToken="669e0ddf0bb1aa2a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.2.15.0" newVersion="1.2.15.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Interactive.Async" publicKeyToken="94bc3704cddfc263" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.1000.0" newVersion="3.0.1000.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/logging/api/QuickStart/QuickStart.csproj
+++ b/logging/api/QuickStart/QuickStart.csproj
@@ -40,43 +40,47 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Api.CommonProtos, Version=1.0.0.0, Culture=neutral, PublicKeyToken=3ec5ea7f18953e47, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Api.CommonProtos.1.0.0-beta02\lib\net45\Google.Api.CommonProtos.dll</HintPath>
+      <HintPath>..\packages\Google.Api.CommonProtos.1.0.0-beta04\lib\net45\Google.Api.CommonProtos.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Api.Gax, Version=1.0.0.0, Culture=neutral, PublicKeyToken=3ec5ea7f18953e47, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Api.Gax.1.0.0-beta02\lib\net45\Google.Api.Gax.dll</HintPath>
+      <HintPath>..\packages\Google.Api.Gax.1.0.0-beta04\lib\net45\Google.Api.Gax.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis, Version=1.16.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.1.16.0\lib\net45\Google.Apis.dll</HintPath>
+    <Reference Include="Google.Api.Gax.Grpc, Version=1.0.0.0, Culture=neutral, PublicKeyToken=3ec5ea7f18953e47, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Api.Gax.Grpc.1.0.0-beta04\lib\net45\Google.Api.Gax.Grpc.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.Auth, Version=1.16.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.Auth.1.16.0\lib\net45\Google.Apis.Auth.dll</HintPath>
+    <Reference Include="Google.Apis, Version=1.18.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.1.18.0\lib\net45\Google.Apis.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.Auth.PlatformServices, Version=1.16.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.Auth.1.16.0\lib\net45\Google.Apis.Auth.PlatformServices.dll</HintPath>
+    <Reference Include="Google.Apis.Auth, Version=1.18.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.Auth.1.18.0\lib\net45\Google.Apis.Auth.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.Core, Version=1.16.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.Core.1.16.0\lib\net45\Google.Apis.Core.dll</HintPath>
+    <Reference Include="Google.Apis.Auth.PlatformServices, Version=1.18.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.Auth.1.18.0\lib\net45\Google.Apis.Auth.PlatformServices.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.PlatformServices, Version=1.16.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.1.16.0\lib\net45\Google.Apis.PlatformServices.dll</HintPath>
+    <Reference Include="Google.Apis.Core, Version=1.18.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.Core.1.18.0\lib\net45\Google.Apis.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Google.Apis.PlatformServices, Version=1.18.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.1.18.0\lib\net45\Google.Apis.PlatformServices.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Logging.Log4Net, Version=1.0.0.0, Culture=neutral, PublicKeyToken=185c282632e132a0, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Logging.Log4Net.1.0.0-beta02\lib\net45\Google.Logging.Log4Net.dll</HintPath>
+      <HintPath>..\packages\Google.Logging.Log4Net.1.0.0-beta04\lib\net45\Google.Logging.Log4Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Logging.Type, Version=1.0.0.0, Culture=neutral, PublicKeyToken=185c282632e132a0, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Logging.Type.1.0.0-beta02\lib\net45\Google.Logging.Type.dll</HintPath>
+      <HintPath>..\packages\Google.Logging.Type.1.0.0-beta04\lib\net45\Google.Logging.Type.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Logging.V2, Version=1.0.0.0, Culture=neutral, PublicKeyToken=185c282632e132a0, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Logging.V2.1.0.0-beta02\lib\net45\Google.Logging.V2.dll</HintPath>
+      <HintPath>..\packages\Google.Logging.V2.1.0.0-beta04\lib\net45\Google.Logging.V2.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Protobuf, Version=3.0.0.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604, processorArchitecture=MSIL">
@@ -84,11 +88,11 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Grpc.Auth, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d754f35622e28bad, processorArchitecture=MSIL">
-      <HintPath>..\packages\Grpc.Auth.1.0.0\lib\net45\Grpc.Auth.dll</HintPath>
+      <HintPath>..\packages\Grpc.Auth.1.0.1\lib\net45\Grpc.Auth.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Grpc.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d754f35622e28bad, processorArchitecture=MSIL">
-      <HintPath>..\packages\Grpc.Core.1.0.0\lib\net45\Grpc.Core.dll</HintPath>
+      <HintPath>..\packages\Grpc.Core.1.0.1\lib\net45\Grpc.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="log4net, Version=1.2.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
@@ -112,11 +116,13 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Interactive.Async, Version=3.0.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+    <Reference Include="System.Interactive.Async, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Interactive.Async.3.1.0-rc2\lib\net45\System.Interactive.Async.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
@@ -127,6 +133,11 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.0.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -163,17 +174,17 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Grpc.Core.1.0.0\build\net45\Grpc.Core.targets" Condition="Exists('..\packages\Grpc.Core.1.0.0\build\net45\Grpc.Core.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Grpc.Core.1.0.0\build\net45\Grpc.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Grpc.Core.1.0.0\build\net45\Grpc.Core.targets'))" />
-  </Target>
   <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
   <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
     <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
     <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
+  </Target>
+  <Import Project="..\packages\Grpc.Core.1.0.1\build\net45\Grpc.Core.targets" Condition="Exists('..\packages\Grpc.Core.1.0.1\build\net45\Grpc.Core.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Grpc.Core.1.0.1\build\net45\Grpc.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Grpc.Core.1.0.1\build\net45\Grpc.Core.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/logging/api/QuickStart/packages.config
+++ b/logging/api/QuickStart/packages.config
@@ -1,24 +1,57 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="BouncyCastle" version="1.7.0" targetFramework="net452" />
-  <package id="Google.Api.CommonProtos" version="1.0.0-beta02" targetFramework="net452" />
-  <package id="Google.Api.Gax" version="1.0.0-beta02" targetFramework="net452" />
-  <package id="Google.Apis" version="1.16.0" targetFramework="net452" />
-  <package id="Google.Apis.Auth" version="1.16.0" targetFramework="net452" />
-  <package id="Google.Apis.Core" version="1.16.0" targetFramework="net452" />
-  <package id="Google.Logging.Log4Net" version="1.0.0-beta02" targetFramework="net452" />
-  <package id="Google.Logging.Type" version="1.0.0-beta02" targetFramework="net452" />
-  <package id="Google.Logging.V2" version="1.0.0-beta02" targetFramework="net452" />
+  <package id="Google.Api.CommonProtos" version="1.0.0-beta04" targetFramework="net452" />
+  <package id="Google.Api.Gax" version="1.0.0-beta04" targetFramework="net452" />
+  <package id="Google.Api.Gax.Grpc" version="1.0.0-beta04" targetFramework="net452" />
+  <package id="Google.Apis" version="1.18.0" targetFramework="net452" />
+  <package id="Google.Apis.Auth" version="1.18.0" targetFramework="net452" />
+  <package id="Google.Apis.Core" version="1.18.0" targetFramework="net452" />
+  <package id="Google.Logging.Log4Net" version="1.0.0-beta04" targetFramework="net452" />
+  <package id="Google.Logging.Type" version="1.0.0-beta04" targetFramework="net452" />
+  <package id="Google.Logging.V2" version="1.0.0-beta04" targetFramework="net452" />
   <package id="Google.Protobuf" version="3.0.0" targetFramework="net452" />
-  <package id="Grpc.Auth" version="1.0.0" targetFramework="net452" />
-  <package id="Grpc.Core" version="1.0.0" targetFramework="net452" />
+  <package id="Grpc.Auth" version="1.0.1" targetFramework="net452" />
+  <package id="Grpc.Core" version="1.0.1" targetFramework="net452" />
   <package id="log4net" version="2.0.5" targetFramework="net452" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net452" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net452" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net452" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net452" />
+  <package id="Microsoft.NETCore.Platforms" version="1.0.1" targetFramework="net452" />
+  <package id="NETStandard.Library" version="1.6.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
-  <package id="System.Interactive.Async" version="3.0.0" targetFramework="net452" />
+  <package id="System.Collections" version="4.0.11" targetFramework="net452" />
+  <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net452" />
+  <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net452" />
+  <package id="System.Diagnostics.Tools" version="4.0.1" targetFramework="net452" />
+  <package id="System.Diagnostics.Tracing" version="4.1.0" targetFramework="net452" />
+  <package id="System.Globalization" version="4.0.11" targetFramework="net452" />
+  <package id="System.Interactive.Async" version="3.1.0-rc2" targetFramework="net452" />
+  <package id="System.IO" version="4.1.0" targetFramework="net452" />
+  <package id="System.IO.Compression" version="4.1.0" targetFramework="net452" />
+  <package id="System.Linq" version="4.1.0" targetFramework="net452" />
+  <package id="System.Linq.Expressions" version="4.1.0" targetFramework="net452" />
+  <package id="System.Net.Http" version="4.1.0" targetFramework="net452" />
+  <package id="System.Net.Primitives" version="4.0.11" targetFramework="net452" />
+  <package id="System.ObjectModel" version="4.0.12" targetFramework="net452" />
+  <package id="System.Reflection" version="4.1.0" targetFramework="net452" />
+  <package id="System.Reflection.Extensions" version="4.0.1" targetFramework="net452" />
+  <package id="System.Reflection.Primitives" version="4.0.1" targetFramework="net452" />
+  <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net452" />
+  <package id="System.Runtime" version="4.1.0" targetFramework="net452" />
+  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net452" />
+  <package id="System.Runtime.InteropServices" version="4.1.0" targetFramework="net452" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" targetFramework="net452" />
+  <package id="System.Runtime.Numerics" version="4.0.1" targetFramework="net452" />
+  <package id="System.Text.Encoding" version="4.0.11" targetFramework="net452" />
+  <package id="System.Text.Encoding.Extensions" version="4.0.11" targetFramework="net452" />
+  <package id="System.Text.RegularExpressions" version="4.1.0" targetFramework="net452" />
+  <package id="System.Threading" version="4.0.11" targetFramework="net452" />
+  <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net452" />
+  <package id="System.Threading.Timer" version="4.0.1" targetFramework="net452" />
+  <package id="System.Xml.ReaderWriter" version="4.0.11" targetFramework="net452" />
+  <package id="System.Xml.XDocument" version="4.0.11" targetFramework="net452" />
   <package id="xunit" version="2.1.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net452" />

--- a/logging/api/packages.config
+++ b/logging/api/packages.config
@@ -1,24 +1,57 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="BouncyCastle" version="1.7.0" targetFramework="net452" />
-  <package id="Google.Api.CommonProtos" version="1.0.0-beta02" targetFramework="net452" />
-  <package id="Google.Api.Gax" version="1.0.0-beta02" targetFramework="net452" />
-  <package id="Google.Apis" version="1.16.0" targetFramework="net452" />
-  <package id="Google.Apis.Auth" version="1.16.0" targetFramework="net452" />
-  <package id="Google.Apis.Core" version="1.16.0" targetFramework="net452" />
-  <package id="Google.Logging.Log4Net" version="1.0.0-beta02" targetFramework="net452" />
-  <package id="Google.Logging.Type" version="1.0.0-beta02" targetFramework="net452" />
-  <package id="Google.Logging.V2" version="1.0.0-beta02" targetFramework="net452" />
+  <package id="Google.Api.CommonProtos" version="1.0.0-beta04" targetFramework="net452" />
+  <package id="Google.Api.Gax" version="1.0.0-beta04" targetFramework="net452" />
+  <package id="Google.Api.Gax.Grpc" version="1.0.0-beta04" targetFramework="net452" />
+  <package id="Google.Apis" version="1.18.0" targetFramework="net452" />
+  <package id="Google.Apis.Auth" version="1.18.0" targetFramework="net452" />
+  <package id="Google.Apis.Core" version="1.18.0" targetFramework="net452" />
+  <package id="Google.Logging.Log4Net" version="1.0.0-beta04" targetFramework="net452" />
+  <package id="Google.Logging.Type" version="1.0.0-beta04" targetFramework="net452" />
+  <package id="Google.Logging.V2" version="1.0.0-beta04" targetFramework="net452" />
   <package id="Google.Protobuf" version="3.0.0" targetFramework="net452" />
-  <package id="Grpc.Auth" version="1.0.0" targetFramework="net452" />
-  <package id="Grpc.Core" version="1.0.0" targetFramework="net452" />
+  <package id="Grpc.Auth" version="1.0.1" targetFramework="net452" />
+  <package id="Grpc.Core" version="1.0.1" targetFramework="net452" />
   <package id="log4net" version="2.0.5" targetFramework="net452" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net452" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net452" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net452" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net452" />
+  <package id="Microsoft.NETCore.Platforms" version="1.0.1" targetFramework="net452" />
+  <package id="NETStandard.Library" version="1.6.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
-  <package id="System.Interactive.Async" version="3.0.0" targetFramework="net452" />
+  <package id="System.Collections" version="4.0.11" targetFramework="net452" />
+  <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net452" />
+  <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net452" />
+  <package id="System.Diagnostics.Tools" version="4.0.1" targetFramework="net452" />
+  <package id="System.Diagnostics.Tracing" version="4.1.0" targetFramework="net452" />
+  <package id="System.Globalization" version="4.0.11" targetFramework="net452" />
+  <package id="System.Interactive.Async" version="3.1.0-rc2" targetFramework="net452" />
+  <package id="System.IO" version="4.1.0" targetFramework="net452" />
+  <package id="System.IO.Compression" version="4.1.0" targetFramework="net452" />
+  <package id="System.Linq" version="4.1.0" targetFramework="net452" />
+  <package id="System.Linq.Expressions" version="4.1.0" targetFramework="net452" />
+  <package id="System.Net.Http" version="4.1.0" targetFramework="net452" />
+  <package id="System.Net.Primitives" version="4.0.11" targetFramework="net452" />
+  <package id="System.ObjectModel" version="4.0.12" targetFramework="net452" />
+  <package id="System.Reflection" version="4.1.0" targetFramework="net452" />
+  <package id="System.Reflection.Extensions" version="4.0.1" targetFramework="net452" />
+  <package id="System.Reflection.Primitives" version="4.0.1" targetFramework="net452" />
+  <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net452" />
+  <package id="System.Runtime" version="4.1.0" targetFramework="net452" />
+  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net452" />
+  <package id="System.Runtime.InteropServices" version="4.1.0" targetFramework="net452" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" targetFramework="net452" />
+  <package id="System.Runtime.Numerics" version="4.0.1" targetFramework="net452" />
+  <package id="System.Text.Encoding" version="4.0.11" targetFramework="net452" />
+  <package id="System.Text.Encoding.Extensions" version="4.0.11" targetFramework="net452" />
+  <package id="System.Text.RegularExpressions" version="4.1.0" targetFramework="net452" />
+  <package id="System.Threading" version="4.0.11" targetFramework="net452" />
+  <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net452" />
+  <package id="System.Threading.Timer" version="4.0.1" targetFramework="net452" />
+  <package id="System.Xml.ReaderWriter" version="4.0.11" targetFramework="net452" />
+  <package id="System.Xml.XDocument" version="4.0.11" targetFramework="net452" />
   <package id="xunit" version="2.1.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net452" />


### PR DESCRIPTION
The logging test fails sometimes due to random errors on the server like this:
`Grpc.Core.RpcException : Status(StatusCode=Internal, Detail="Internal error encountered.")`
When that happens, retry for 20 seconds.

First, upgrade to beta04, because the CallSettings syntax has changed between beta02 and beta04.