### PR TITLE
Update QuickstartSample.cs

### DIFF
--- a/pubsub/quickstart/QuickstartSample.cs
+++ b/pubsub/quickstart/QuickstartSample.cs
@@ -27,11 +27,11 @@ public class QuickstartSample
         // Your Google Cloud Platform project ID
         string projectId = "YOUR_PROJECT_ID";
 
-        // The name for the new topic
-        string projectTopic = "my-new-topic";
+        // The id for the new topic
+        string topicId = "my-new-topic";
 
         // The fully qualified name for the new topic
-        var topicName = new TopicName(projectId, projectTopic);
+        var topicName = new TopicName(projectId, topicId);
 
         // Creates the new topic
         Topic topic = publisher.CreateTopic(topicName);

--- a/pubsub/quickstart/QuickstartSample.cs
+++ b/pubsub/quickstart/QuickstartSample.cs
@@ -28,13 +28,13 @@ public class QuickstartSample
         string projectId = "YOUR_PROJECT_ID";
 
         // The name for the new topic
-        string topicName = "my-new-topic";
+        string projectTopic = "my-new-topic";
 
         // The fully qualified name for the new topic
-        string formattedTopicName = PublisherClient.FormatTopicName(projectId, topicName);
+        var topicName = new TopicName(projectId, projectTopic);
 
         // Creates the new topic
-        Topic topic = publisher.CreateTopic(formattedTopicName);
+        Topic topic = publisher.CreateTopic(topicName);
 
         Console.WriteLine($"Topic {topic.Name} created.");
     }


### PR DESCRIPTION
Use TopicName class as `PublisherClient.FormatTopicName` is gone (from version `1.0.0-beta06`).