### PR TITLE
Fix occaisonal Jenkins test failure.

### DIFF
--- a/vision/api/VisionTest/VisionTest.cs
+++ b/vision/api/VisionTest/VisionTest.cs
@@ -64,8 +64,8 @@ namespace GoogleCloudSamples
         public static byte[] ToPngBytes(string imagePath)
         {
             var stream = new MemoryStream();
-            var image = Image.FromFile(imagePath);
-            image.Save(stream, System.Drawing.Imaging.ImageFormat.Png);
+            using (var image = Image.FromFile(imagePath))
+                image.Save(stream, System.Drawing.Imaging.ImageFormat.Png);
             var buffer = new byte[stream.Length];
             stream.Read(buffer, 0, buffer.Length);
             return buffer;


### PR DESCRIPTION
The image file is sometimes left open between tests.  This attempts to fix
it.  I haven't been able to reproduce the issue locally.