### PR TITLE
Update to the latest Vision API

### DIFF
--- a/vision/api/Detect/Detect.csproj
+++ b/vision/api/Detect/Detect.csproj
@@ -44,11 +44,11 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Api.Gax, Version=1.0.0.0, Culture=neutral, PublicKeyToken=3ec5ea7f18953e47, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Api.Gax.1.0.0-beta06\lib\net45\Google.Api.Gax.dll</HintPath>
+      <HintPath>..\packages\Google.Api.Gax.1.0.0-beta12\lib\net45\Google.Api.Gax.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Api.Gax.Grpc, Version=1.0.0.0, Culture=neutral, PublicKeyToken=3ec5ea7f18953e47, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Api.Gax.Grpc.1.0.0-beta06\lib\net45\Google.Api.Gax.Grpc.dll</HintPath>
+      <HintPath>..\packages\Google.Api.Gax.Grpc.1.0.0-beta12\lib\net45\Google.Api.Gax.Grpc.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Apis, Version=1.20.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
@@ -72,7 +72,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Cloud.Vision.V1, Version=1.0.0.0, Culture=neutral, PublicKeyToken=185c282632e132a0, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Cloud.Vision.V1.1.0.0-alpha05\lib\net45\Google.Cloud.Vision.V1.dll</HintPath>
+      <HintPath>..\packages\Google.Cloud.Vision.V1.1.0.0-beta01\lib\net45\Google.Cloud.Vision.V1.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Protobuf, Version=3.0.0.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604, processorArchitecture=MSIL">
@@ -80,11 +80,11 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Grpc.Auth, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d754f35622e28bad, processorArchitecture=MSIL">
-      <HintPath>..\packages\Grpc.Auth.1.0.1\lib\net45\Grpc.Auth.dll</HintPath>
+      <HintPath>..\packages\Grpc.Auth.1.1.0\lib\net45\Grpc.Auth.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Grpc.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d754f35622e28bad, processorArchitecture=MSIL">
-      <HintPath>..\packages\Grpc.Core.1.0.1\lib\net45\Grpc.Core.dll</HintPath>
+      <HintPath>..\packages\Grpc.Core.1.1.0\lib\net45\Grpc.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
@@ -121,12 +121,12 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Grpc.Core.1.0.1\build\net45\Grpc.Core.targets" Condition="Exists('..\packages\Grpc.Core.1.0.1\build\net45\Grpc.Core.targets')" />
+  <Import Project="..\packages\Grpc.Core.1.1.0\build\net45\Grpc.Core.targets" Condition="Exists('..\packages\Grpc.Core.1.1.0\build\net45\Grpc.Core.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Grpc.Core.1.0.1\build\net45\Grpc.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Grpc.Core.1.0.1\build\net45\Grpc.Core.targets'))" />
+    <Error Condition="!Exists('..\packages\Grpc.Core.1.1.0\build\net45\Grpc.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Grpc.Core.1.1.0\build\net45\Grpc.Core.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/vision/api/Detect/Program.cs
+++ b/vision/api/Detect/Program.cs
@@ -84,7 +84,7 @@ namespace GoogleCloudSamples
         private static object DetectFaces(string bucketName, string objectName)
         {
             var client = ImageAnnotatorClient.Create();
-            var image = Image.FromStorageUri($"gs://{bucketName}/{objectName}");
+            var image = Image.FromUri($"gs://{bucketName}/{objectName}");
             var response = client.DetectFaces(image);
             int count = 1;
             foreach (var faceAnnotation in response)
@@ -122,7 +122,7 @@ namespace GoogleCloudSamples
         private static object DetectLabels(string bucketName, string objectName)
         {
             var client = ImageAnnotatorClient.Create();
-            var image = Image.FromStorageUri($"gs://{bucketName}/{objectName}");
+            var image = Image.FromUri($"gs://{bucketName}/{objectName}");
             var response = client.DetectLabels(image);
             foreach (var annotation in response)
             {
@@ -152,7 +152,7 @@ namespace GoogleCloudSamples
         private static object DetectSafeSearch(string bucketName, string objectName)
         {
             var client = ImageAnnotatorClient.Create();
-            var image = Image.FromStorageUri($"gs://{bucketName}/{objectName}");
+            var image = Image.FromUri($"gs://{bucketName}/{objectName}");
             var response = client.DetectSafeSearch(image);
             Console.WriteLine("Adult: {0}", response.Adult.ToString());
             Console.WriteLine("Spoof: {0}", response.Spoof.ToString());
@@ -180,7 +180,7 @@ namespace GoogleCloudSamples
         private static object DetectProperties(string bucketName, string objectName)
         {
             var client = ImageAnnotatorClient.Create();
-            var image = Image.FromStorageUri($"gs://{bucketName}/{objectName}");
+            var image = Image.FromUri($"gs://{bucketName}/{objectName}");
             var response = client.DetectImageProperties(image);
             string header = "Red\tGreen\tBlue\tAlpha\n";
             foreach (var color in response.DominantColors.Colors)
@@ -218,7 +218,7 @@ namespace GoogleCloudSamples
         private static object DetectLandmarks(string bucketName, string objectName)
         {
             var client = ImageAnnotatorClient.Create();
-            var image = Image.FromStorageUri($"gs://{bucketName}/{objectName}");
+            var image = Image.FromUri($"gs://{bucketName}/{objectName}");
             var response = client.DetectLandmarks(image);
             foreach (var annotation in response)
             {
@@ -248,7 +248,7 @@ namespace GoogleCloudSamples
         private static object DetectText(string bucketName, string objectName)
         {
             var client = ImageAnnotatorClient.Create();
-            var image = Image.FromStorageUri($"gs://{bucketName}/{objectName}");
+            var image = Image.FromUri($"gs://{bucketName}/{objectName}");
             var response = client.DetectText(image);
             foreach (var annotation in response)
             {
@@ -278,7 +278,7 @@ namespace GoogleCloudSamples
         private static object DetectLogos(string bucketName, string objectName)
         {
             var client = ImageAnnotatorClient.Create();
-            var image = Image.FromStorageUri($"gs://{bucketName}/{objectName}");
+            var image = Image.FromUri($"gs://{bucketName}/{objectName}");
             var response = client.DetectLogos(image);
             foreach (var annotation in response)
             {

--- a/vision/api/Detect/packages.config
+++ b/vision/api/Detect/packages.config
@@ -2,18 +2,18 @@
 <packages>
   <package id="CommandLineParser" version="2.1.1-beta" targetFramework="net452" />
   <package id="Google.Api.CommonProtos" version="1.0.0-beta05" targetFramework="net452" />
-  <package id="Google.Api.Gax" version="1.0.0-beta06" targetFramework="net452" />
-  <package id="Google.Api.Gax.Grpc" version="1.0.0-beta06" targetFramework="net452" />
+  <package id="Google.Api.Gax" version="1.0.0-beta12" targetFramework="net452" />
+  <package id="Google.Api.Gax.Grpc" version="1.0.0-beta12" targetFramework="net452" />
   <package id="Google.Apis" version="1.20.0" targetFramework="net452" />
   <package id="Google.Apis.Auth" version="1.20.0" targetFramework="net452" />
   <package id="Google.Apis.Core" version="1.20.0" targetFramework="net452" />
-  <package id="Google.Cloud.Vision.V1" version="1.0.0-alpha05" targetFramework="net452" />
+  <package id="Google.Cloud.Vision.V1" version="1.0.0-beta01" targetFramework="net452" />
   <package id="Google.Protobuf" version="3.0.0" targetFramework="net452" />
-  <package id="Grpc.Auth" version="1.0.1" targetFramework="net452" />
-  <package id="Grpc.Core" version="1.0.1" targetFramework="net452" />
+  <package id="Grpc.Auth" version="1.1.0" targetFramework="net452" />
+  <package id="Grpc.Core" version="1.1.0" targetFramework="net452" />
   <package id="log4net" version="2.0.3" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
   <package id="System.Interactive.Async" version="3.1.1" targetFramework="net452" />
-  <package id="System.Net.Http" version="4.0.0" targetFramework="net452" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net452" />
   <package id="Zlib.Portable.Signed" version="1.11.0" targetFramework="net452" />
 </packages>

--- a/vision/api/DetectFaces/DetectFaces.csproj
+++ b/vision/api/DetectFaces/DetectFaces.csproj
@@ -40,11 +40,11 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Api.Gax, Version=1.0.0.0, Culture=neutral, PublicKeyToken=3ec5ea7f18953e47, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Api.Gax.1.0.0-beta06\lib\net45\Google.Api.Gax.dll</HintPath>
+      <HintPath>..\packages\Google.Api.Gax.1.0.0-beta12\lib\net45\Google.Api.Gax.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Api.Gax.Grpc, Version=1.0.0.0, Culture=neutral, PublicKeyToken=3ec5ea7f18953e47, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Api.Gax.Grpc.1.0.0-beta06\lib\net45\Google.Api.Gax.Grpc.dll</HintPath>
+      <HintPath>..\packages\Google.Api.Gax.Grpc.1.0.0-beta12\lib\net45\Google.Api.Gax.Grpc.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Apis, Version=1.20.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
@@ -68,7 +68,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Cloud.Vision.V1, Version=1.0.0.0, Culture=neutral, PublicKeyToken=185c282632e132a0, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Cloud.Vision.V1.1.0.0-alpha05\lib\net45\Google.Cloud.Vision.V1.dll</HintPath>
+      <HintPath>..\packages\Google.Cloud.Vision.V1.1.0.0-beta01\lib\net45\Google.Cloud.Vision.V1.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Protobuf, Version=3.0.0.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604, processorArchitecture=MSIL">
@@ -76,11 +76,11 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Grpc.Auth, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d754f35622e28bad, processorArchitecture=MSIL">
-      <HintPath>..\packages\Grpc.Auth.1.0.1\lib\net45\Grpc.Auth.dll</HintPath>
+      <HintPath>..\packages\Grpc.Auth.1.1.0\lib\net45\Grpc.Auth.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Grpc.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d754f35622e28bad, processorArchitecture=MSIL">
-      <HintPath>..\packages\Grpc.Core.1.0.1\lib\net45\Grpc.Core.dll</HintPath>
+      <HintPath>..\packages\Grpc.Core.1.1.0\lib\net45\Grpc.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
@@ -118,12 +118,12 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Grpc.Core.1.0.1\build\net45\Grpc.Core.targets" Condition="Exists('..\packages\Grpc.Core.1.0.1\build\net45\Grpc.Core.targets')" />
+  <Import Project="..\packages\Grpc.Core.1.1.0\build\net45\Grpc.Core.targets" Condition="Exists('..\packages\Grpc.Core.1.1.0\build\net45\Grpc.Core.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Grpc.Core.1.0.1\build\net45\Grpc.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Grpc.Core.1.0.1\build\net45\Grpc.Core.targets'))" />
+    <Error Condition="!Exists('..\packages\Grpc.Core.1.1.0\build\net45\Grpc.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Grpc.Core.1.1.0\build\net45\Grpc.Core.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/vision/api/DetectFaces/packages.config
+++ b/vision/api/DetectFaces/packages.config
@@ -1,18 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Google.Api.CommonProtos" version="1.0.0-beta05" targetFramework="net452" />
-  <package id="Google.Api.Gax" version="1.0.0-beta06" targetFramework="net452" />
-  <package id="Google.Api.Gax.Grpc" version="1.0.0-beta06" targetFramework="net452" />
+  <package id="Google.Api.Gax" version="1.0.0-beta12" targetFramework="net452" />
+  <package id="Google.Api.Gax.Grpc" version="1.0.0-beta12" targetFramework="net452" />
   <package id="Google.Apis" version="1.20.0" targetFramework="net452" />
   <package id="Google.Apis.Auth" version="1.20.0" targetFramework="net452" />
   <package id="Google.Apis.Core" version="1.20.0" targetFramework="net452" />
-  <package id="Google.Cloud.Vision.V1" version="1.0.0-alpha05" targetFramework="net452" />
+  <package id="Google.Cloud.Vision.V1" version="1.0.0-beta01" targetFramework="net452" />
   <package id="Google.Protobuf" version="3.0.0" targetFramework="net452" />
-  <package id="Grpc.Auth" version="1.0.1" targetFramework="net452" />
-  <package id="Grpc.Core" version="1.0.1" targetFramework="net452" />
+  <package id="Grpc.Auth" version="1.1.0" targetFramework="net452" />
+  <package id="Grpc.Core" version="1.1.0" targetFramework="net452" />
   <package id="log4net" version="2.0.3" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
   <package id="System.Interactive.Async" version="3.1.1" targetFramework="net452" />
-  <package id="System.Net.Http" version="4.0.0" targetFramework="net452" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net452" />
   <package id="Zlib.Portable.Signed" version="1.11.0" targetFramework="net452" />
 </packages>

--- a/vision/api/QuickStart/QuickStart.csproj
+++ b/vision/api/QuickStart/QuickStart.csproj
@@ -40,11 +40,11 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Api.Gax, Version=1.0.0.0, Culture=neutral, PublicKeyToken=3ec5ea7f18953e47, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Api.Gax.1.0.0-beta06\lib\net45\Google.Api.Gax.dll</HintPath>
+      <HintPath>..\packages\Google.Api.Gax.1.0.0-beta12\lib\net45\Google.Api.Gax.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Api.Gax.Grpc, Version=1.0.0.0, Culture=neutral, PublicKeyToken=3ec5ea7f18953e47, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Api.Gax.Grpc.1.0.0-beta06\lib\net45\Google.Api.Gax.Grpc.dll</HintPath>
+      <HintPath>..\packages\Google.Api.Gax.Grpc.1.0.0-beta12\lib\net45\Google.Api.Gax.Grpc.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Apis, Version=1.20.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
@@ -68,7 +68,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Cloud.Vision.V1, Version=1.0.0.0, Culture=neutral, PublicKeyToken=185c282632e132a0, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Cloud.Vision.V1.1.0.0-alpha05\lib\net45\Google.Cloud.Vision.V1.dll</HintPath>
+      <HintPath>..\packages\Google.Cloud.Vision.V1.1.0.0-beta01\lib\net45\Google.Cloud.Vision.V1.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Protobuf, Version=3.0.0.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604, processorArchitecture=MSIL">
@@ -76,11 +76,11 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Grpc.Auth, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d754f35622e28bad, processorArchitecture=MSIL">
-      <HintPath>..\packages\Grpc.Auth.1.0.1\lib\net45\Grpc.Auth.dll</HintPath>
+      <HintPath>..\packages\Grpc.Auth.1.1.0\lib\net45\Grpc.Auth.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Grpc.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d754f35622e28bad, processorArchitecture=MSIL">
-      <HintPath>..\packages\Grpc.Core.1.0.1\lib\net45\Grpc.Core.dll</HintPath>
+      <HintPath>..\packages\Grpc.Core.1.1.0\lib\net45\Grpc.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
@@ -123,12 +123,12 @@
     </Content>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Grpc.Core.1.0.1\build\net45\Grpc.Core.targets" Condition="Exists('..\packages\Grpc.Core.1.0.1\build\net45\Grpc.Core.targets')" />
+  <Import Project="..\packages\Grpc.Core.1.1.0\build\net45\Grpc.Core.targets" Condition="Exists('..\packages\Grpc.Core.1.1.0\build\net45\Grpc.Core.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Grpc.Core.1.0.1\build\net45\Grpc.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Grpc.Core.1.0.1\build\net45\Grpc.Core.targets'))" />
+    <Error Condition="!Exists('..\packages\Grpc.Core.1.1.0\build\net45\Grpc.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Grpc.Core.1.1.0\build\net45\Grpc.Core.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/vision/api/QuickStart/packages.config
+++ b/vision/api/QuickStart/packages.config
@@ -1,18 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Google.Api.CommonProtos" version="1.0.0-beta05" targetFramework="net452" />
-  <package id="Google.Api.Gax" version="1.0.0-beta06" targetFramework="net452" />
-  <package id="Google.Api.Gax.Grpc" version="1.0.0-beta06" targetFramework="net452" />
+  <package id="Google.Api.Gax" version="1.0.0-beta12" targetFramework="net452" />
+  <package id="Google.Api.Gax.Grpc" version="1.0.0-beta12" targetFramework="net452" />
   <package id="Google.Apis" version="1.20.0" targetFramework="net452" />
   <package id="Google.Apis.Auth" version="1.20.0" targetFramework="net452" />
   <package id="Google.Apis.Core" version="1.20.0" targetFramework="net452" />
-  <package id="Google.Cloud.Vision.V1" version="1.0.0-alpha05" targetFramework="net452" />
+  <package id="Google.Cloud.Vision.V1" version="1.0.0-beta01" targetFramework="net452" />
   <package id="Google.Protobuf" version="3.0.0" targetFramework="net452" />
-  <package id="Grpc.Auth" version="1.0.1" targetFramework="net452" />
-  <package id="Grpc.Core" version="1.0.1" targetFramework="net452" />
+  <package id="Grpc.Auth" version="1.1.0" targetFramework="net452" />
+  <package id="Grpc.Core" version="1.1.0" targetFramework="net452" />
   <package id="log4net" version="2.0.3" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
   <package id="System.Interactive.Async" version="3.1.1" targetFramework="net452" />
-  <package id="System.Net.Http" version="4.0.0" targetFramework="net452" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net452" />
   <package id="Zlib.Portable.Signed" version="1.11.0" targetFramework="net452" />
 </packages>

--- a/vision/api/VisionTest/VisionTest.csproj
+++ b/vision/api/VisionTest/VisionTest.csproj
@@ -38,47 +38,47 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Api.Gax, Version=1.0.0.0, Culture=neutral, PublicKeyToken=3ec5ea7f18953e47, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Api.Gax.1.0.0-beta06\lib\net45\Google.Api.Gax.dll</HintPath>
+      <HintPath>..\packages\Google.Api.Gax.1.0.0-beta12\lib\net45\Google.Api.Gax.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Api.Gax.Grpc, Version=1.0.0.0, Culture=neutral, PublicKeyToken=3ec5ea7f18953e47, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Api.Gax.Grpc.1.0.0-beta06\lib\net45\Google.Api.Gax.Grpc.dll</HintPath>
+      <HintPath>..\packages\Google.Api.Gax.Grpc.1.0.0-beta12\lib\net45\Google.Api.Gax.Grpc.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Api.Gax.Rest, Version=1.0.0.0, Culture=neutral, PublicKeyToken=3ec5ea7f18953e47, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Api.Gax.Rest.1.0.0-beta06\lib\net45\Google.Api.Gax.Rest.dll</HintPath>
+      <HintPath>..\packages\Google.Api.Gax.Rest.1.0.0-beta12\lib\net45\Google.Api.Gax.Rest.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis, Version=1.20.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.1.20.0\lib\net45\Google.Apis.dll</HintPath>
+    <Reference Include="Google.Apis, Version=1.21.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.1.21.0\lib\net45\Google.Apis.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.Auth, Version=1.20.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.Auth.1.20.0\lib\net45\Google.Apis.Auth.dll</HintPath>
+    <Reference Include="Google.Apis.Auth, Version=1.21.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.Auth.1.21.0\lib\net45\Google.Apis.Auth.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.Auth.PlatformServices, Version=1.20.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.Auth.1.20.0\lib\net45\Google.Apis.Auth.PlatformServices.dll</HintPath>
+    <Reference Include="Google.Apis.Auth.PlatformServices, Version=1.21.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.Auth.1.21.0\lib\net45\Google.Apis.Auth.PlatformServices.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.Core, Version=1.20.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.Core.1.20.0\lib\net45\Google.Apis.Core.dll</HintPath>
+    <Reference Include="Google.Apis.Core, Version=1.21.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.Core.1.21.0\lib\net45\Google.Apis.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.PlatformServices, Version=1.20.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.1.20.0\lib\net45\Google.Apis.PlatformServices.dll</HintPath>
+    <Reference Include="Google.Apis.PlatformServices, Version=1.21.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.1.21.0\lib\net45\Google.Apis.PlatformServices.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.Storage.v1, Version=1.18.0.658, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.Storage.v1.1.18.0.658\lib\net45\Google.Apis.Storage.v1.dll</HintPath>
+    <Reference Include="Google.Apis.Storage.v1, Version=1.21.0.753, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.Storage.v1.1.21.0.753\lib\net45\Google.Apis.Storage.v1.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Cloud.Storage.V1, Version=1.0.0.0, Culture=neutral, PublicKeyToken=185c282632e132a0, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Cloud.Storage.V1.1.0.0-beta06\lib\net45\Google.Cloud.Storage.V1.dll</HintPath>
+      <HintPath>..\packages\Google.Cloud.Storage.V1.1.0.0-beta08\lib\net45\Google.Cloud.Storage.V1.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Cloud.Vision.V1, Version=1.0.0.0, Culture=neutral, PublicKeyToken=185c282632e132a0, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Cloud.Vision.V1.1.0.0-alpha05\lib\net45\Google.Cloud.Vision.V1.dll</HintPath>
+      <HintPath>..\packages\Google.Cloud.Vision.V1.1.0.0-beta01\lib\net45\Google.Cloud.Vision.V1.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Protobuf, Version=3.0.0.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604, processorArchitecture=MSIL">
@@ -86,11 +86,11 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Grpc.Auth, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d754f35622e28bad, processorArchitecture=MSIL">
-      <HintPath>..\packages\Grpc.Auth.1.0.1\lib\net45\Grpc.Auth.dll</HintPath>
+      <HintPath>..\packages\Grpc.Auth.1.1.0\lib\net45\Grpc.Auth.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Grpc.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d754f35622e28bad, processorArchitecture=MSIL">
-      <HintPath>..\packages\Grpc.Core.1.0.1\lib\net45\Grpc.Core.dll</HintPath>
+      <HintPath>..\packages\Grpc.Core.1.1.0\lib\net45\Grpc.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
@@ -210,9 +210,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
-    <Error Condition="!Exists('..\packages\Grpc.Core.1.0.1\build\net45\Grpc.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Grpc.Core.1.0.1\build\net45\Grpc.Core.targets'))" />
+    <Error Condition="!Exists('..\packages\Grpc.Core.1.1.0\build\net45\Grpc.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Grpc.Core.1.1.0\build\net45\Grpc.Core.targets'))" />
   </Target>
-  <Import Project="..\packages\Grpc.Core.1.0.1\build\net45\Grpc.Core.targets" Condition="Exists('..\packages\Grpc.Core.1.0.1\build\net45\Grpc.Core.targets')" />
+  <Import Project="..\packages\Grpc.Core.1.1.0\build\net45\Grpc.Core.targets" Condition="Exists('..\packages\Grpc.Core.1.1.0\build\net45\Grpc.Core.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/vision/api/VisionTest/app.config
+++ b/vision/api/VisionTest/app.config
@@ -8,15 +8,15 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Google.Apis.Auth" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.20.0.0" newVersion="1.20.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.21.0.0" newVersion="1.21.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Google.Apis.Auth.PlatformServices" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.20.0.0" newVersion="1.20.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.21.0.0" newVersion="1.21.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Google.Apis" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.20.0.0" newVersion="1.20.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.21.0.0" newVersion="1.21.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Google.Apis.Core" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />

--- a/vision/api/VisionTest/packages.config
+++ b/vision/api/VisionTest/packages.config
@@ -1,22 +1,22 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Google.Api.CommonProtos" version="1.0.0-beta05" targetFramework="net452" />
-  <package id="Google.Api.Gax" version="1.0.0-beta06" targetFramework="net452" />
-  <package id="Google.Api.Gax.Grpc" version="1.0.0-beta06" targetFramework="net452" />
-  <package id="Google.Api.Gax.Rest" version="1.0.0-beta06" targetFramework="net452" />
-  <package id="Google.Apis" version="1.20.0" targetFramework="net452" />
-  <package id="Google.Apis.Auth" version="1.20.0" targetFramework="net452" />
-  <package id="Google.Apis.Core" version="1.20.0" targetFramework="net452" />
-  <package id="Google.Apis.Storage.v1" version="1.18.0.658" targetFramework="net452" />
-  <package id="Google.Cloud.Storage.V1" version="1.0.0-beta06" targetFramework="net452" />
-  <package id="Google.Cloud.Vision.V1" version="1.0.0-alpha05" targetFramework="net452" />
+  <package id="Google.Api.Gax" version="1.0.0-beta12" targetFramework="net452" />
+  <package id="Google.Api.Gax.Grpc" version="1.0.0-beta12" targetFramework="net452" />
+  <package id="Google.Api.Gax.Rest" version="1.0.0-beta12" targetFramework="net452" />
+  <package id="Google.Apis" version="1.21.0" targetFramework="net452" />
+  <package id="Google.Apis.Auth" version="1.21.0" targetFramework="net452" />
+  <package id="Google.Apis.Core" version="1.21.0" targetFramework="net452" />
+  <package id="Google.Apis.Storage.v1" version="1.21.0.753" targetFramework="net452" />
+  <package id="Google.Cloud.Storage.V1" version="1.0.0-beta08" targetFramework="net452" />
+  <package id="Google.Cloud.Vision.V1" version="1.0.0-beta01" targetFramework="net452" />
   <package id="Google.Protobuf" version="3.0.0" targetFramework="net452" />
-  <package id="Grpc.Auth" version="1.0.1" targetFramework="net452" />
-  <package id="Grpc.Core" version="1.0.1" targetFramework="net452" />
+  <package id="Grpc.Auth" version="1.1.0" targetFramework="net452" />
+  <package id="Grpc.Core" version="1.1.0" targetFramework="net452" />
   <package id="log4net" version="2.0.3" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
   <package id="System.Interactive.Async" version="3.1.1" targetFramework="net452" />
-  <package id="System.Net.Http" version="4.0.0" targetFramework="net452" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net452" />
   <package id="xunit" version="2.1.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net452" />


### PR DESCRIPTION
One breaking change: FromStorageUri has been renamed to
FromUri as it now accepts other URI formats (http/https).

This change does not demonstrate any of the new features (crop hints
etc).