### PR TITLE
Fix duplicate region tag names

### DIFF
--- a/appengine/flexible/CloudSql-PostgreSql/Startup.cs
+++ b/appengine/flexible/CloudSql-PostgreSql/Startup.cs
@@ -50,7 +50,7 @@ namespace CloudSql
 
         NpgsqlConnection NewConnection()
         {
-            // [START example]
+            // [START connection]
             var connectionString = new NpgsqlConnectionStringBuilder(Configuration["CloudSqlConnectionString"])
             {
                 SslMode = SslMode.Require,
@@ -61,7 +61,7 @@ namespace CloudSql
             connection.ProvideClientCertificatesCallback +=
                 (X509CertificateCollection certs) => certs.Add(new X509Certificate2("client.pfx"));            
             connection.Open();
-            // [END example]
+            // [END connection]
             return connection;
         }
 

--- a/appengine/flexible/CloudSql/Startup.cs
+++ b/appengine/flexible/CloudSql/Startup.cs
@@ -60,13 +60,13 @@ namespace CloudSql
             try
             {
                 string connectionString = Configuration["CloudSqlConnectionString"];
-                // [START example]
+                // [START connection]
                 connection = new MySqlConnection(connectionString);
                 connection.Open();
                 var createTableCommand = new MySqlCommand(@"CREATE TABLE IF NOT EXISTS visits
                 (time_stamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP, user_ip CHAR(64))", connection);
                 createTableCommand.ExecuteNonQuery();
-                // [END example]
+                // [END connection]
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Add new region tag "connection" for connection code block.

These files had 2 conflicting "example" region tags.