### PR TITLE
Add openapi-appengine.yaml file for App Engine deployments.

### DIFF
--- a/endpoints/getting-started/openapi.yaml
+++ b/endpoints/getting-started/openapi.yaml
@@ -6,9 +6,6 @@ info:
   version: "1.0.0"
 host: "echo-api.endpoints.YOUR-PROJECT-ID.cloud.goog"
 # [END swagger]
-# For App Engine deployments, delete the above "host:" line and remove the "# "
-# from the following line. Then change YOUR-PROJECT-ID to your project id.
-# host: "YOUR-PROJECT-ID.appspot.com"
 consumes:
 - "application/json"
 produces:

--- a/endpoints/getting-started/src/IO.Swagger/deployTests.ps1
+++ b/endpoints/getting-started/src/IO.Swagger/deployTests.ps1
@@ -16,35 +16,20 @@ Import-Module -DisableNameChecking ..\..\..\..\BuildTools.psm1
 
 dotnet restore
 $projectId = gcloud config get-value project
-$openapiYamlPath = "..\..\openapi.yaml"
+$openapiYamlPath = "..\..\openapi-appengine.yaml"
 BackupAndEdit-TextFile $openapiYamlPath `
     @{"YOUR-PROJECT-ID" = $projectId} `
 {
-	# Remove the one host line for kubernetes-based APIs and uncomment the host
-	# line for App Engine.  These are the same steps described in
-	# https://cloud.google.com/endpoints/docs/get-started-app-engine-dotnet
-	$content = Get-Content $openapiYamlPath | ForEach-Object {
-		[string] $line = $_
-		if ($line -like "host:*echo-api*") {
-			# swallow it.
-		} elseif ($line -like "# host*") {
-			$line.Substring(2)  # Uncomment the line.
-		} else {
-			$line  # echo the line unchanged.
-		}
-	}
-	$content | Out-File -Force -Encoding UTF8 $openapiYamlPath
-	
 	# Now deploy it.
-	gcloud service-management deploy ..\..\openapi.yaml
-	$configs = gcloud service-management configs list --service=echo-api.endpoints.$projectId.cloud.goog --sort-by=~CONFIG_ID
+	gcloud service-management deploy ..\..\openapi-appengine.yaml
+	$configs = gcloud service-management configs list --service=$projectId.appspot.com --sort-by=~CONFIG_ID
 	$configId, $serviceName = $configs[1].split()
 	BackupAndEdit-TextFile "app.yaml" @{
 		"ENDPOINTS SERVICE NAME" = $serviceName;
 		"ENDPOINTS CONFIG ID" = $configId
 	} {
 		dotnet publish
-		gcloud beta app deploy --quiet --no-promote --version=deploytest .\bin\Debug\netcoreapp1.0\publish\app.yaml		
+		gcloud beta app deploy --quiet --no-promote --version=deploytest .\bin\Debug\netcoreapp1.0\publish\app.yaml
 		.\Test.ps1 "https://deploytest-dot-$projectId.appspot.com/echo?key=$env:TEST_GOOGLE_ENDPOINTS_APIKEY"
 	}
  }


### PR DESCRIPTION
After conversation with the Endpoints team, this was the most effective solution we came up with to guide users through setting up Endpoints on App Engine. Having users uncomment code proved to be difficult. If you have another idea that could work better, please let me know. Otherwise, this will have to do.