### PR TITLE
add new tags for netcore versions of transaction samples.

### DIFF
--- a/spanner/api/Program.cs
+++ b/spanner/api/Program.cs
@@ -176,6 +176,8 @@ namespace GoogleCloudSamples.Spanner
         public string instanceId { get; set; }
         [Value(2, HelpText = "The ID of the database where the sample database resides.", Required = true)]
         public string databaseId { get; set; }
+        [Value(3, HelpText = "The platform code to execute (netcore or net45).", Required = false)]
+        public string platform { get; set; }
     }
 
     [Verb("readWriteWithTransaction", HelpText = "Update data in the sample Cloud Spanner database table using a read-write transaction.")]
@@ -187,11 +189,14 @@ namespace GoogleCloudSamples.Spanner
         public string instanceId { get; set; }
         [Value(2, HelpText = "The ID of the database where the sample database resides.", Required = true)]
         public string databaseId { get; set; }
+        [Value(3, HelpText = "The platform code to execute (netcore or net45).", Required = false)]
+        public string platform { get; set; }
     }
 
     public class Program
     {
         static readonly ILog s_logger = LogManager.GetLogger(typeof(Program));
+        private static readonly string NetCorePlatform = "netcore";
 
         enum ExitCode : int
         {
@@ -424,6 +429,68 @@ namespace GoogleCloudSamples.Spanner
             // [END read_data_with_storing_index]
         }
 
+        public static async Task QueryDataWithTransactionCoreAsync(
+            string projectId, string instanceId, string databaseId)
+        {
+            Console.WriteLine(".NetCore API sample.");
+
+            // [START read_only_transaction_core]
+            string connectionString =
+                $"Data Source=projects/{projectId}/instances/{instanceId}"
+                + $"/databases/{databaseId}";
+
+            // Create connection to Cloud Spanner.
+            using (var connection = new SpannerConnection(connectionString))
+            {
+                await connection.OpenAsync();
+
+                // Open a new read only transaction.
+                using (var transaction = await connection.BeginReadOnlyTransactionAsync())
+                {
+                    var cmd = connection.CreateSelectCommand(
+                        "SELECT SingerId, AlbumId, AlbumTitle FROM Albums");
+                    cmd.Transaction = transaction;
+
+                    // Read #1.
+                    using (var reader = await cmd.ExecuteReaderAsync())
+                    {
+                        while (await reader.ReadAsync())
+                        {
+                            Console.WriteLine("SingerId : "
+                                              + reader.GetFieldValue<string>("SingerId")
+                                              + " AlbumId : "
+                                              + reader.GetFieldValue<string>("AlbumId")
+                                              + " AlbumTitle : "
+                                              + reader.GetFieldValue<string>("AlbumTitle"));
+                        }
+                    }
+                    // Read #2. Even if changes occur in-between the reads, 
+                    // the transaction ensures that Read #1 and Read #2 
+                    // return the same data.
+                    using (var reader = await cmd.ExecuteReaderAsync())
+                    {
+                        while (await reader.ReadAsync())
+                        {
+                            Console.WriteLine("SingerId : "
+                                              + reader.GetFieldValue<string>("SingerId")
+                                              + " AlbumId : "
+                                              + reader.GetFieldValue<string>("AlbumId")
+                                              + " AlbumTitle : "
+                                              + reader.GetFieldValue<string>("AlbumTitle"));
+                        }
+                    }
+                }
+            }
+            // Yield Task thread back to the current context.
+            await Task.Yield();
+            Console.WriteLine("Transaction complete.");
+            // [END read_only_transaction_core]
+            // TODO - Remove the above Task.Yield() statement. 
+            // A pending client library update will not require this
+            // for transactions.
+            // Link to issue: https://github.com/grpc/grpc/issues/11824
+        }
+
         public static async Task QueryDataWithTransactionAsync(
             string projectId, string instanceId, string databaseId)
         {
@@ -439,8 +506,9 @@ namespace GoogleCloudSamples.Spanner
                 // Create connection to Cloud Spanner.
                 using (var connection = new SpannerConnection(connectionString))
                 {
-                    // Open connection as read only within the scope 
-                    // of the current transaction.
+                    // Open the connection, making the implicitly created
+                    // transaction read only when it connects to the outer
+                    // transaction scope.
                     await connection.OpenAsReadOnlyAsync().ConfigureAwait(false);
                     var cmd = connection.CreateSelectCommand(
                         "SELECT SingerId, AlbumId, AlbumTitle FROM Albums");
@@ -568,10 +636,105 @@ namespace GoogleCloudSamples.Spanner
                 ex.IsTransientSpannerFault();
         }
 
-        public static async Task ReadWriteWithTransactionAsync(
-            string projectId, string instanceId, string databaseId)
+        // [START read_write_transaction_core]
+        public static async Task ReadWriteWithTransactionCoreAsync(string projectId, string instanceId,
+            string databaseId)
         {
-            // [START read_write_transaction]
+            // This sample transfers 200,000 from the MarketingBudget 
+            // field of the second Album to the first Album. Make sure to run
+            // the addColumn and writeDataToNewColumn samples first,
+            // in that order.
+            string connectionString =
+                $"Data Source=projects/{projectId}/instances/{instanceId}"
+                + $"/databases/{databaseId}";
+
+            decimal transferAmount = 200000;
+            decimal minimumAmountToTransfer = 300000;
+            decimal secondBudget = 0;
+            decimal firstBudget = 0;
+
+            Console.WriteLine(".NetCore API sample.");
+
+            // Create connection to Cloud Spanner.
+            using (var connection =
+                new SpannerConnection(connectionString))
+            {
+                await connection.OpenAsync();
+
+                // Create a readwrite transaction that we'll assign to each SpannerCommand.
+                using (var transaction = await connection.BeginTransactionAsync())
+                {
+                    // Create statement to select the second album's data.
+                    var cmdLookup = connection.CreateSelectCommand(
+                        "SELECT * FROM Albums WHERE SingerId = 2 AND AlbumId = 2");
+                    cmdLookup.Transaction = transaction;
+                    // Excecute the select query.
+                    using (var reader = await cmdLookup.ExecuteReaderAsync())
+                    {
+                        while (await reader.ReadAsync())
+                        {
+                            // Read the second album's budget.
+                            secondBudget =
+                                reader.GetFieldValue<decimal>("MarketingBudget");
+                            // Confirm second Album's budget is sufficient and
+                            // if not raise an exception. Raising an exception
+                            // will automatically roll back the transaction.
+                            if (secondBudget < minimumAmountToTransfer)
+                            {
+                                throw new Exception("The second album's "
+                                                    + $"budget {secondBudget} "
+                                                    + "is less than the minimum required "
+                                                    + "amount to transfer.");
+                            }
+                        }
+                    }
+                    // Read the first album's budget.
+                    cmdLookup = connection.CreateSelectCommand(
+                        "SELECT * FROM Albums WHERE SingerId = 1 and AlbumId = 1");
+                    cmdLookup.Transaction = transaction;
+                    using (var reader = await cmdLookup.ExecuteReaderAsync())
+                    {
+                        while (await reader.ReadAsync())
+                        {
+                            firstBudget =
+                                reader.GetFieldValue<decimal>("MarketingBudget");
+                        }
+                    }
+
+                    // Specify update command parameters.
+                    var cmd = connection.CreateUpdateCommand("Albums",
+                        new SpannerParameterCollection
+                        {
+                            {"SingerId", SpannerDbType.Int64},
+                            {"AlbumId", SpannerDbType.Int64},
+                            {"MarketingBudget", SpannerDbType.Int64},
+                        });
+                    cmd.Transaction = transaction;
+                    // Update second album to remove the transfer amount.
+                    secondBudget -= transferAmount;
+                    cmd.Parameters["SingerId"].Value = 2;
+                    cmd.Parameters["AlbumId"].Value = 2;
+                    cmd.Parameters["MarketingBudget"].Value = secondBudget;
+                    await cmd.ExecuteNonQueryAsync();
+                    // Update first album to add the transfer amount.
+                    firstBudget += transferAmount;
+                    cmd.Parameters["SingerId"].Value = 1;
+                    cmd.Parameters["AlbumId"].Value = 1;
+                    cmd.Parameters["MarketingBudget"].Value = firstBudget;
+                    await cmd.ExecuteNonQueryAsync();
+
+                    await transaction.CommitAsync();
+                }
+                // Yield Task thread back to the current context.
+                await Task.Yield();
+                Console.WriteLine("Transaction complete.");
+            }
+        }
+        // [END read_write_transaction_core]
+
+        // [START read_write_transaction]
+        public static async Task ReadWriteWithTransactionAsync(string projectId, string instanceId, string databaseId)
+        {
             // This sample transfers 200,000 from the MarketingBudget 
             // field of the second Album to the first Album. Make sure to run
             // the addColumn and writeDataToNewColumn samples first,
@@ -651,14 +814,14 @@ namespace GoogleCloudSamples.Spanner
                     // Yield Task thread back to the current context.
                     await Task.Yield();
                     Console.WriteLine("Transaction complete.");
-                    // [END read_write_transaction]
-                    // TODO - Remove the above Task.Yield() statement. 
-                    // A pending client library update will not require this
-                    // for transactions.
-                    // Link to issue: https://github.com/grpc/grpc/issues/11824
                 }
             }
         }
+        // [END read_write_transaction]
+        // TODO - Remove the above Task.Yield() statement. 
+        // A pending client library update will not require this
+        // for transactions.
+        // Link to issue: https://github.com/grpc/grpc/issues/11824
 
         // [START insert_data]
         public static async Task InsertSampleDataAsync(
@@ -928,34 +1091,55 @@ namespace GoogleCloudSamples.Spanner
             return ExitCode.Success;
         }
 
-        public static object QueryDataWithTransaction(string projectId,
-            string instanceId, string databaseId)
+        public static object QueryDataWithTransaction(string projectId, string instanceId, string databaseId, string platform)
         {
+
             var retryPolicy =
                 new RetryPolicy<CustomTransientErrorDetectionStrategy>
                     (RetryStrategy.DefaultExponential);
-            var response = retryPolicy.ExecuteAsync(async () =>
-               await QueryDataWithTransactionAsync(
-                    projectId, instanceId, databaseId));
+
+            var response = platform == NetCorePlatform
+                ? retryPolicy.ExecuteAsync(() =>
+                    QueryDataWithTransactionCoreAsync(projectId, instanceId, databaseId))
+                : retryPolicy.ExecuteAsync(() =>
+                    QueryDataWithTransactionAsync(projectId, instanceId, databaseId));
+
             s_logger.Info("Waiting for operation to complete...");
             response.Wait();
             s_logger.Info($"Operation status: {response.Status}");
             return ExitCode.Success;
         }
 
-        public static object ReadWriteWithTransaction(string projectId,
-            string instanceId, string databaseId)
+        public static object ReadWriteWithTransaction(string projectId, string instanceId, string databaseId, string platform)
         {
             try
             {
-                var retryPolicy =
-                    new RetryPolicy<CustomTransientErrorDetectionStrategy>
-                        (RetryStrategy.DefaultExponential);
-                var response = retryPolicy.ExecuteAsync(async () =>
-                await ReadWriteWithTransactionAsync(
-                    projectId, instanceId, databaseId));
                 s_logger.Info("Waiting for operation to complete...");
-                Task.WaitAll(response);
+                var response = platform == NetCorePlatform
+                    ? Task.Run(async () =>
+                    {
+                        var retryPolicy = new
+                            RetryPolicy<CustomTransientErrorDetectionStrategy>(RetryStrategy.DefaultExponential);
+
+                        await retryPolicy.ExecuteAsync(() => ReadWriteWithTransactionCoreAsync(
+                            projectId, instanceId, databaseId));
+
+                        await Task.Yield(); // fix for gRPC threading issue.
+                    })
+                    : Task.Run(async () =>
+                    {
+                        // [START read_write_retry]
+                        var retryPolicy = new
+                            RetryPolicy<CustomTransientErrorDetectionStrategy>(RetryStrategy.DefaultExponential);
+
+                        await retryPolicy.ExecuteAsync(() => 
+                            ReadWriteWithTransactionAsync(projectId, instanceId, databaseId));
+                        // [END read_write_retry]
+
+                        await Task.Yield(); // fix for gRPC threading issue.
+                    });
+
+                response.Wait();
                 s_logger.Info($"Response status: {response.Status}");
             }
             catch (Exception e)
@@ -999,12 +1183,12 @@ namespace GoogleCloudSamples.Spanner
                     opts.projectId, opts.instanceId, opts.databaseId),
                 (QueryNewColumnOptions opts) => QueryNewColumn(
                     opts.projectId, opts.instanceId, opts.databaseId),
-                (QueryDataWithTransactionOptions opts) =>
+                (QueryDataWithTransactionOptions opts) => 
                     QueryDataWithTransaction(
-                        opts.projectId, opts.instanceId, opts.databaseId),
+                        opts.projectId, opts.instanceId, opts.databaseId, opts.platform),
                 (ReadWriteWithTransactionOptions opts) =>
                     ReadWriteWithTransaction(
-                        opts.projectId, opts.instanceId, opts.databaseId),
+                        opts.projectId, opts.instanceId, opts.databaseId, opts.platform),
                 (AddIndexOptions opts) => AddIndex(
                     opts.projectId, opts.instanceId, opts.databaseId),
                 (AddStoringIndexOptions opts) => AddStoringIndex(

--- a/spanner/api/Program.cs
+++ b/spanner/api/Program.cs
@@ -176,8 +176,9 @@ namespace GoogleCloudSamples.Spanner
         public string instanceId { get; set; }
         [Value(2, HelpText = "The ID of the database where the sample database resides.", Required = true)]
         public string databaseId { get; set; }
-        [Value(3, HelpText = "The platform code to execute (netcore or net45).", Required = false)]
-        public string platform { get; set; }
+
+        [Value(3, HelpText = "The platform code to execute. This should be 'netcore' or 'net45' (the default).", Required = false)]
+        public string platform { get; set; } = "net45";
     }
 
     [Verb("readWriteWithTransaction", HelpText = "Update data in the sample Cloud Spanner database table using a read-write transaction.")]
@@ -189,8 +190,9 @@ namespace GoogleCloudSamples.Spanner
         public string instanceId { get; set; }
         [Value(2, HelpText = "The ID of the database where the sample database resides.", Required = true)]
         public string databaseId { get; set; }
-        [Value(3, HelpText = "The platform code to execute (netcore or net45).", Required = false)]
-        public string platform { get; set; }
+
+        [Value(3, HelpText = "The platform code to execute. This should be 'netcore' or 'net45' (the default).", Required = false)]
+        public string platform { get; set; } = "net45";
     }
 
     public class Program
@@ -445,7 +447,8 @@ namespace GoogleCloudSamples.Spanner
                 await connection.OpenAsync();
 
                 // Open a new read only transaction.
-                using (var transaction = await connection.BeginReadOnlyTransactionAsync())
+                using (var transaction =
+                    await connection.BeginReadOnlyTransactionAsync())
                 {
                     var cmd = connection.CreateSelectCommand(
                         "SELECT SingerId, AlbumId, AlbumTitle FROM Albums");
@@ -457,11 +460,11 @@ namespace GoogleCloudSamples.Spanner
                         while (await reader.ReadAsync())
                         {
                             Console.WriteLine("SingerId : "
-                                              + reader.GetFieldValue<string>("SingerId")
-                                              + " AlbumId : "
-                                              + reader.GetFieldValue<string>("AlbumId")
-                                              + " AlbumTitle : "
-                                              + reader.GetFieldValue<string>("AlbumTitle"));
+                                + reader.GetFieldValue<string>("SingerId")
+                                + " AlbumId : "
+                                + reader.GetFieldValue<string>("AlbumId")
+                                + " AlbumTitle : "
+                                + reader.GetFieldValue<string>("AlbumTitle"));
                         }
                     }
                     // Read #2. Even if changes occur in-between the reads, 
@@ -472,11 +475,11 @@ namespace GoogleCloudSamples.Spanner
                         while (await reader.ReadAsync())
                         {
                             Console.WriteLine("SingerId : "
-                                              + reader.GetFieldValue<string>("SingerId")
-                                              + " AlbumId : "
-                                              + reader.GetFieldValue<string>("AlbumId")
-                                              + " AlbumTitle : "
-                                              + reader.GetFieldValue<string>("AlbumTitle"));
+                                + reader.GetFieldValue<string>("SingerId")
+                                + " AlbumId : "
+                                + reader.GetFieldValue<string>("AlbumId")
+                                + " AlbumTitle : "
+                                + reader.GetFieldValue<string>("AlbumTitle"));
                         }
                     }
                 }
@@ -509,7 +512,8 @@ namespace GoogleCloudSamples.Spanner
                     // Open the connection, making the implicitly created
                     // transaction read only when it connects to the outer
                     // transaction scope.
-                    await connection.OpenAsReadOnlyAsync().ConfigureAwait(false);
+                    await connection.OpenAsReadOnlyAsync()
+                        .ConfigureAwait(false);
                     var cmd = connection.CreateSelectCommand(
                         "SELECT SingerId, AlbumId, AlbumTitle FROM Albums");
                     // Read #1.
@@ -637,7 +641,9 @@ namespace GoogleCloudSamples.Spanner
         }
 
         // [START read_write_transaction_core]
-        public static async Task ReadWriteWithTransactionCoreAsync(string projectId, string instanceId,
+        public static async Task ReadWriteWithTransactionCoreAsync(
+            string projectId,
+            string instanceId,
             string databaseId)
         {
             // This sample transfers 200,000 from the MarketingBudget 
@@ -661,12 +667,14 @@ namespace GoogleCloudSamples.Spanner
             {
                 await connection.OpenAsync();
 
-                // Create a readwrite transaction that we'll assign to each SpannerCommand.
-                using (var transaction = await connection.BeginTransactionAsync())
+                // Create a readwrite transaction that we'll assign
+                // to each SpannerCommand.
+                using (var transaction =
+                        await connection.BeginTransactionAsync())
                 {
                     // Create statement to select the second album's data.
                     var cmdLookup = connection.CreateSelectCommand(
-                        "SELECT * FROM Albums WHERE SingerId = 2 AND AlbumId = 2");
+                     "SELECT * FROM Albums WHERE SingerId = 2 AND AlbumId = 2");
                     cmdLookup.Transaction = transaction;
                     // Excecute the select query.
                     using (var reader = await cmdLookup.ExecuteReaderAsync())
@@ -675,29 +683,29 @@ namespace GoogleCloudSamples.Spanner
                         {
                             // Read the second album's budget.
                             secondBudget =
-                                reader.GetFieldValue<decimal>("MarketingBudget");
+                               reader.GetFieldValue<decimal>("MarketingBudget");
                             // Confirm second Album's budget is sufficient and
                             // if not raise an exception. Raising an exception
                             // will automatically roll back the transaction.
                             if (secondBudget < minimumAmountToTransfer)
                             {
                                 throw new Exception("The second album's "
-                                                    + $"budget {secondBudget} "
-                                                    + "is less than the minimum required "
-                                                    + "amount to transfer.");
+                                        + $"budget {secondBudget} "
+                                        + "is less than the minimum required "
+                                        + "amount to transfer.");
                             }
                         }
                     }
                     // Read the first album's budget.
                     cmdLookup = connection.CreateSelectCommand(
-                        "SELECT * FROM Albums WHERE SingerId = 1 and AlbumId = 1");
+                     "SELECT * FROM Albums WHERE SingerId = 1 and AlbumId = 1");
                     cmdLookup.Transaction = transaction;
                     using (var reader = await cmdLookup.ExecuteReaderAsync())
                     {
                         while (await reader.ReadAsync())
                         {
                             firstBudget =
-                                reader.GetFieldValue<decimal>("MarketingBudget");
+                              reader.GetFieldValue<decimal>("MarketingBudget");
                         }
                     }
 
@@ -733,7 +741,10 @@ namespace GoogleCloudSamples.Spanner
         // [END read_write_transaction_core]
 
         // [START read_write_transaction]
-        public static async Task ReadWriteWithTransactionAsync(string projectId, string instanceId, string databaseId)
+        public static async Task ReadWriteWithTransactionAsync(
+            string projectId,
+            string instanceId,
+            string databaseId)
         {
             // This sample transfers 200,000 from the MarketingBudget 
             // field of the second Album to the first Album. Make sure to run
@@ -766,7 +777,7 @@ namespace GoogleCloudSamples.Spanner
                         {
                             // Read the second album's budget.
                             secondBudget =
-                                reader.GetFieldValue<decimal>("MarketingBudget");
+                              reader.GetFieldValue<decimal>("MarketingBudget");
                             // Confirm second Album's budget is sufficient and
                             // if not raise an exception. Raising an exception
                             // will automatically roll back the transaction.
@@ -787,7 +798,7 @@ namespace GoogleCloudSamples.Spanner
                         while (await reader.ReadAsync())
                         {
                             firstBudget =
-                                reader.GetFieldValue<decimal>("MarketingBudget");
+                              reader.GetFieldValue<decimal>("MarketingBudget");
                         }
                     }
 
@@ -1019,8 +1030,9 @@ namespace GoogleCloudSamples.Spanner
             return ExitCode.Success;
         }
 
-        public static object QueryDataWithStoringIndex(string projectId,
-            string instanceId, string databaseId, string startTitle, string endTitle)
+        public static object QueryDataWithStoringIndex(
+            string projectId, string instanceId,
+            string databaseId, string startTitle, string endTitle)
         {
             var response = new Task(() => { });
             // Call method QueryDataWithStoringIndexAsync() based on whether 
@@ -1084,14 +1096,17 @@ namespace GoogleCloudSamples.Spanner
         public static object QueryNewColumn(string projectId,
             string instanceId, string databaseId)
         {
-            var response = QueryNewColumnAsync(projectId, instanceId, databaseId);
+            var response = QueryNewColumnAsync(projectId,
+                                instanceId, databaseId);
             s_logger.Info("Waiting for operation to complete...");
             response.Wait();
             s_logger.Info($"Response status: {response.Status}");
             return ExitCode.Success;
         }
 
-        public static object QueryDataWithTransaction(string projectId, string instanceId, string databaseId, string platform)
+        public static object QueryDataWithTransaction(
+            string projectId, string instanceId,
+            string databaseId, string platform)
         {
 
             var retryPolicy =
@@ -1100,9 +1115,11 @@ namespace GoogleCloudSamples.Spanner
 
             var response = platform == NetCorePlatform
                 ? retryPolicy.ExecuteAsync(() =>
-                    QueryDataWithTransactionCoreAsync(projectId, instanceId, databaseId))
+                    QueryDataWithTransactionCoreAsync(projectId,
+                        instanceId, databaseId))
                 : retryPolicy.ExecuteAsync(() =>
-                    QueryDataWithTransactionAsync(projectId, instanceId, databaseId));
+                    QueryDataWithTransactionAsync(projectId,
+                        instanceId, databaseId));
 
             s_logger.Info("Waiting for operation to complete...");
             response.Wait();
@@ -1110,7 +1127,9 @@ namespace GoogleCloudSamples.Spanner
             return ExitCode.Success;
         }
 
-        public static object ReadWriteWithTransaction(string projectId, string instanceId, string databaseId, string platform)
+        public static object ReadWriteWithTransaction(
+            string projectId, string instanceId,
+            string databaseId, string platform)
         {
             try
             {
@@ -1119,10 +1138,12 @@ namespace GoogleCloudSamples.Spanner
                     ? Task.Run(async () =>
                     {
                         var retryPolicy = new
-                            RetryPolicy<CustomTransientErrorDetectionStrategy>(RetryStrategy.DefaultExponential);
+                          RetryPolicy<CustomTransientErrorDetectionStrategy>
+                            (RetryStrategy.DefaultExponential);
 
-                        await retryPolicy.ExecuteAsync(() => ReadWriteWithTransactionCoreAsync(
-                            projectId, instanceId, databaseId));
+                        await retryPolicy.ExecuteAsync(
+                            () => ReadWriteWithTransactionCoreAsync(
+                                projectId, instanceId, databaseId));
 
                         await Task.Yield(); // fix for gRPC threading issue.
                     })
@@ -1130,10 +1151,12 @@ namespace GoogleCloudSamples.Spanner
                     {
                         // [START read_write_retry]
                         var retryPolicy = new
-                            RetryPolicy<CustomTransientErrorDetectionStrategy>(RetryStrategy.DefaultExponential);
+                            RetryPolicy<CustomTransientErrorDetectionStrategy>
+                                (RetryStrategy.DefaultExponential);
 
                         await retryPolicy.ExecuteAsync(() => 
-                            ReadWriteWithTransactionAsync(projectId, instanceId, databaseId));
+                            ReadWriteWithTransactionAsync(
+                                    projectId, instanceId, databaseId));
                         // [END read_write_retry]
 
                         await Task.Yield(); // fix for gRPC threading issue.
@@ -1185,10 +1208,12 @@ namespace GoogleCloudSamples.Spanner
                     opts.projectId, opts.instanceId, opts.databaseId),
                 (QueryDataWithTransactionOptions opts) => 
                     QueryDataWithTransaction(
-                        opts.projectId, opts.instanceId, opts.databaseId, opts.platform),
+                        opts.projectId, opts.instanceId, opts.databaseId,
+                        opts.platform),
                 (ReadWriteWithTransactionOptions opts) =>
                     ReadWriteWithTransaction(
-                        opts.projectId, opts.instanceId, opts.databaseId, opts.platform),
+                        opts.projectId, opts.instanceId, opts.databaseId,
+                        opts.platform),
                 (AddIndexOptions opts) => AddIndex(
                     opts.projectId, opts.instanceId, opts.databaseId),
                 (AddStoringIndexOptions opts) => AddStoringIndex(

--- a/spanner/api/QuickStart/QuickStart.csproj
+++ b/spanner/api/QuickStart/QuickStart.csproj
@@ -72,20 +72,16 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Cloud.Spanner.Admin.Database.V1, Version=1.0.0.0, Culture=neutral, PublicKeyToken=185c282632e132a0, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Cloud.Spanner.Admin.Database.V1.1.0.0-beta02\lib\net45\Google.Cloud.Spanner.Admin.Database.V1.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Google.Cloud.Spanner.Admin.Database.V1.1.0.0-beta03\lib\net45\Google.Cloud.Spanner.Admin.Database.V1.dll</HintPath>
     </Reference>
     <Reference Include="Google.Cloud.Spanner.Admin.Instance.V1, Version=1.0.0.0, Culture=neutral, PublicKeyToken=185c282632e132a0, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Cloud.Spanner.Admin.Instance.V1.1.0.0-beta02\lib\net45\Google.Cloud.Spanner.Admin.Instance.V1.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Google.Cloud.Spanner.Admin.Instance.V1.1.0.0-beta03\lib\net45\Google.Cloud.Spanner.Admin.Instance.V1.dll</HintPath>
     </Reference>
     <Reference Include="Google.Cloud.Spanner.Data, Version=1.0.0.0, Culture=neutral, PublicKeyToken=185c282632e132a0, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Cloud.Spanner.Data.1.0.0-beta02\lib\net45\Google.Cloud.Spanner.Data.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Google.Cloud.Spanner.Data.1.0.0-beta03\lib\net45\Google.Cloud.Spanner.Data.dll</HintPath>
     </Reference>
     <Reference Include="Google.Cloud.Spanner.V1, Version=1.0.0.0, Culture=neutral, PublicKeyToken=185c282632e132a0, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Cloud.Spanner.V1.1.0.0-beta02\lib\net45\Google.Cloud.Spanner.V1.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Google.Cloud.Spanner.V1.1.0.0-beta03\lib\net45\Google.Cloud.Spanner.V1.dll</HintPath>
     </Reference>
     <Reference Include="Google.LongRunning, Version=1.0.0.0, Culture=neutral, PublicKeyToken=185c282632e132a0, processorArchitecture=MSIL">
       <HintPath>..\packages\Google.LongRunning.1.0.0-beta10\lib\net45\Google.LongRunning.dll</HintPath>

--- a/spanner/api/QuickStart/packages.config
+++ b/spanner/api/QuickStart/packages.config
@@ -7,10 +7,10 @@
   <package id="Google.Apis.Auth" version="1.27.1" targetFramework="net452" />
   <package id="Google.Apis.Core" version="1.27.1" targetFramework="net452" />
   <package id="Google.Cloud.Iam.V1" version="1.0.0-beta11" targetFramework="net452" />
-  <package id="Google.Cloud.Spanner.Admin.Database.V1" version="1.0.0-beta02" targetFramework="net452" />
-  <package id="Google.Cloud.Spanner.Admin.Instance.V1" version="1.0.0-beta02" targetFramework="net452" />
-  <package id="Google.Cloud.Spanner.Data" version="1.0.0-beta02" targetFramework="net452" />
-  <package id="Google.Cloud.Spanner.V1" version="1.0.0-beta02" targetFramework="net452" />
+  <package id="Google.Cloud.Spanner.Admin.Database.V1" version="1.0.0-beta03" targetFramework="net452" />
+  <package id="Google.Cloud.Spanner.Admin.Instance.V1" version="1.0.0-beta03" targetFramework="net452" />
+  <package id="Google.Cloud.Spanner.Data" version="1.0.0-beta03" targetFramework="net452" />
+  <package id="Google.Cloud.Spanner.V1" version="1.0.0-beta03" targetFramework="net452" />
   <package id="Google.LongRunning" version="1.0.0-beta10" targetFramework="net452" />
   <package id="Google.Protobuf" version="3.3.0" targetFramework="net452" />
   <package id="Grpc.Auth" version="1.4.0" targetFramework="net452" />

--- a/spanner/api/Spanner.csproj
+++ b/spanner/api/Spanner.csproj
@@ -76,20 +76,16 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Cloud.Spanner.Admin.Database.V1, Version=1.0.0.0, Culture=neutral, PublicKeyToken=185c282632e132a0, processorArchitecture=MSIL">
-      <HintPath>packages\Google.Cloud.Spanner.Admin.Database.V1.1.0.0-beta02\lib\net45\Google.Cloud.Spanner.Admin.Database.V1.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>packages\Google.Cloud.Spanner.Admin.Database.V1.1.0.0-beta03\lib\net45\Google.Cloud.Spanner.Admin.Database.V1.dll</HintPath>
     </Reference>
     <Reference Include="Google.Cloud.Spanner.Admin.Instance.V1, Version=1.0.0.0, Culture=neutral, PublicKeyToken=185c282632e132a0, processorArchitecture=MSIL">
-      <HintPath>packages\Google.Cloud.Spanner.Admin.Instance.V1.1.0.0-beta02\lib\net45\Google.Cloud.Spanner.Admin.Instance.V1.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>packages\Google.Cloud.Spanner.Admin.Instance.V1.1.0.0-beta03\lib\net45\Google.Cloud.Spanner.Admin.Instance.V1.dll</HintPath>
     </Reference>
     <Reference Include="Google.Cloud.Spanner.Data, Version=1.0.0.0, Culture=neutral, PublicKeyToken=185c282632e132a0, processorArchitecture=MSIL">
-      <HintPath>packages\Google.Cloud.Spanner.Data.1.0.0-beta02\lib\net45\Google.Cloud.Spanner.Data.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>packages\Google.Cloud.Spanner.Data.1.0.0-beta03\lib\net45\Google.Cloud.Spanner.Data.dll</HintPath>
     </Reference>
     <Reference Include="Google.Cloud.Spanner.V1, Version=1.0.0.0, Culture=neutral, PublicKeyToken=185c282632e132a0, processorArchitecture=MSIL">
-      <HintPath>packages\Google.Cloud.Spanner.V1.1.0.0-beta02\lib\net45\Google.Cloud.Spanner.V1.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>packages\Google.Cloud.Spanner.V1.1.0.0-beta03\lib\net45\Google.Cloud.Spanner.V1.dll</HintPath>
     </Reference>
     <Reference Include="Google.LongRunning, Version=1.0.0.0, Culture=neutral, PublicKeyToken=185c282632e132a0, processorArchitecture=MSIL">
       <HintPath>packages\Google.LongRunning.1.0.0-beta10\lib\net45\Google.LongRunning.dll</HintPath>

--- a/spanner/api/SpannerTest/Tests.cs
+++ b/spanner/api/SpannerTest/Tests.cs
@@ -54,20 +54,43 @@ namespace GoogleCloudSamples.Spanner
             Assert.Contains("SingerId : 2 AlbumId : 1", output.Stdout);
         }
 
-        //[Fact]
-        //void TestQueryTransaction()
-        //{
-        //    ConsoleOutput output = _spanner.Run("queryDataWithTransaction",
-        //        s_projectId, _instanceId, _databseId);
-        //    Assert.Equal(0, output.ExitCode);
-        //    Assert.Contains("SingerId : 1 AlbumId : 1", output.Stdout);
-        //    Assert.Contains("SingerId : 2 AlbumId : 1", output.Stdout);
-        //}
-        // TODO: Uncomment the above test when the client library is updated
-        // for transactions which will enable this test to run consistently
-        // without transient issues. 
-        // Link to issue: https://github.com/grpc/grpc/issues/11824
+        [Fact]
+        void TestQueryTransaction()
+        {
+            ConsoleOutput output = _spanner.Run("queryDataWithTransaction",
+                s_projectId, _instanceId, _databseId);
+            Assert.Equal(0, output.ExitCode);
+            Assert.Contains("SingerId : 1 AlbumId : 1", output.Stdout);
+            Assert.Contains("SingerId : 2 AlbumId : 1", output.Stdout);
+        }
 
+        [Fact]
+        void TestQueryTransactionCore()
+        {
+            ConsoleOutput output = _spanner.Run("queryDataWithTransaction",
+                s_projectId, _instanceId, _databseId, "netcore");
+            Assert.Equal(0, output.ExitCode);
+            Assert.Contains("SingerId : 1 AlbumId : 1", output.Stdout);
+            Assert.Contains("SingerId : 2 AlbumId : 1", output.Stdout);
+        }
+
+        [Fact]
+        void TestReadWriteTransaction()
+        {
+            ConsoleOutput output = _spanner.Run("readWriteWithTransaction",
+                s_projectId, _instanceId, _databseId);
+            Assert.Equal(0, output.ExitCode);
+            Assert.Contains("Transaction complete.", output.Stdout);
+        }
+
+        [Fact]
+        void TestReadWriteTransactionCore()
+        {
+            ConsoleOutput output = _spanner.Run("readWriteWithTransaction",
+                s_projectId, _instanceId, _databseId, "netcore");
+            Assert.Equal(0, output.ExitCode);
+            Assert.Contains("Transaction complete.", output.Stdout);
+        }
 
         [Fact]
         void TestSpannerNoArgsSucceeds()

--- a/spanner/api/packages.config
+++ b/spanner/api/packages.config
@@ -9,10 +9,10 @@
   <package id="Google.Apis.Auth" version="1.27.1" targetFramework="net452" />
   <package id="Google.Apis.Core" version="1.27.1" targetFramework="net452" />
   <package id="Google.Cloud.Iam.V1" version="1.0.0-beta11" targetFramework="net452" />
-  <package id="Google.Cloud.Spanner.Admin.Database.V1" version="1.0.0-beta02" targetFramework="net452" />
-  <package id="Google.Cloud.Spanner.Admin.Instance.V1" version="1.0.0-beta02" targetFramework="net452" />
-  <package id="Google.Cloud.Spanner.Data" version="1.0.0-beta02" targetFramework="net452" />
-  <package id="Google.Cloud.Spanner.V1" version="1.0.0-beta02" targetFramework="net452" />
+  <package id="Google.Cloud.Spanner.Admin.Database.V1" version="1.0.0-beta03" targetFramework="net452" />
+  <package id="Google.Cloud.Spanner.Admin.Instance.V1" version="1.0.0-beta03" targetFramework="net452" />
+  <package id="Google.Cloud.Spanner.Data" version="1.0.0-beta03" targetFramework="net452" />
+  <package id="Google.Cloud.Spanner.V1" version="1.0.0-beta03" targetFramework="net452" />
   <package id="Google.LongRunning" version="1.0.0-beta10" targetFramework="net452" />
   <package id="Google.Protobuf" version="3.3.0" targetFramework="net452" />
   <package id="Grpc.Auth" version="1.4.0" targetFramework="net452" />


### PR DESCRIPTION
read_only_transaction_core
read_write_transaction_core

also adds a new tag for showing code on how to use the transient fault app block to handle transaction retries.
read_write_retry

(only one is needed as its the same in netcore and net45)