### PR TITLE
KMS: Make the samples consistent with the other languages.

### DIFF
--- a/kms/api/CloudKmsTest/CloudKmsTest.cs
+++ b/kms/api/CloudKmsTest/CloudKmsTest.cs
@@ -113,19 +113,19 @@ namespace GoogleCloudSamples
             string cryptoKey = $"testCryptoKey{timeStamp}";
             var createKeyRingOutput = Run("createKeyRing", s_projectId, "global", keyRing);
             var createCryptoKeyOutput = Run("createCryptoKey", s_projectId, "global", keyRing, cryptoKey);
-            var outputEncrypt = Run("encrypt", s_projectId, "global", keyRing, cryptoKey, inFile, outFile);
+            var encryptOutput = Run("encrypt", s_projectId, "global", keyRing, cryptoKey, inFile, outFile);
             // Confirm original input file contents are not equal to encrypted file's contents
             Eventually(() =>
             {
-                Assert.Equal(0, outputEncrypt.ExitCode);
+                Assert.Equal(0, encryptOutput.ExitCode);
                 Assert.False(File.ReadLines(inFile).SequenceEqual(File.ReadLines(outFile)));
             });
             // Confirm original input file contents are equal to decrypted file's contents
-            Console.WriteLine("Confirming decrypted contents match original content...");
-            var outputDecrypt = Run("decrypt", s_projectId, "global", keyRing, cryptoKey, outFile, testFile);
+            Console.WriteLine("Confirming decrypted contents match original contents...");
+            var decryptOutput = Run("decrypt", s_projectId, "global", keyRing, cryptoKey, outFile, testFile);
             Eventually(() =>
             {
-                Assert.Equal(0, outputDecrypt.ExitCode);
+                Assert.Equal(0, decryptOutput.ExitCode);
                 Assert.True(File.ReadLines(inFile).SequenceEqual(File.ReadLines(testFile)));
             });
             // Delete encrypted & decrypted files to clean up

--- a/kms/api/Program.cs
+++ b/kms/api/Program.cs
@@ -626,40 +626,38 @@ namespace GoogleCloudSamples
 
         // [START kms_encrypt]
         public static object Encrypt(string projectId, string locationId, string keyRingId, string cryptoKeyId,
-string fileToEncrypt, string fileToOutput)
+string plaintextFile, string ciphertextFile)
         {
             var cloudKms = CreateAuthorizedClient();
             // Generate the full path of the crypto key to use for encryption.
             var cryptoKey = $"projects/{projectId}/locations/{locationId}/keyRings/{keyRingId}/cryptoKeys/{cryptoKeyId}";
-            EncryptRequest dataToEncrypt = new EncryptRequest();
-            byte[] bytes = File.ReadAllBytes(fileToEncrypt);
-            string contents = Convert.ToBase64String(bytes);
-            dataToEncrypt.Plaintext = contents;
-            Console.WriteLine($"dataToEncrypt.Plaintext: {dataToEncrypt.Plaintext}");
-            var result = cloudKms.Projects.Locations.KeyRings.CryptoKeys.Encrypt(body: dataToEncrypt, name: cryptoKey).Execute();
-            // Output encypted data to a file.
-            File.WriteAllBytes(fileToOutput, Convert.FromBase64String(result.Ciphertext));
-            Console.Write($"Encypted file created: {fileToOutput}");
+            EncryptRequest encryptRequest = new EncryptRequest();
+            byte[] plaintext = File.ReadAllBytes(plaintextFile);
+            encryptRequest.Plaintext = Convert.ToBase64String(plaintext);
+            Console.WriteLine($"dataToEncrypt.Plaintext: {encryptRequest.Plaintext}");
+            var result = cloudKms.Projects.Locations.KeyRings.CryptoKeys.Encrypt(name: cryptoKey, body: encryptRequest).Execute();
+            // Output encrypted data to a file.
+            File.WriteAllBytes(ciphertextFile, Convert.FromBase64String(result.Ciphertext));
+            Console.Write($"Encrypted file created: {ciphertextFile}");
             return 0;
         }
         // [END kms_encrypt]
 
         // [START kms_decrypt]
         public static object Decrypt(string projectId, string locationId, string keyRingId, string cryptoKeyId,
-    string fileToDecrypt, string fileToOutput)
+    string ciphertextFile, string plaintextFile)
         {
             var cloudKms = CreateAuthorizedClient();
             // Generate the full path of the crypto key to use for encryption.
             var cryptoKey = $"projects/{projectId}/locations/{locationId}/keyRings/{keyRingId}/cryptoKeys/{cryptoKeyId}";
-            DecryptRequest dataToDecrypt = new DecryptRequest();
-            byte[] bytes = File.ReadAllBytes(fileToDecrypt);
-            string contents = Convert.ToBase64String(bytes);
-            dataToDecrypt.Ciphertext = contents;
-            Console.WriteLine($"dataToDecrypt.Ciphertext: {dataToDecrypt.Ciphertext}");
-            var result = cloudKms.Projects.Locations.KeyRings.CryptoKeys.Decrypt(dataToDecrypt, cryptoKey).Execute();
-            // Output decypted data to a file
-            File.WriteAllBytes(fileToOutput, Convert.FromBase64String(result.Plaintext));
-            Console.Write($"Encypted file created: {fileToOutput}");
+            DecryptRequest decryptRequest = new DecryptRequest();
+            byte[] ciphertext = File.ReadAllBytes(ciphertextFile);
+            decryptRequest.Ciphertext = Convert.ToBase64String(ciphertext);
+            Console.WriteLine($"dataToDecrypt.Ciphertext: {decryptRequest.Ciphertext}");
+            var result = cloudKms.Projects.Locations.KeyRings.CryptoKeys.Decrypt(name: cryptoKey, body: decryptRequest).Execute();
+            // Output decrypted data to a file.
+            File.WriteAllBytes(plaintextFile, Convert.FromBase64String(result.Plaintext));
+            Console.Write($"Decrypted file created: {plaintextFile}");
             return 0;
         }
         // [END kms_decrypt]

--- a/kms/api/Program.cs
+++ b/kms/api/Program.cs
@@ -40,13 +40,13 @@ namespace GoogleCloudSamples
         public string projectId { get; set; }
 
         [Value(1, HelpText = "The location of the crypto key. Ex. 'global'", Required = true)]
-        public string location { get; set; }
+        public string locationId { get; set; }
 
         [Value(2, HelpText = "The name of the key ring containing the crypto key.", Required = true)]
-        public string keyRing { get; set; }
+        public string keyRingId { get; set; }
 
         [Value(3, HelpText = "The name of the crypto key.", Required = true)]
-        public string keyName { get; set; }
+        public string cryptoKeyId { get; set; }
 
         [Value(4, HelpText = "The name of the input file to encrypt or decrypt.", Required = true)]
         public string inFile { get; set; }
@@ -61,7 +61,7 @@ namespace GoogleCloudSamples
         [Value(0, HelpText = "The project ID of the project to use when listing Cloud KMS resources.", Required = true)]
         public string projectId { get; set; }
         [Value(1, HelpText = "The location to use when listing Cloud KMS resources. Ex. 'global'", Required = true)]
-        public string location { get; set; }
+        public string locationId { get; set; }
     }
 
     [Verb("listCryptoKeys", HelpText = "List all crypto keys for the specified key ring.")]
@@ -78,9 +78,9 @@ namespace GoogleCloudSamples
         [Value(0, HelpText = "The project ID of the project to use when accessing Cloud KMS resources.", Required = true)]
         public string projectId { get; set; }
         [Value(1, HelpText = "The location to use when accessing Cloud KMS resources. Ex. 'global'", Required = true)]
-        public string location { get; set; }
+        public string locationId { get; set; }
         [Value(2, HelpText = "The name of the key ring to use when accessing Cloud KMS resources.", Required = true)]
-        public string keyRing { get; set; }
+        public string keyRingId { get; set; }
     }
 
     [Verb("createCryptoKey", HelpText = "Create a crypto key.")]
@@ -94,11 +94,11 @@ namespace GoogleCloudSamples
         [Value(0, HelpText = "The project ID of the project to use when accessing Cloud KMS resources.", Required = true)]
         public string projectId { get; set; }
         [Value(1, HelpText = "The location to use when accessing Cloud KMS resources. Ex. 'global'", Required = true)]
-        public string location { get; set; }
+        public string locationId { get; set; }
         [Value(2, HelpText = "The name of the key ring holding the crypto key.", Required = true)]
-        public string keyRing { get; set; }
+        public string keyRingId { get; set; }
         [Value(3, HelpText = "The name of the crypto key.", Required = true)]
-        public string cryptoKey { get; set; }
+        public string cryptoKeyId { get; set; }
     }
 
     [Verb("disableCryptoKeyVersion", HelpText = "Disable a crypto key version.")]
@@ -121,13 +121,13 @@ namespace GoogleCloudSamples
         [Value(0, HelpText = "The project ID of the project to use when updating Cloud KMS resources.", Required = true)]
         public string projectId { get; set; }
         [Value(1, HelpText = "The location to use when updating Cloud KMS resources. Ex. 'global'", Required = true)]
-        public string location { get; set; }
+        public string locationId { get; set; }
         [Value(2, HelpText = "The name of the key ring that contains the crypto key to update.", Required = true)]
-        public string keyRing { get; set; }
+        public string keyRingId { get; set; }
         [Value(3, HelpText = "The name of the crypto key to update.", Required = true)]
-        public string cryptoKey { get; set; }
+        public string cryptoKeyId { get; set; }
         [Value(4, HelpText = "The name of the crypto key version to update.", Required = true)]
-        public string version { get; set; }
+        public string versionId { get; set; }
     }
 
     [Verb("getCryptoKeyIamPolicy", HelpText = "Get a crypto key's IAM policy.")]
@@ -136,11 +136,11 @@ namespace GoogleCloudSamples
         [Value(0, HelpText = "The project ID of the project to use when listing Cloud KMS resources.", Required = true)]
         public string projectId { get; set; }
         [Value(1, HelpText = "The location to use when listing Cloud KMS resources. Ex. 'global'", Required = true)]
-        public string location { get; set; }
+        public string locationId { get; set; }
         [Value(2, HelpText = "The name of the keyRing containing the crypto key.", Required = true)]
-        public string keyRing { get; set; }
+        public string keyRingId { get; set; }
         [Value(3, HelpText = "The name of the crypto key to get the IAM policy details for.", Required = true)]
-        public string cryptoKey { get; set; }
+        public string cryptoKeyId { get; set; }
     }
 
 
@@ -150,11 +150,11 @@ namespace GoogleCloudSamples
         [Value(0, HelpText = "The project ID of the project to use when updating Cloud KMS resources.", Required = true)]
         public string projectId { get; set; }
         [Value(1, HelpText = "The location to use when updating Cloud KMS resources. Ex. 'global'", Required = true)]
-        public string location { get; set; }
+        public string locationId { get; set; }
         [Value(2, HelpText = "The name of the keyRing containing the crypto key.", Required = true)]
-        public string keyRing { get; set; }
+        public string keyRingId { get; set; }
         [Value(3, HelpText = "The name of the crypto key to set the IAM policy details for.", Required = true)]
-        public string cryptoKey { get; set; }
+        public string cryptoKeyId { get; set; }
         [Value(4, HelpText = "The role to add to the keyRing's IAM policy.", Required = true)]
         public string role { get; set; }
         [Value(5, HelpText = "The member to add to the keyRing's IAM policy.", Required = true)]
@@ -167,11 +167,11 @@ namespace GoogleCloudSamples
         [Value(0, HelpText = "The project ID of the project to use when updating Cloud KMS resources.", Required = true)]
         public string projectId { get; set; }
         [Value(1, HelpText = "The location to use when updating Cloud KMS resources. Ex. 'global'", Required = true)]
-        public string location { get; set; }
+        public string locationId { get; set; }
         [Value(2, HelpText = "The name of the keyRing containing the crypto key.", Required = true)]
-        public string keyRing { get; set; }
+        public string keyRingId { get; set; }
         [Value(3, HelpText = "The name of the crypto key to set the IAM policy details for.", Required = true)]
-        public string cryptoKey { get; set; }
+        public string cryptoKeyId { get; set; }
         [Value(4, HelpText = "The role to remove to the keyRing's IAM policy.", Required = true)]
         public string role { get; set; }
         [Value(5, HelpText = "The member to remove to the keyRing's IAM policy.", Required = true)]
@@ -184,9 +184,9 @@ namespace GoogleCloudSamples
         [Value(0, HelpText = "The project ID of the project to use when listing Cloud KMS resources.", Required = true)]
         public string projectId { get; set; }
         [Value(1, HelpText = "The location to use when listing Cloud KMS resources. Ex. 'global'", Required = true)]
-        public string location { get; set; }
+        public string locationId { get; set; }
         [Value(2, HelpText = "The name of the keyRing to get the IAM policy details for.", Required = true)]
-        public string keyRing { get; set; }
+        public string keyRingId { get; set; }
     }
 
     [Verb("addMemberToKeyRingPolicy", HelpText = "Add member to a keyRing's IAM policy.")]
@@ -195,9 +195,9 @@ namespace GoogleCloudSamples
         [Value(0, HelpText = "The project ID of the project to use when updating Cloud KMS resources.", Required = true)]
         public string projectId { get; set; }
         [Value(1, HelpText = "The location to use when updating Cloud KMS resources. Ex. 'global'", Required = true)]
-        public string location { get; set; }
+        public string locationId { get; set; }
         [Value(2, HelpText = "The name of the keyRing to set the IAM policy details for.", Required = true)]
-        public string keyRing { get; set; }
+        public string keyRingId { get; set; }
         [Value(3, HelpText = "The role to add to the keyRing's IAM policy.", Required = true)]
         public string role { get; set; }
         [Value(4, HelpText = "The member to add to the keyRing's IAM policy.", Required = true)]
@@ -233,11 +233,11 @@ namespace GoogleCloudSamples
         }
 
         // [START kms_list_keyrings]
-        public static object ListKeyRings(string projectId, string location)
+        public static object ListKeyRings(string projectId, string locationId)
         {
             var cloudKms = CreateAuthorizedClient();
             // The resource name of the location associated with the key rings.
-            var parent = $"projects/{projectId}/locations/{location}";
+            var parent = $"projects/{projectId}/locations/{locationId}";
             try
             {
                 var result = cloudKms.Projects.Locations.KeyRings.List(parent).Execute();
@@ -254,17 +254,17 @@ namespace GoogleCloudSamples
         // [END kms_list_keyrings]
 
         // [START kms_list_cryptokeys]
-        public static object ListCryptoKeys(string projectId, string location, string keyRing)
+        public static object ListCryptoKeys(string projectId, string locationId, string keyRingId)
         {
             var cloudKms = CreateAuthorizedClient();
             // Generate the full path of the parent to use for listing crypto keys.
-            var parent = $"projects/{projectId}/locations/{location}/keyRings/{keyRing}";
+            var parent = $"projects/{projectId}/locations/{locationId}/keyRings/{keyRingId}";
             var result = cloudKms.Projects.Locations.KeyRings.CryptoKeys.List(parent).Execute();
             Console.WriteLine("Crypto Keys: ");
             result.CryptoKeys.ToList().ForEach(response =>
             {
                 Console.WriteLine(response.Name);
-                Console.WriteLine($"  Created:{response.CreateTime}");
+                Console.WriteLine($"  Created: {response.CreateTime}");
                 Console.WriteLine($"  Purpose: {response.Purpose}");
                 Console.WriteLine($"  Primary: {response.Primary}");
                 Console.WriteLine($"    State: {response.Primary.State}");
@@ -275,15 +275,15 @@ namespace GoogleCloudSamples
         // [END kms_list_cryptokeys]
 
         // [START kms_create_keyring]
-        public static object CreateKeyRing(string projectId, string location, string keyRing)
+        public static object CreateKeyRing(string projectId, string locationId, string keyRingId)
         {
             var cloudKms = CreateAuthorizedClient();
             // Generate the full path of the parent to use for creating key rings.
-            var parent = $"projects/{projectId}/locations/{location}";
+            var parent = $"projects/{projectId}/locations/{locationId}";
             KeyRing keyRingToCreate = new KeyRing();
             var request = new ProjectsResource.LocationsResource.KeyRingsResource.CreateRequest(
                 cloudKms, keyRingToCreate, parent);
-            request.KeyRingId = keyRing;
+            request.KeyRingId = keyRingId;
             var result = request.Execute();
             Console.Write($"Created Key Ring: {result.Name}");
             return 0;
@@ -291,11 +291,11 @@ namespace GoogleCloudSamples
         // [END kms_create_keyring]
 
         // [START kms_get_keyring]
-        public static object GetKeyRing(string projectId, string location, string keyRing)
+        public static object GetKeyRing(string projectId, string locationId, string keyRingId)
         {
             var cloudKms = CreateAuthorizedClient();
             // Generate the full path of the parent to use for getting the key ring.
-            var parent = $"projects/{projectId}/locations/{location}/keyRings/{keyRing}";
+            var parent = $"projects/{projectId}/locations/{locationId}/keyRings/{keyRingId}";
             var result = cloudKms.Projects.Locations.KeyRings.Get(parent).Execute();
             Console.WriteLine($"Found KeyRing: {result.Name}");
             Console.WriteLine($"  Created on:{result.CreateTime}");
@@ -304,15 +304,15 @@ namespace GoogleCloudSamples
         // [END kms_get_keyring]
 
         // [START kms_get_cryptokey]
-        public static object GetCryptoKey(string projectId, string location, string keyRing, string cryptoKey)
+        public static object GetCryptoKey(string projectId, string locationId, string keyRingId, string cryptoKeyId)
         {
             var cloudKms = CreateAuthorizedClient();
             // Generate the full path of the parent to use for getting the key ring.
-            var parent = $"projects/{projectId}/locations/{location}/keyRings/{keyRing}/cryptoKeys/{cryptoKey}";
+            var parent = $"projects/{projectId}/locations/{locationId}/keyRings/{keyRingId}/cryptoKeys/{cryptoKeyId}";
             var result = cloudKms.Projects.Locations.KeyRings.CryptoKeys.Get(parent).Execute();
             Console.WriteLine($"Name: {result.Name}");
             Console.WriteLine($"Created: {result.CreateTime}");
-            Console.WriteLine($"Purpose:{result.Purpose}");
+            Console.WriteLine($"Purpose: {result.Purpose}");
             Console.WriteLine($"Primary: {result.Primary}");
             Console.WriteLine($"  State: { result.Primary.State}");
             Console.WriteLine($"  Created: { result.Primary.CreateTime}");
@@ -321,16 +321,16 @@ namespace GoogleCloudSamples
         // [END kms_get_cryptokey]
 
         // [START kms_create_cryptokey]
-        public static object CreateCryptoKey(string projectId, string location, string keyRing, string cryptoKey)
+        public static object CreateCryptoKey(string projectId, string locationId, string keyRingId, string cryptoKeyId)
         {
             var cloudKms = CreateAuthorizedClient();
             // Generate the full path of the parent to use for creating the crypto key.
-            var parent = $"projects/{projectId}/locations/{location}/keyRings/{keyRing}";
+            var parent = $"projects/{projectId}/locations/{locationId}/keyRings/{keyRingId}";
             CryptoKey cryptoKeyToCreate = new CryptoKey();
             cryptoKeyToCreate.Purpose = "ENCRYPT_DECRYPT";
             var request = new ProjectsResource.LocationsResource.KeyRingsResource.CryptoKeysResource.CreateRequest(
                 cloudKms, cryptoKeyToCreate, parent);
-            request.CryptoKeyId = cryptoKey;
+            request.CryptoKeyId = cryptoKeyId;
             var result = request.Execute();
             Console.Write($"Created Crypto Key: {result.Name}");
             return 0;
@@ -339,11 +339,11 @@ namespace GoogleCloudSamples
 
 
         // [START kms_disable_cryptokey_version]
-        public static object DisableCryptoKeyVersion(string projectId, string location, string keyRing, string cryptoKey, string version)
+        public static object DisableCryptoKeyVersion(string projectId, string locationId, string keyRingId, string cryptoKeyId, string versionId)
         {
             var cloudKms = CreateAuthorizedClient();
             // Generate the full path of the parent to use for disabling the crypto key Version.
-            var parent = $"projects/{projectId}/locations/{location}/keyRings/{keyRing}/cryptoKeys/{cryptoKey}/cryptoKeyVersions/{version}";
+            var parent = $"projects/{projectId}/locations/{locationId}/keyRings/{keyRingId}/cryptoKeys/{cryptoKeyId}/cryptoKeyVersions/{versionId}";
             // Get crypto key version.
             var request = new ProjectsResource.LocationsResource.KeyRingsResource.CryptoKeysResource
                 .CryptoKeyVersionsResource.GetRequest(cloudKms, parent);
@@ -359,11 +359,11 @@ namespace GoogleCloudSamples
         // [END kms_disable_cryptokey_version]
 
         // [START kms_enable_cryptokey_version]
-        public static object EnableCryptoKeyVersion(string projectId, string location, string keyRing, string cryptoKey, string version)
+        public static object EnableCryptoKeyVersion(string projectId, string locationId, string keyRingId, string cryptoKeyId, string versionId)
         {
             var cloudKms = CreateAuthorizedClient();
             // Generate the full path of the parent to use for enabling the crypto key Version.
-            var parent = $"projects/{projectId}/locations/{location}/keyRings/{keyRing}/cryptoKeys/{cryptoKey}/cryptoKeyVersions/{version}";
+            var parent = $"projects/{projectId}/locations/{locationId}/keyRings/{keyRingId}/cryptoKeys/{cryptoKeyId}/cryptoKeyVersions/{versionId}";
             // Get crypto key version.
             var request = new ProjectsResource.LocationsResource.KeyRingsResource.CryptoKeysResource
             .CryptoKeyVersionsResource.GetRequest(cloudKms, parent);
@@ -379,11 +379,11 @@ namespace GoogleCloudSamples
         // [END kms_enable_cryptokey_version]
 
         // [START kms_get_cryptokey_version]
-        public static object GetCryptoKeyVersion(string projectId, string location, string keyRing, string cryptoKey, string version)
+        public static object GetCryptoKeyVersion(string projectId, string locationId, string keyRingId, string cryptoKeyId, string versionId)
         {
             var cloudKms = CreateAuthorizedClient();
             // Generate the full path of the parent to use for getting the crypto key Version.
-            var parent = $"projects/{projectId}/locations/{location}/keyRings/{keyRing}/cryptoKeys/{cryptoKey}/cryptoKeyVersions/{version}";
+            var parent = $"projects/{projectId}/locations/{locationId}/keyRings/{keyRingId}/cryptoKeys/{cryptoKeyId}/cryptoKeyVersions/{versionId}";
             var result = cloudKms.Projects.Locations.KeyRings.CryptoKeys.CryptoKeyVersions.Get(parent).Execute();
             Console.WriteLine($"Name: {result.Name}");
             Console.WriteLine($"Created: {result.CreateTime}");
@@ -393,11 +393,11 @@ namespace GoogleCloudSamples
         // [END kms_get_cryptokey_version]
 
         // [START kms_destroy_cryptokey_version]
-        public static object DestroyCryptoKeyVersion(string projectId, string location, string keyRing, string cryptoKey, string version)
+        public static object DestroyCryptoKeyVersion(string projectId, string locationId, string keyRingId, string cryptoKeyId, string versionId)
         {
             var cloudKms = CreateAuthorizedClient();
             // Generate the full path of the parent to use for destroying the crypto key Version.
-            var parent = $"projects/{projectId}/locations/{location}/keyRings/{keyRing}/cryptoKeys/{cryptoKey}/cryptoKeyVersions/{version}";
+            var parent = $"projects/{projectId}/locations/{locationId}/keyRings/{keyRingId}/cryptoKeys/{cryptoKeyId}/cryptoKeyVersions/{versionId}";
             DestroyCryptoKeyVersionRequest destroyRequest = new DestroyCryptoKeyVersionRequest();
             // Destroy crypto key version.
             var request = new ProjectsResource.LocationsResource.KeyRingsResource.CryptoKeysResource
@@ -409,11 +409,11 @@ namespace GoogleCloudSamples
         // [END kms_destroy_cryptokey_version]
 
         // [START kms_restore_cryptokey_version]
-        public static object RestoreCryptoKeyVersion(string projectId, string location, string keyRing, string cryptoKey, string version)
+        public static object RestoreCryptoKeyVersion(string projectId, string locationId, string keyRingId, string cryptoKeyId, string versionId)
         {
             var cloudKms = CreateAuthorizedClient();
             // Generate the full path of the parent to use for restoring the crypto key Version.
-            var parent = $"projects/{projectId}/locations/{location}/keyRings/{keyRing}/cryptoKeys/{cryptoKey}/cryptoKeyVersions/{version}";
+            var parent = $"projects/{projectId}/locations/{locationId}/keyRings/{keyRingId}/cryptoKeys/{cryptoKeyId}/cryptoKeyVersions/{versionId}";
             RestoreCryptoKeyVersionRequest restoreRequest = new RestoreCryptoKeyVersionRequest();
             // Restore crypto key version.
             var request = new ProjectsResource.LocationsResource.KeyRingsResource.CryptoKeysResource
@@ -425,12 +425,12 @@ namespace GoogleCloudSamples
         // [END kms_restore_cryptokey_version]
 
         // [START kms_get_cryptokey_policy]
-        public static object GetCryptoKeyIamPolicy(string projectId, string location,
-            string keyRing, string cryptoKey)
+        public static object GetCryptoKeyIamPolicy(string projectId, string locationId,
+            string keyRingId, string cryptoKeyId)
         {
             var cloudKms = CreateAuthorizedClient();
             // Generate the full path of the parent to use for getting the crypto key IAM policy.
-            var parent = $"projects/{projectId}/locations/{location}/keyRings/{keyRing}/cryptoKeys/{cryptoKey}";
+            var parent = $"projects/{projectId}/locations/{locationId}/keyRings/{keyRingId}/cryptoKeys/{cryptoKeyId}";
             var result = cloudKms.Projects.Locations.KeyRings.CryptoKeys.GetIamPolicy(parent).Execute();
             if (result.Bindings != null)
             {
@@ -452,12 +452,12 @@ namespace GoogleCloudSamples
         // [END kms_get_cryptokey_policy]
 
         // [START kms_add_member_to_cryptokey_policy]
-        public static object AddMemberToCryptoKeyPolicy(string projectId, string location,
-            string keyRing, string cryptoKey, string role, string member)
+        public static object AddMemberToCryptoKeyPolicy(string projectId, string locationId,
+            string keyRingId, string cryptoKeyId, string role, string member)
         {
             var cloudKms = CreateAuthorizedClient();
             // Generate the full path of the parent to use for updating the crypto key IAM policy.
-            var parent = $"projects/{projectId}/locations/{location}/keyRings/{keyRing}/cryptoKeys/{cryptoKey}";
+            var parent = $"projects/{projectId}/locations/{locationId}/keyRings/{keyRingId}/cryptoKeys/{cryptoKeyId}";
             SetIamPolicyRequest setIamPolicyRequest = new SetIamPolicyRequest();
             var result = cloudKms.Projects.Locations.KeyRings.CryptoKeys.GetIamPolicy(parent).Execute();
             if (result.Bindings != null)
@@ -499,12 +499,12 @@ namespace GoogleCloudSamples
         // [END kms_add_member_to_cryptokey_policy]
 
         // [START kms_remove_member_from_cryptokey_policy]
-        public static object RemoveMemberFromCryptoKeyPolicy(string projectId, string location,
-            string keyRing, string cryptoKey, string role, string member)
+        public static object RemoveMemberFromCryptoKeyPolicy(string projectId, string locationId,
+            string keyRingId, string cryptoKeyId, string role, string member)
         {
             var cloudKms = CreateAuthorizedClient();
             // Generate the full path of the parent to use for updating the crypto key IAM policy.
-            var parent = $"projects/{projectId}/locations/{location}/keyRings/{keyRing}/cryptoKeys/{cryptoKey}";
+            var parent = $"projects/{projectId}/locations/{locationId}/keyRings/{keyRingId}/cryptoKeys/{cryptoKeyId}";
             var result = cloudKms.Projects.Locations.KeyRings.CryptoKeys.GetIamPolicy(parent).Execute();
             if (result.Bindings != null)
             {
@@ -550,11 +550,11 @@ namespace GoogleCloudSamples
         // [END kms_remove_member_from_cryptokey_policy]
 
         // [START kms_get_keyring_policy]
-        public static object GetKeyRingIamPolicy(string projectId, string location, string keyRing)
+        public static object GetKeyRingIamPolicy(string projectId, string locationId, string keyRingId)
         {
             var cloudKms = CreateAuthorizedClient();
             // Generate the full path of the parent to use for getting the key ring IAM policy.
-            var parent = $"projects/{projectId}/locations/{location}/keyRings/{keyRing}";
+            var parent = $"projects/{projectId}/locations/{locationId}/keyRings/{keyRingId}";
             var result = cloudKms.Projects.Locations.KeyRings.GetIamPolicy(parent).Execute();
             if (result.Bindings != null)
             {
@@ -578,12 +578,12 @@ namespace GoogleCloudSamples
         // [END kms_get_keyring_policy]
 
         // [START kms_add_member_to_keyring_policy]
-        public static object AddMemberToKeyRingPolicy(string projectId, string location,
-            string keyRing, string role, string member)
+        public static object AddMemberToKeyRingPolicy(string projectId, string locationId,
+            string keyRingId, string role, string member)
         {
             var cloudKms = CreateAuthorizedClient();
             // Generate the full path of the parent to use for updating the key ring IAM policy.
-            var parent = $"projects/{projectId}/locations/{location}/keyRings/{keyRing}";
+            var parent = $"projects/{projectId}/locations/{locationId}/keyRings/{keyRingId}";
             SetIamPolicyRequest setIamPolicyRequest = new SetIamPolicyRequest();
             var result = cloudKms.Projects.Locations.KeyRings.GetIamPolicy(parent).Execute();
             if (result.Bindings != null)
@@ -625,12 +625,12 @@ namespace GoogleCloudSamples
         // [END kms_add_member_to_keyring_policy]
 
         // [START kms_encrypt]
-        public static object Encrypt(string projectId, string location, string keyRing, string cryptoKeyName,
+        public static object Encrypt(string projectId, string locationId, string keyRingId, string cryptoKeyId,
 string fileToEncrypt, string fileToOutput)
         {
             var cloudKms = CreateAuthorizedClient();
             // Generate the full path of the crypto key to use for encryption.
-            var cryptoKey = $"projects/{projectId}/locations/{location}/keyRings/{keyRing}/cryptoKeys/{cryptoKeyName}";
+            var cryptoKey = $"projects/{projectId}/locations/{locationId}/keyRings/{keyRingId}/cryptoKeys/{cryptoKeyId}";
             EncryptRequest dataToEncrypt = new EncryptRequest();
             byte[] bytes = File.ReadAllBytes(fileToEncrypt);
             string contents = Convert.ToBase64String(bytes);
@@ -645,12 +645,12 @@ string fileToEncrypt, string fileToOutput)
         // [END kms_encrypt]
 
         // [START kms_decrypt]
-        public static object Decrypt(string projectId, string location, string keyRing, string cryptoKeyName,
+        public static object Decrypt(string projectId, string locationId, string keyRingId, string cryptoKeyId,
     string fileToDecrypt, string fileToOutput)
         {
             var cloudKms = CreateAuthorizedClient();
             // Generate the full path of the crypto key to use for encryption.
-            var cryptoKey = $"projects/{projectId}/locations/{location}/keyRings/{keyRing}/cryptoKeys/{cryptoKeyName}";
+            var cryptoKey = $"projects/{projectId}/locations/{locationId}/keyRings/{keyRingId}/cryptoKeys/{cryptoKeyId}";
             DecryptRequest dataToDecrypt = new DecryptRequest();
             byte[] bytes = File.ReadAllBytes(fileToDecrypt);
             string contents = Convert.ToBase64String(bytes);
@@ -674,24 +674,24 @@ string fileToEncrypt, string fileToOutput)
                  AddMemberToCryptoKeyPolicyOptions, AddMemberToKeyRingPolicyOptions, RemoveMemberFromCryptoKeyPolicyOptions
                 >(args)
               .MapResult(
-                (CreateKeyRingOptions opts) => CreateKeyRing(opts.projectId, opts.location, opts.keyRing),
-                (GetKeyRingOptions opts) => GetKeyRing(opts.projectId, opts.location, opts.keyRing),
-                (CreateCryptoKeyOptions opts) => CreateCryptoKey(opts.projectId, opts.location, opts.keyRing, opts.cryptoKey),
-                (GetCryptoKeyOptions opts) => GetCryptoKey(opts.projectId, opts.location, opts.keyRing, opts.cryptoKey),
-                (ListKeyRingsOptions opts) => ListKeyRings(opts.projectId, opts.location),
-                (ListCryptoKeysOptions opts) => ListCryptoKeys(opts.projectId, opts.location, opts.keyRing),
-                (EncryptOptions opts) => Encrypt(opts.projectId, opts.location,
-                opts.keyRing, opts.keyName, opts.inFile, opts.outFile),
-                (DecryptOptions opts) => Decrypt(opts.projectId, opts.location,
-                opts.keyRing, opts.keyName, opts.inFile, opts.outFile),
-                (DisableCryptoKeyVersionOptions opts) => DisableCryptoKeyVersion(opts.projectId, opts.location, opts.keyRing, opts.cryptoKey, opts.version),
-                (EnableCryptoKeyVersionOptions opts) => EnableCryptoKeyVersion(opts.projectId, opts.location, opts.keyRing, opts.cryptoKey, opts.version),
-                (DestroyCryptoKeyVersionOptions opts) => DestroyCryptoKeyVersion(opts.projectId, opts.location, opts.keyRing, opts.cryptoKey, opts.version),
-                (RestoreCryptoKeyVersionOptions opts) => RestoreCryptoKeyVersion(opts.projectId, opts.location, opts.keyRing, opts.cryptoKey, opts.version),
-                (AddMemberToCryptoKeyPolicyOptions opts) => AddMemberToCryptoKeyPolicy(opts.projectId, opts.location, opts.keyRing, opts.cryptoKey, opts.role, opts.member),
-                (GetCryptoKeyIamPolicyOptions opts) => GetCryptoKeyIamPolicy(opts.projectId, opts.location, opts.keyRing, opts.cryptoKey),
-                (AddMemberToKeyRingPolicyOptions opts) => AddMemberToKeyRingPolicy(opts.projectId, opts.location, opts.keyRing, opts.role, opts.member),
-                (RemoveMemberFromCryptoKeyPolicyOptions opts) => RemoveMemberFromCryptoKeyPolicy(opts.projectId, opts.location, opts.keyRing, opts.cryptoKey, opts.role, opts.member),
+                (CreateKeyRingOptions opts) => CreateKeyRing(opts.projectId, opts.locationId, opts.keyRingId),
+                (GetKeyRingOptions opts) => GetKeyRing(opts.projectId, opts.locationId, opts.keyRingId),
+                (CreateCryptoKeyOptions opts) => CreateCryptoKey(opts.projectId, opts.locationId, opts.keyRingId, opts.cryptoKeyId),
+                (GetCryptoKeyOptions opts) => GetCryptoKey(opts.projectId, opts.locationId, opts.keyRingId, opts.cryptoKeyId),
+                (ListKeyRingsOptions opts) => ListKeyRings(opts.projectId, opts.locationId),
+                (ListCryptoKeysOptions opts) => ListCryptoKeys(opts.projectId, opts.locationId, opts.keyRingId),
+                (EncryptOptions opts) => Encrypt(opts.projectId, opts.locationId,
+                opts.keyRingId, opts.cryptoKeyId, opts.inFile, opts.outFile),
+                (DecryptOptions opts) => Decrypt(opts.projectId, opts.locationId,
+                opts.keyRingId, opts.cryptoKeyId, opts.inFile, opts.outFile),
+                (DisableCryptoKeyVersionOptions opts) => DisableCryptoKeyVersion(opts.projectId, opts.locationId, opts.keyRingId, opts.cryptoKeyId, opts.versionId),
+                (EnableCryptoKeyVersionOptions opts) => EnableCryptoKeyVersion(opts.projectId, opts.locationId, opts.keyRingId, opts.cryptoKeyId, opts.versionId),
+                (DestroyCryptoKeyVersionOptions opts) => DestroyCryptoKeyVersion(opts.projectId, opts.locationId, opts.keyRingId, opts.cryptoKeyId, opts.versionId),
+                (RestoreCryptoKeyVersionOptions opts) => RestoreCryptoKeyVersion(opts.projectId, opts.locationId, opts.keyRingId, opts.cryptoKeyId, opts.versionId),
+                (AddMemberToCryptoKeyPolicyOptions opts) => AddMemberToCryptoKeyPolicy(opts.projectId, opts.locationId, opts.keyRingId, opts.cryptoKeyId, opts.role, opts.member),
+                (GetCryptoKeyIamPolicyOptions opts) => GetCryptoKeyIamPolicy(opts.projectId, opts.locationId, opts.keyRingId, opts.cryptoKeyId),
+                (AddMemberToKeyRingPolicyOptions opts) => AddMemberToKeyRingPolicy(opts.projectId, opts.locationId, opts.keyRingId, opts.role, opts.member),
+                (RemoveMemberFromCryptoKeyPolicyOptions opts) => RemoveMemberFromCryptoKeyPolicy(opts.projectId, opts.locationId, opts.keyRingId, opts.cryptoKeyId, opts.role, opts.member),
                 errs => 1);
         }
     }


### PR DESCRIPTION
In particular, this change:

- changes to use a consistent "Id" suffix for resource name components
- uses "plaintext" and "ciphertext" consistently to refer to unecrypted and encrypted data, respectively
- fixes some of the text that misspells "decrypt" and "encrypt"

Tracking bug: http://b/64758639