### PR TITLE
Update to BigQuery library 1.0.0-beta18

### DIFF
--- a/bigquery/api/GettingStarted/App.config
+++ b/bigquery/api/GettingStarted/App.config
@@ -11,7 +11,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Google.Apis.Core" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.27.1.0" newVersion="1.27.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.29.1.0" newVersion="1.29.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Google.Apis.PlatformServices" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
@@ -19,7 +19,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Google.Apis" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.27.1.0" newVersion="1.27.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.29.1.0" newVersion="1.29.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
@@ -47,7 +47,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Google.Apis.Auth" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.27.1.0" newVersion="1.27.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.29.1.0" newVersion="1.29.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Google.Api.Gax" publicKeyToken="3ec5ea7f18953e47" culture="neutral" />

--- a/bigquery/api/GettingStarted/BigquerySample.csproj
+++ b/bigquery/api/GettingStarted/BigquerySample.csproj
@@ -39,35 +39,35 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Api.Gax, Version=2.1.0.0, Culture=neutral, PublicKeyToken=3ec5ea7f18953e47, processorArchitecture=MSIL">
-      <HintPath>packages\Google.Api.Gax.2.1.0-beta01\lib\net45\Google.Api.Gax.dll</HintPath>
+      <HintPath>packages\Google.Api.Gax.2.1.0\lib\net45\Google.Api.Gax.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Api.Gax.Rest, Version=2.1.0.0, Culture=neutral, PublicKeyToken=3ec5ea7f18953e47, processorArchitecture=MSIL">
-      <HintPath>packages\Google.Api.Gax.Rest.2.1.0-beta01\lib\net45\Google.Api.Gax.Rest.dll</HintPath>
+      <HintPath>packages\Google.Api.Gax.Rest.2.1.0\lib\net45\Google.Api.Gax.Rest.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis, Version=1.27.1.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>packages\Google.Apis.1.27.1\lib\net45\Google.Apis.dll</HintPath>
+    <Reference Include="Google.Apis, Version=1.29.1.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>packages\Google.Apis.1.29.1\lib\net45\Google.Apis.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.Auth, Version=1.27.1.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>packages\Google.Apis.Auth.1.27.1\lib\net45\Google.Apis.Auth.dll</HintPath>
+    <Reference Include="Google.Apis.Auth, Version=1.29.1.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>packages\Google.Apis.Auth.1.29.1\lib\net45\Google.Apis.Auth.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.Auth.PlatformServices, Version=1.27.1.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>packages\Google.Apis.Auth.1.27.1\lib\net45\Google.Apis.Auth.PlatformServices.dll</HintPath>
+    <Reference Include="Google.Apis.Auth.PlatformServices, Version=1.29.1.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>packages\Google.Apis.Auth.1.29.1\lib\net45\Google.Apis.Auth.PlatformServices.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.Bigquery.v2, Version=1.27.1.885, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>packages\Google.Apis.Bigquery.v2.1.27.1.885\lib\net45\Google.Apis.Bigquery.v2.dll</HintPath>
+    <Reference Include="Google.Apis.Bigquery.v2, Version=1.29.1.990, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>packages\Google.Apis.Bigquery.v2.1.29.1.990\lib\net45\Google.Apis.Bigquery.v2.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.Core, Version=1.27.1.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>packages\Google.Apis.Core.1.27.1\lib\net45\Google.Apis.Core.dll</HintPath>
+    <Reference Include="Google.Apis.Core, Version=1.29.1.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>packages\Google.Apis.Core.1.29.1\lib\net45\Google.Apis.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.PlatformServices, Version=1.27.1.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>packages\Google.Apis.1.27.1\lib\net45\Google.Apis.PlatformServices.dll</HintPath>
+    <Reference Include="Google.Apis.PlatformServices, Version=1.29.1.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>packages\Google.Apis.1.29.1\lib\net45\Google.Apis.PlatformServices.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Apis.Storage.v1, Version=1.27.1.881, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
@@ -75,7 +75,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Cloud.BigQuery.V2, Version=1.0.0.0, Culture=neutral, PublicKeyToken=185c282632e132a0, processorArchitecture=MSIL">
-      <HintPath>packages\Google.Cloud.BigQuery.V2.1.0.0-beta15\lib\net45\Google.Cloud.BigQuery.V2.dll</HintPath>
+      <HintPath>packages\Google.Cloud.BigQuery.V2.1.0.0-beta18\lib\net45\Google.Cloud.BigQuery.V2.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Cloud.Storage.V1, Version=2.1.0.0, Culture=neutral, PublicKeyToken=185c282632e132a0, processorArchitecture=MSIL">

--- a/bigquery/api/GettingStarted/BigqueryTest/BigqueryTest.cs
+++ b/bigquery/api/GettingStarted/BigqueryTest/BigqueryTest.cs
@@ -130,7 +130,8 @@ namespace GoogleCloudSamples
         {
             var table = client.GetTable(projectId, datasetId, tableId);
             BigQueryJob job = client.CreateQueryJob(query,
-                new QueryOptions { UseQueryCache = false });
+                parameters: null,
+                options: new QueryOptions { UseQueryCache = false });
             // Get the query result, waiting for the timespan specified in milliseconds.
             BigQueryResults result = client.GetQueryResults(job.Reference.JobId,
                 new GetQueryResultsOptions { Timeout = TimeSpan.FromMilliseconds(timeoutMs) });
@@ -144,7 +145,8 @@ namespace GoogleCloudSamples
         {
             var table = client.GetTable(projectId, datasetId, tableId);
             BigQueryJob job = client.CreateQueryJob(query,
-                new QueryOptions { UseLegacySql = true });
+                parameters: null,
+                options: new QueryOptions { UseLegacySql = true });
             // Get the query result, waiting for the timespan specified in milliseconds.
             BigQueryResults result = client.GetQueryResults(job.Reference.JobId,
                 new GetQueryResultsOptions { Timeout = TimeSpan.FromMilliseconds(timeoutMs) });
@@ -158,7 +160,8 @@ namespace GoogleCloudSamples
         {
             var table = client.GetTable(projectId, datasetId, tableId);
             BigQueryJob job = client.CreateQueryJob(query,
-                new QueryOptions { UseQueryCache = false });
+                parameters: null,
+                options: new QueryOptions { UseQueryCache = false });
 
             // Wait for the job to complete.
             job.PollUntilCompleted();
@@ -263,7 +266,8 @@ namespace GoogleCloudSamples
         {
             var destination = client.GetTableReference(datasetId, newTableId);
             BigQueryJob job = client.CreateQueryJob(query,
-                new QueryOptions { DestinationTable = destination });
+                parameters: null,
+                options: new QueryOptions { DestinationTable = destination });
             // Wait for the job to complete.
             job.GetQueryResults();
         }
@@ -276,7 +280,8 @@ namespace GoogleCloudSamples
             string query = $"SELECT * FROM {table}";
             var destination = client.GetTableReference(datasetId, newTableId);
             BigQueryJob job = client.CreateQueryJob(query,
-                new QueryOptions { DestinationTable = destination });
+                parameters: null,
+                options: new QueryOptions { DestinationTable = destination });
             // Wait for the job to complete.
             job.GetQueryResults();
         }

--- a/bigquery/api/GettingStarted/BigqueryTest/BigqueryTest.csproj
+++ b/bigquery/api/GettingStarted/BigqueryTest/BigqueryTest.csproj
@@ -37,35 +37,35 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Api.Gax, Version=2.1.0.0, Culture=neutral, PublicKeyToken=3ec5ea7f18953e47, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Api.Gax.2.1.0-beta01\lib\net45\Google.Api.Gax.dll</HintPath>
+      <HintPath>..\packages\Google.Api.Gax.2.1.0\lib\net45\Google.Api.Gax.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Api.Gax.Rest, Version=2.1.0.0, Culture=neutral, PublicKeyToken=3ec5ea7f18953e47, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Api.Gax.Rest.2.1.0-beta01\lib\net45\Google.Api.Gax.Rest.dll</HintPath>
+      <HintPath>..\packages\Google.Api.Gax.Rest.2.1.0\lib\net45\Google.Api.Gax.Rest.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis, Version=1.27.1.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.1.27.1\lib\net45\Google.Apis.dll</HintPath>
+    <Reference Include="Google.Apis, Version=1.29.1.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.1.29.1\lib\net45\Google.Apis.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.Auth, Version=1.27.1.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.Auth.1.27.1\lib\net45\Google.Apis.Auth.dll</HintPath>
+    <Reference Include="Google.Apis.Auth, Version=1.29.1.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.Auth.1.29.1\lib\net45\Google.Apis.Auth.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.Auth.PlatformServices, Version=1.27.1.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.Auth.1.27.1\lib\net45\Google.Apis.Auth.PlatformServices.dll</HintPath>
+    <Reference Include="Google.Apis.Auth.PlatformServices, Version=1.29.1.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.Auth.1.29.1\lib\net45\Google.Apis.Auth.PlatformServices.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.Bigquery.v2, Version=1.27.1.885, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.Bigquery.v2.1.27.1.885\lib\net45\Google.Apis.Bigquery.v2.dll</HintPath>
+    <Reference Include="Google.Apis.Bigquery.v2, Version=1.29.1.990, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.Bigquery.v2.1.29.1.990\lib\net45\Google.Apis.Bigquery.v2.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.Core, Version=1.27.1.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.Core.1.27.1\lib\net45\Google.Apis.Core.dll</HintPath>
+    <Reference Include="Google.Apis.Core, Version=1.29.1.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.Core.1.29.1\lib\net45\Google.Apis.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.PlatformServices, Version=1.27.1.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.1.27.1\lib\net45\Google.Apis.PlatformServices.dll</HintPath>
+    <Reference Include="Google.Apis.PlatformServices, Version=1.29.1.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.1.29.1\lib\net45\Google.Apis.PlatformServices.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Apis.Storage.v1, Version=1.27.1.881, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
@@ -73,7 +73,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Cloud.BigQuery.V2, Version=1.0.0.0, Culture=neutral, PublicKeyToken=185c282632e132a0, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Cloud.BigQuery.V2.1.0.0-beta15\lib\net45\Google.Cloud.BigQuery.V2.dll</HintPath>
+      <HintPath>..\packages\Google.Cloud.BigQuery.V2.1.0.0-beta18\lib\net45\Google.Cloud.BigQuery.V2.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Cloud.Storage.V1, Version=2.1.0.0, Culture=neutral, PublicKeyToken=185c282632e132a0, processorArchitecture=MSIL">

--- a/bigquery/api/GettingStarted/BigqueryTest/app.config
+++ b/bigquery/api/GettingStarted/BigqueryTest/app.config
@@ -16,7 +16,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Google.Apis" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.27.1.0" newVersion="1.27.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.29.1.0" newVersion="1.29.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Google.Apis.Bigquery.v2" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
@@ -28,7 +28,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Google.Apis.Core" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.27.1.0" newVersion="1.27.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.29.1.0" newVersion="1.29.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Google.Apis.Storage.v1" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
@@ -36,7 +36,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Google.Apis.Auth" publicKeyToken="4b01fa6e34db77ab" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.27.1.0" newVersion="1.27.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.29.1.0" newVersion="1.29.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Google.Api.Gax" publicKeyToken="3ec5ea7f18953e47" culture="neutral" />

--- a/bigquery/api/GettingStarted/BigqueryTest/packages.config
+++ b/bigquery/api/GettingStarted/BigqueryTest/packages.config
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="BouncyCastle" version="1.7.0" targetFramework="net452" />
-  <package id="Google.Api.Gax" version="2.1.0-beta01" targetFramework="net452" />
-  <package id="Google.Api.Gax.Rest" version="2.1.0-beta01" targetFramework="net452" />
-  <package id="Google.Apis" version="1.27.1" targetFramework="net452" />
-  <package id="Google.Apis.Auth" version="1.27.1" targetFramework="net452" />
-  <package id="Google.Apis.Bigquery.v2" version="1.27.1.885" targetFramework="net452" />
-  <package id="Google.Apis.Core" version="1.27.1" targetFramework="net452" />
+  <package id="Google.Api.Gax" version="2.1.0" targetFramework="net452" />
+  <package id="Google.Api.Gax.Rest" version="2.1.0" targetFramework="net452" />
+  <package id="Google.Apis" version="1.29.1" targetFramework="net452" />
+  <package id="Google.Apis.Auth" version="1.29.1" targetFramework="net452" />
+  <package id="Google.Apis.Bigquery.v2" version="1.29.1.990" targetFramework="net452" />
+  <package id="Google.Apis.Core" version="1.29.1" targetFramework="net452" />
   <package id="Google.Apis.Storage.v1" version="1.27.1.881" targetFramework="net452" />
-  <package id="Google.Cloud.BigQuery.V2" version="1.0.0-beta15" targetFramework="net452" />
+  <package id="Google.Cloud.BigQuery.V2" version="1.0.0-beta18" targetFramework="net452" />
   <package id="Google.Cloud.Storage.V1" version="2.1.0-alpha01" targetFramework="net452" />
   <package id="log4net" version="2.0.5" targetFramework="net452" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net452" />

--- a/bigquery/api/GettingStarted/Program.cs
+++ b/bigquery/api/GettingStarted/Program.cs
@@ -49,7 +49,7 @@ BigquerySample <project_id>";
 
                 string query = $@"SELECT corpus AS title, COUNT(*) AS unique_words FROM `{table.FullyQualifiedId}` 
                     GROUP BY title ORDER BY unique_words DESC LIMIT 42";
-                var result = client.ExecuteQuery(query);
+                var result = client.ExecuteQuery(query, parameters: null);
                 // [END query]
                 // [START print_results]
                 Console.Write("\nQuery Results:\n------------\n");

--- a/bigquery/api/GettingStarted/packages.config
+++ b/bigquery/api/GettingStarted/packages.config
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="BouncyCastle" version="1.7.0" targetFramework="net45" />
-  <package id="Google.Api.Gax" version="2.1.0-beta01" targetFramework="net45" />
-  <package id="Google.Api.Gax.Rest" version="2.1.0-beta01" targetFramework="net45" />
-  <package id="Google.Apis" version="1.27.1" targetFramework="net45" />
-  <package id="Google.Apis.Auth" version="1.27.1" targetFramework="net45" />
-  <package id="Google.Apis.Bigquery.v2" version="1.27.1.885" targetFramework="net45" />
-  <package id="Google.Apis.Core" version="1.27.1" targetFramework="net45" />
+  <package id="Google.Api.Gax" version="2.1.0" targetFramework="net45" />
+  <package id="Google.Api.Gax.Rest" version="2.1.0" targetFramework="net45" />
+  <package id="Google.Apis" version="1.29.1" targetFramework="net45" />
+  <package id="Google.Apis.Auth" version="1.29.1" targetFramework="net45" />
+  <package id="Google.Apis.Bigquery.v2" version="1.29.1.990" targetFramework="net45" />
+  <package id="Google.Apis.Core" version="1.29.1" targetFramework="net45" />
   <package id="Google.Apis.Storage.v1" version="1.27.1.881" targetFramework="net45" />
-  <package id="Google.Cloud.BigQuery.V2" version="1.0.0-beta15" targetFramework="net45" />
+  <package id="Google.Cloud.BigQuery.V2" version="1.0.0-beta18" targetFramework="net45" />
   <package id="Google.Cloud.Storage.V1" version="2.1.0-alpha01" targetFramework="net45" />
   <package id="log4net" version="2.0.5" targetFramework="net45" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />


### PR DESCRIPTION
Some old overloads are now obsolete; the changes here use the new
overload.