### PR TITLE
Factor VerbMap class out of Spanner sample.

### DIFF
--- a/commandlineutil/Lib/CommandLineUtil.csproj
+++ b/commandlineutil/Lib/CommandLineUtil.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.1.1-beta" />
+  </ItemGroup>
+</Project>

--- a/commandlineutil/Lib/VerbMap.cs
+++ b/commandlineutil/Lib/VerbMap.cs
@@ -1,0 +1,88 @@
+﻿/*
+ * Copyright (c) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+using CommandLine;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace GoogleCloudSamples
+{
+    /// <summary>
+    /// A fluent interface to CommandLineParser library that can handle more
+    /// 16 verbs.
+    /// 
+    /// <param name="ResultType">The return type of your verb delegates.
+    /// Usually an int.
+    /// </param>
+    /// </summary>
+    public class VerbMap<ResultType>
+    {
+        protected readonly Dictionary<Type, Func<object, ResultType>> _verbs =
+                new Dictionary<Type, Func<object, ResultType>>();
+
+        /// <summary>
+        /// When an Action (with no return value) is invoked by Run(), this
+        /// value will be returned.
+        /// </summary>
+        public ResultType DefaultResult { get; set; }
+
+        /// <summary>
+        /// Invoked when the command line arguments failed to parse.
+        /// </summary>        
+        public Func<NotParsed<object>, ResultType> NotParsedFunc { get; set;}
+
+        /// <summary>
+        /// Map an OptionsType to its handler function.
+        /// </summary>
+        public VerbMap<ResultType> Add<OptionsType>(Func<OptionsType, ResultType> f)
+        {
+            _verbs.Add(typeof(OptionsType), (object a) => f((OptionsType)a));
+            return this;
+        }
+
+        /// <summary>
+        /// Map an OptionsType to its handler action.
+        /// </summary>
+        public VerbMap<ResultType> Add<ArgType>(Action<ArgType> f)
+        {
+            _verbs.Add(typeof(ArgType), (object a) => {
+                f((ArgType)a);
+                return DefaultResult;
+            });
+            return this;
+        }
+
+        /// <summary>
+        /// Invoke a verb based on the arguments.
+        /// </summary>
+        public ResultType Run(string[] args, Parser parser = null)
+        {
+            parser = parser ?? Parser.Default;
+            ParserResult<object> result = 
+                parser.ParseArguments(args, _verbs.Keys.ToArray());
+            var parsed = result as Parsed<object>;
+            if (parsed != null)
+            {
+                return _verbs[parsed.Value.GetType()](parsed.Value);
+            }
+            if (NotParsedFunc == null)
+            {
+                return DefaultResult;
+            }
+            return NotParsedFunc((NotParsed<object>)result);
+        }
+    }
+}

--- a/commandlineutil/Lib/VerbMap.cs
+++ b/commandlineutil/Lib/VerbMap.cs
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 using CommandLine;
 using System;
 using System.Collections.Generic;
@@ -42,7 +43,7 @@ namespace GoogleCloudSamples
         /// <summary>
         /// Invoked when the command line arguments failed to parse.
         /// </summary>        
-        public Func<NotParsed<object>, ResultType> NotParsedFunc { get; set;}
+        public Func<NotParsed<object>, ResultType> NotParsedFunc { get; set; }
 
         /// <summary>
         /// Map an OptionsType to its handler function.
@@ -58,7 +59,8 @@ namespace GoogleCloudSamples
         /// </summary>
         public VerbMap<ResultType> Add<ArgType>(Action<ArgType> f)
         {
-            _verbs.Add(typeof(ArgType), (object a) => {
+            _verbs.Add(typeof(ArgType), (object a) =>
+            {
                 f((ArgType)a);
                 return DefaultResult;
             });
@@ -71,7 +73,7 @@ namespace GoogleCloudSamples
         public ResultType Run(string[] args, Parser parser = null)
         {
             parser = parser ?? Parser.Default;
-            ParserResult<object> result = 
+            ParserResult<object> result =
                 parser.ParseArguments(args, _verbs.Keys.ToArray());
             var parsed = result as Parsed<object>;
             if (parsed != null)

--- a/commandlineutil/Sample/CommandLineUtilSample.csproj
+++ b/commandlineutil/Sample/CommandLineUtilSample.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Lib\CommandLineUtil.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/commandlineutil/Sample/Program.cs
+++ b/commandlineutil/Sample/Program.cs
@@ -13,30 +13,31 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
- using CommandLine;
+
+using CommandLine;
 using System;
 
 namespace GoogleCloudSamples
 {
     class CommandLineUtilSample
     {
-        [Verb("v1")] class Verb1 {};
-        [Verb("v2")] class Verb2 {};
-        [Verb("v3")] class Verb3 {};
-        [Verb("v4")] class Verb4 {};
-        [Verb("v5")] class Verb5 {};
-        [Verb("v6")] class Verb6 {};
-        [Verb("v7")] class Verb7 {};
-        [Verb("v8")] class Verb8 {};
-        [Verb("v9")] class Verb9 {};
-        [Verb("v10")] class Verb10 {};
-        [Verb("v11")] class Verb11 {};
-        [Verb("v12")] class Verb12 {};
-        [Verb("v13")] class Verb13 {};
-        [Verb("v14")] class Verb14 {};
-        [Verb("v15")] class Verb15 {};
-        [Verb("v16")] class Verb16 {};
-        [Verb("v17")] class Verb17 {};
+        [Verb("v1")] class Verb1 { };
+        [Verb("v2")] class Verb2 { };
+        [Verb("v3")] class Verb3 { };
+        [Verb("v4")] class Verb4 { };
+        [Verb("v5")] class Verb5 { };
+        [Verb("v6")] class Verb6 { };
+        [Verb("v7")] class Verb7 { };
+        [Verb("v8")] class Verb8 { };
+        [Verb("v9")] class Verb9 { };
+        [Verb("v10")] class Verb10 { };
+        [Verb("v11")] class Verb11 { };
+        [Verb("v12")] class Verb12 { };
+        [Verb("v13")] class Verb13 { };
+        [Verb("v14")] class Verb14 { };
+        [Verb("v15")] class Verb15 { };
+        [Verb("v16")] class Verb16 { };
+        [Verb("v17")] class Verb17 { };
 
         static int Main(string[] args)
         {
@@ -46,7 +47,8 @@ namespace GoogleCloudSamples
                 .Add((Verb2 v2) => Console.WriteLine("You invoked Verb2!"))
                 .Add((Verb3 v3) => Console.WriteLine("You invoked Verb3!"))
                 .Add((Verb4 v4) => Console.WriteLine("You invoked Verb4!"))
-                .Add((Verb5 v5) => {
+                .Add((Verb5 v5) =>
+                {
                     Console.WriteLine("You invoked Verb5!  It returns 5.");
                     return 5;
                 })

--- a/commandlineutil/Sample/Program.cs
+++ b/commandlineutil/Sample/Program.cs
@@ -1,0 +1,69 @@
+﻿/*
+ * Copyright (c) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+ using CommandLine;
+using System;
+
+namespace GoogleCloudSamples
+{
+    class CommandLineUtilSample
+    {
+        [Verb("v1")] class Verb1 {};
+        [Verb("v2")] class Verb2 {};
+        [Verb("v3")] class Verb3 {};
+        [Verb("v4")] class Verb4 {};
+        [Verb("v5")] class Verb5 {};
+        [Verb("v6")] class Verb6 {};
+        [Verb("v7")] class Verb7 {};
+        [Verb("v8")] class Verb8 {};
+        [Verb("v9")] class Verb9 {};
+        [Verb("v10")] class Verb10 {};
+        [Verb("v11")] class Verb11 {};
+        [Verb("v12")] class Verb12 {};
+        [Verb("v13")] class Verb13 {};
+        [Verb("v14")] class Verb14 {};
+        [Verb("v15")] class Verb15 {};
+        [Verb("v16")] class Verb16 {};
+        [Verb("v17")] class Verb17 {};
+
+        static int Main(string[] args)
+        {
+            var verbMap = new VerbMap<int>();
+            verbMap
+                .Add((Verb1 v1) => Console.WriteLine("You invoked Verb1!"))
+                .Add((Verb2 v2) => Console.WriteLine("You invoked Verb2!"))
+                .Add((Verb3 v3) => Console.WriteLine("You invoked Verb3!"))
+                .Add((Verb4 v4) => Console.WriteLine("You invoked Verb4!"))
+                .Add((Verb5 v5) => {
+                    Console.WriteLine("You invoked Verb5!  It returns 5.");
+                    return 5;
+                })
+                .Add((Verb6 v6) => Console.WriteLine("You invoked Verb6!"))
+                .Add((Verb7 v7) => Console.WriteLine("You invoked Verb7!"))
+                .Add((Verb8 v8) => Console.WriteLine("You invoked Verb8!"))
+                .Add((Verb9 v9) => Console.WriteLine("You invoked Verb9!"))
+                .Add((Verb10 v10) => Console.WriteLine("You invoked Verb10!"))
+                .Add((Verb11 v11) => Console.WriteLine("You invoked Verb11!"))
+                .Add((Verb12 v12) => Console.WriteLine("You invoked Verb12!"))
+                .Add((Verb13 v13) => Console.WriteLine("You invoked Verb13!"))
+                .Add((Verb14 v14) => Console.WriteLine("You invoked Verb14!"))
+                .Add((Verb15 v15) => Console.WriteLine("You invoked Verb15!"))
+                .Add((Verb16 v16) => Console.WriteLine("You invoked Verb16!"))
+                .Add((Verb17 v17) => Console.WriteLine("You invoked Verb17!"))
+                .NotParsedFunc = (err) => 255;
+            return verbMap.Run(args);
+        }
+    }
+}

--- a/commandlineutil/Sample/runTests.ps1
+++ b/commandlineutil/Sample/runTests.ps1
@@ -1,0 +1,32 @@
+# Copyright(c) 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+##############################
+#.SYNOPSIS
+#Need a function with a return value so I can throw within a boolean expression.
+##############################
+function Throw($message) {
+    throw $message
+}
+
+dotnet restore
+dotnet run -- v1
+$LASTEXITCODE -eq 0 -or (Throw "Expected exit code 0 for v1")
+dotnet run -- v5
+$LASTEXITCODE -eq 5 -or (Throw "Expected exit code 5 for v5")
+dotnet run -- v17
+$LASTEXITCODE -eq 0 -or (Throw "Expected exit code 0 for v17")
+dotnet run -- no-such-verb
+$LASTEXITCODE -eq 255 -or (Throw "Expected exit code 255 for no-such-verb")
+

--- a/commandlineutil/Sample/runTests.ps1
+++ b/commandlineutil/Sample/runTests.ps1
@@ -21,12 +21,12 @@ function Throw($message) {
 }
 
 dotnet restore
-dotnet run -- v1
+dotnet build 
+dotnet run --no-build -- v1
 $LASTEXITCODE -eq 0 -or (Throw "Expected exit code 0 for v1")
-dotnet run -- v5
+dotnet run --no-build -- v5
 $LASTEXITCODE -eq 5 -or (Throw "Expected exit code 5 for v5")
-dotnet run -- v17
-$LASTEXITCODE -eq 0 -or (Throw "Expected exit code 0 for v17")
-dotnet run -- no-such-verb
+dotnet run --no-build -- no-such-verb
 $LASTEXITCODE -eq 255 -or (Throw "Expected exit code 255 for no-such-verb")
-
+dotnet run --no-build -- v17
+$LASTEXITCODE -eq 0 -or (Throw "Expected exit code 0 for v17")

--- a/spanner/api/Spanner.csproj
+++ b/spanner/api/Spanner.csproj
@@ -133,6 +133,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\commandlineutil\Lib\VerbMap.cs">
+      <Link>VerbMap.cs</Link>
+    </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
So we can generally reuse it in other samples.  It has a number of advantages over calling `Parser.ParserArguments().MapResult()`:

1. It can handle more than 16 verbs.
2. You can call void functions in addition to functions that return a value.
3. You don't have to repeat the options type.  With .MapResult(), you have use the options type once in the template parameter list, and again in the lambda.
4. You'll see sane error messages if there's a typo.

Like TestUtil, .NET 4.6 projects must include the source file.  .NET core projects should add a reference to the library.

I'm not suggesting that we retrofit all the existing code to use this class.  But we should consider it when writing new code, and whenever we add new verbs to an old sample and cross the 16-verb boundary.

