### PR TITLE
Keeping costs low

### DIFF
--- a/appengine/flexible/HelloWorld/app.yaml
+++ b/appengine/flexible/HelloWorld/app.yaml
@@ -1,2 +1,13 @@
 runtime: aspnetcore
 env: flex
+
+# This sample incurs costs to run on the App Engine flexible environment. 
+# The settings below are to reduce costs during testing and are not appropriate
+# for production use. For more information, see:
+# https://cloud.google.com/appengine/docs/flexible/python/configuring-your-app-with-app-yaml
+manual_scaling:
+  instances: 1
+resources:
+  cpu: 1
+  memory_gb: 0.5
+  disk_size_gb: 10


### PR DESCRIPTION
We've gotten reports of unexpected costs from users that left the hello world running and had two standard instances running for a month. This keeps the costs to a minimum to kick the tires.