### PR TITLE
Retry one more time because datastore eventual consistency is causing…

### DIFF
--- a/datastore/api/TaskListTest/DatastoreTest.cs
+++ b/datastore/api/TaskListTest/DatastoreTest.cs
@@ -40,7 +40,9 @@ namespace GoogleCloudSamples
         // [END retry]
         private readonly RetryRobot _retryRobot = new RetryRobot()
         {
-            RetryWhenExceptions = new[] { typeof(Xunit.Sdk.XunitException) }
+            RetryWhenExceptions = new[] { typeof(Xunit.Sdk.XunitException) },
+            // Eventually consistency can take a long time.
+            MaxTryCount = 8
         };
 
         public DatastoreTest()


### PR DESCRIPTION
… tests to fail.