### PR TITLE
Fix csproj to not point to .net core 1.x

### DIFF
--- a/endpoints/getting-started/src/IO.Swagger/IO.Swagger.csproj
+++ b/endpoints/getting-started/src/IO.Swagger/IO.Swagger.csproj
@@ -10,8 +10,6 @@
     <AssemblyName>IO.Swagger</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>IO.Swagger</PackageId>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.6;dnxcore50;netstandard1.6;portable-net452+win81</PackageTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
A few minor things that prevented successful build