### PR TITLE
[DO NOT MERGE] Change to endpoints managed rollout

### DIFF
--- a/endpoints/getting-started/src/IO.Swagger/app.yaml
+++ b/endpoints/getting-started/src/IO.Swagger/app.yaml
@@ -10,5 +10,5 @@ endpoints_api_service:
   # 'gcloud endpoints configs list --service=[PROJECT-ID].appspot.com'
   # where [PROJECT-ID].appspot.com is your Endpoints service name.
   name: ENDPOINTS-SERVICE-NAME
-  config_id: ENDPOINTS-CONFIG-ID
+  rollout_strategy: managed
 # [END configuration]


### PR DESCRIPTION
We introduce a new feature where we can specify in YAML that service configuration for Endpoints is going to be managed. This means that the service will pull latest deployed service configuration automatically, rather than requiring customer to specify specific version of service configuration.

New flag:
**--rollout_strategy=managed**
Previously the only way to specify a version was using the following flag:
**--version=SERVICE_CONFIG_ID**