### PR TITLE
TestDeleteLog() was flaky.

### DIFF
--- a/logging/api/LoggingTest/LoggingTest.cs
+++ b/logging/api/LoggingTest/LoggingTest.cs
@@ -44,7 +44,7 @@ namespace GoogleCloudSamples
                 if (rpcException != null)
                 {
                     return new[] { StatusCode.Aborted, StatusCode.Internal,
-                        StatusCode.Cancelled }
+                        StatusCode.Cancelled, StatusCode.NotFound }
                         .Contains(rpcException.Status.StatusCode);
                 }
                 return false;
@@ -153,7 +153,11 @@ namespace GoogleCloudSamples
                 var created = Run("create-log-entry", logId, message);
                 created.AssertSucceeded();
                 // Try deleting log and assert on success.
-                Run("delete-log", logId).AssertSucceeded();
+                Eventually(() =>
+                {
+                    Run("delete-log", logId).AssertSucceeded();
+                    _logsToDelete.Remove(logId);
+                });
             }
 
             [Fact]


### PR DESCRIPTION
Due to eventual consistency.  Fix it with an Eventually().

Change-Id: I6aa0471336089b20a15b6c8ee3785b82960013df