### PR TITLE
Updates for the Developer Portal

### DIFF
--- a/endpoints/getting-started/openapi.yaml
+++ b/endpoints/getting-started/openapi.yaml
@@ -11,7 +11,9 @@ consumes:
 produces:
 - "application/json"
 schemes:
-- "https"
+# Uncomment the next line if you configure SSL for this API.
+#- "https"
+- "http"
 paths:
   "/echo":
     post:
@@ -70,6 +72,7 @@ paths:
 
 definitions:
   echoMessage:
+    type: "object"
     properties:
       message:
         type: "string"
@@ -105,4 +108,4 @@ securityDefinitions:
     flow: "implicit"
     type: "oauth2"
     x-google-issuer: "https://accounts.google.com"
-    x-google-jwks_uri: "https://www.googleapis.com/oauth2/v1/certs"
+    x-google-jwks_uri: "https://www.googleapis.com/oauth2/v1/certs"


### PR DESCRIPTION
Updates so the sample API can be used easily in the Developer Portal. 
-- In schemes, it has to be "http" so that you can test the echo API in the Developer Portal. 
-- In the echoMessage definition, adding type: "object" provides a better user experience in the Developer Portal.