### PR TITLE
Downgrade phantomjs to 1.9.8.

### DIFF
--- a/.kokoro-windows/Activate.ps1
+++ b/.kokoro-windows/Activate.ps1
@@ -15,7 +15,7 @@
 $installDir = Resolve-Path "$PSScriptRoot/install"
 
 $env:PATH = @("$installDir/codeformatter/bin",
-    "$installDir/phantomjs-1.9.8-windows/bin",
+    "$installDir/phantomjs-1.9.8-windows",
     "$installDir/n1k0-casperjs-76fc831/batchbin",
     "$env:SystemDrive/Python27",
     "$env:SystemDrive/Program Files (x86)/MSBuild/14.0/Bin",

--- a/.kokoro-windows/Activate.ps1
+++ b/.kokoro-windows/Activate.ps1
@@ -12,16 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-$installDir = Resolve-Path "$PSScriptRoot\install"
+$installDir = Resolve-Path "$PSScriptRoot/install"
 
-$env:PATH = @("$installDir\codeformatter\bin",
-    "$installDir\phantomjs-2.1.1-windows\bin",
-    "$installDir\n1k0-casperjs-76fc831\batchbin",
-    "$env:SystemDrive\Python27",
-    "$env:SystemDrive\Program Files (x86)\MSBuild\14.0\Bin",
+$env:PATH = @("$installDir/codeformatter/bin",
+    "$installDir/phantomjs-1.9.8-windows/bin",
+    "$installDir/n1k0-casperjs-76fc831/batchbin",
+    "$env:SystemDrive/Python27",
+    "$env:SystemDrive/Program Files (x86)/MSBuild/14.0/Bin",
     $env:PATH) -join ';'
 
-$env:CASPERJS11_BIN = "$installDir\casperjs-1.1.4-1\bin"
+$env:CASPERJS11_BIN = "$installDir/casperjs-1.1.4-1/bin"
 
 if (Get-Module BuildTools) {
     Remove-Module BuildTools

--- a/.kokoro-windows/New-BuildEnv.ps1
+++ b/.kokoro-windows/New-BuildEnv.ps1
@@ -14,32 +14,34 @@
 Param ($Dir, [switch]$SkipDownloadKokoroDir)
 
 if (-Not $Dir) {
-    $Dir = "$PSScriptRoot\..\env"
+    $Dir = "$PSScriptRoot/../env"
 }
 
-# Install choco packages.
-get-command choco -ErrorAction Stop
-$chocoPackages = (choco list -li) -join ' '
+if ([environment]::OSVersion.Platform -match 'Win*') {
+    # Install choco packages.
+    get-command choco -ErrorAction Stop
+    $chocoPackages = (choco list -li) -join ' '
 
-if (-not $chocoPackages.Contains('Microsoft .NET Core SDK - 2.0.')) {
-    choco install -y --sxs dotnetcore-sdk --version 2.0.0    
-}
+    if (-not $chocoPackages.Contains('Microsoft .NET Core SDK - 2.0.')) {
+        choco install -y --sxs dotnetcore-sdk --version 2.0.0    
+    }
 
-if (-not $chocoPackages.Contains('.NET Core SDK 1.1.')) {
-    choco install -y --sxs dotnetcore-sdk --version 1.1.2    
-}
+    if (-not $chocoPackages.Contains('.NET Core SDK 1.1.')) {
+        choco install -y --sxs dotnetcore-sdk --version 1.1.2    
+    }
 
-if (-not $chocoPackages.Contains('nuget.commandline 4.5.')) {
-    choco install -y nuget.commandline
-}   
+    if (-not $chocoPackages.Contains('nuget.commandline 4.5.')) {
+        choco install -y nuget.commandline
+    }   
 
-if (-not $chocoPackages.Contains('microsoft-build-tools 14.')) {
-    choco install -y --sxs microsoft-build-tools --version 14.0.23107.10
-}
+    if (-not $chocoPackages.Contains('microsoft-build-tools 14.')) {
+        choco install -y --sxs microsoft-build-tools --version 14.0.23107.10
+    }
 
-if (-not (($chocoPackages.Contains('python 2.7.') -or
-    (Test-Path "$env:SystemDrive\Python27")))) {
-    choco install -y --sxs python --version 2.7.6
+    if (-not (($chocoPackages.Contains('python 2.7.') -or
+        (Test-Path "$env:SystemDrive/Python27")))) {
+        choco install -y --sxs python --version 2.7.6
+    }
 }
 
 # Create environment directory structure.
@@ -50,7 +52,7 @@ if (-not $SkipDownloadKokoroDir) {
     $env:KOKORO_GFILE_DIR = Join-Path $Dir 'kokoro'
     (New-Item -Path $env:KOKORO_GFILE_DIR -ItemType Directory -Force).FullName
     # Copy all the files from our kokoro secrets bucket.
-    gsutil cp gs://cloud-devrel-kokoro-resources/dotnet-docs-samples/* $env:KOKORO_GFILE_DIR
+    gsutil -m cp gs://cloud-devrel-kokoro-resources/dotnet-docs-samples/* $env:KOKORO_GFILE_DIR
 }
 
 # Prepare to unzip the files.
@@ -62,25 +64,25 @@ function Unzip([string]$zipfile, [string]$outpath)
 
 Set-PsDebug -Trace 1
 # Install codeformatter
-Unzip $env:KOKORO_GFILE_DIR\codeformatter.zip $installDir\codeformatter
+Unzip $env:KOKORO_GFILE_DIR/codeformatter.zip $installDir/codeformatter
 # Install phantomjs
-Unzip $env:KOKORO_GFILE_DIR\phantomjs-2.1.1-windows.zip $installDir
+Unzip $env:KOKORO_GFILE_DIR/phantomjs-1.9.8-windows.zip $installDir
 # Install casperjs
-Unzip $env:KOKORO_GFILE_DIR\n1k0-casperjs-1.0.3-0-g76fc831.zip $installDir
+Unzip $env:KOKORO_GFILE_DIR/n1k0-casperjs-1.0.3-0-g76fc831.zip $installDir
 # Patch casperjs
-Copy-Item -Force $PSScriptRoot\..\.kokoro\docker\bootstrap.js `
-    $installDir\n1k0-casperjs-76fc831\bin\bootstrap.js
+Copy-Item -Force $PSScriptRoot/../.kokoro/docker/bootstrap.js `
+    $installDir/n1k0-casperjs-76fc831/bin/bootstrap.js
 # Install casperjs 1.1
-Unzip $env:KOKORO_GFILE_DIR\casperjs-1.1.4-1.zip $installDir
+Unzip $env:KOKORO_GFILE_DIR/casperjs-1.1.4-1.zip $installDir
 Set-PsDebug -Off
 
 # Copy Activate.ps1 to the environment directory.
 # And append 3 more lines.
-$activatePs1 = Get-Content $PSScriptRoot\Activate.ps1
-$importSecretsPath = "$PSScriptRoot\Import-Secrets.ps1"
-$buildToolsPath = Resolve-Path "$PSScriptRoot\..\BuildTools.psm1"
+$activatePs1 = Get-Content $PSScriptRoot/Activate.ps1
+$importSecretsPath = "$PSScriptRoot/Import-Secrets.ps1"
+$buildToolsPath = Resolve-Path "$PSScriptRoot/../BuildTools.psm1"
 @($activatePs1, '', 
     "`$env:KOKORO_GFILE_DIR = '$env:KOKORO_GFILE_DIR'",
     "& '$importSecretsPath'",
     "Import-Module -DisableNameChecking '$buildToolsPath'") `
-    | Out-File -Force $Dir\Activate.ps1
+    | Out-File -Force $Dir/Activate.ps1

--- a/.kokoro/docker/Dockerfile
+++ b/.kokoro/docker/Dockerfile
@@ -1,3 +1,6 @@
+# $ docker build -t gcr.io/cloud-devrel-kokoro-resources/dotnet .
+# $ gcloud docker -- push gcr.io/cloud-devrel-kokoro-resources/dotnet
+
 # start with a powershell image.
 FROM microsoft/powershell
 
@@ -12,10 +15,9 @@ RUN apt-get -y install dotnet-sdk-2.0.0 dotnet-dev-1.1.4
 # install phantomjs
 # steps from https://www.vultr.com/docs/how-to-install-phantomjs-on-ubuntu-16-04
 RUN apt-get install build-essential chrpath libssl-dev libxft-dev libfreetype6-dev libfreetype6 libfontconfig1-dev libfontconfig1 -y
-RUN curl https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O -L
-RUN ls -lash phantomjs-2.1.1-linux-x86_64.tar.bz2
-RUN tar xvjf phantomjs-2.1.1-linux-x86_64.tar.bz2 -C /usr/local/share/
-RUN ln -s /usr/local/share/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin/
+RUN curl https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-linux-x86_64.tar.bz2 -O -L
+RUN tar xvjf phantomjs-1.9.8-linux-x86_64.tar.bz2  -C /usr/local/share/
+RUN ln -s /usr/local/share/phantomjs-1.9.8-linux-x86_64/bin/phantomjs /usr/local/bin/
 
 # install python (required by casperjs)
 RUN apt-get install python -y


### PR DESCRIPTION
The old combination of phantomjs 2.1.1 + casperjs 1.1.4-1 was super
buggy.  The selftest crashed after reporting hundreds of failures.

This combination of phantomjs + casperjs is as good as it gets:

In the docker image:
casperjs selftest:

FAIL 1250 tests executed in 36.168s, 1249 passed, 1 failed, 0 dubious, 5 skipped.

Details for the 1 failed test:

In /casperjs-1.1.4-1/tests/suites/casper/wait.js:2512
  waitForExec() tests