### PR TITLE
BigQuery: Updates to standard region tags and deletes unused samples

### DIFF
--- a/bigquery/api/BigqueryTest/BigqueryTest.cs
+++ b/bigquery/api/BigqueryTest/BigqueryTest.cs
@@ -340,9 +340,9 @@ namespace GoogleCloudSamples
         // [END bigquery_list_datasets]
 
         // [START bigquery_list_tables]
-        public List<BigQueryDataset> ListTables(BigQueryClient client)
+        public List<BigQueryTable> ListTables(BigQueryClient client, string datasetId)
         {
-            var tables = _client.ListTables(datasetId).ToList();
+            var tables = client.ListTables(datasetId).ToList();
             return tables;
         }
         // [END bigquery_list_tables]
@@ -375,7 +375,7 @@ namespace GoogleCloudSamples
             var table = _client.GetTable(projectId, datasetId, tableId);
             string query = $"SELECT TOP(corpus, 42) as title, COUNT(*) as unique_words FROM [{table.FullyQualifiedId}]";
             BigQueryResults results = LegacySqlAsyncQuery(
-                projectId, datasetId, tableId, query, 10000, _client);
+                projectId, datasetId, tableId, query, _client);
             Assert.True(results.Count() > 0);
         }
 
@@ -400,17 +400,6 @@ namespace GoogleCloudSamples
             CreateDataset(datasetId, _client);
             var datasets = ListDatasets(_client);
             Assert.True(datasets.Count() > 0);
-        }
-
-        [Fact]
-        public void TestBrowseRows()
-        {
-            string projectId = "bigquery-public-data";
-            string datasetId = "samples";
-            string tableId = "shakespeare";
-            int numberOfRows = 20;
-            int recordCount = ListRows(projectId, datasetId, tableId, numberOfRows, _client);
-            Assert.True(recordCount == numberOfRows);
         }
 
         [Fact]
@@ -463,8 +452,8 @@ namespace GoogleCloudSamples
             _datasetsToDelete.Add(datasetId);
             CreateDataset(datasetId, _client);
             CreateTable(datasetId, newTableId, _client);
-            var tables = _client.ListTables(datasetId).ToList();
-            Assert.False(tables.Count() == 0);
+            var tables = ListTables(_client, datasetId);
+            Assert.True(tables.Count() > 0);
         }
 
         [Fact]

--- a/bigquery/api/BigqueryTest/BigqueryTest.cs
+++ b/bigquery/api/BigqueryTest/BigqueryTest.cs
@@ -145,7 +145,7 @@ namespace GoogleCloudSamples
         }
         // [END bigquery_delete_table]
 
-        // [START import_file_from_gcs]
+        // [START bigquery_load_table_gcs_csv]
         public void ImportDataFromCloudStorage(string projectId, string datasetId,
             string tableId, BigQueryClient client, string fileName, string folder = null)
         {
@@ -171,7 +171,7 @@ namespace GoogleCloudSamples
                 job.PollUntilCompleted();
             }
         }
-        // [END import_file_from_gcs]
+        // [END bigquery_load_table_gcs_csv]
 
         // [START bigquery_query_legacy]
         public BigQueryResults LegacySqlAsyncQuery(string projectId, string datasetId,
@@ -303,7 +303,7 @@ namespace GoogleCloudSamples
             job.GetQueryResults();
         }
 
-        // [START copy_table]
+        // [START bigquery_copy_table]
         public void CopyTable(
             string datasetId, string tableIdToBeCopied, string newTableId, BigQueryClient client)
         {
@@ -316,7 +316,7 @@ namespace GoogleCloudSamples
             // Wait for the job to complete.
             job.GetQueryResults();
         }
-        // [END copy_table]
+        // [END bigquery_copy_table]
 
         public string GetFileNameFromCloudStorage(string bucket, string fileName)
         {


### PR DESCRIPTION
Updates to standard region tags to enable accurate tracking of BigQuery samples. Also deletes unused samples.

These samples all have commit branches specified for devsite, so this PR will not break any sample rendering. After this PR is merged, I will update the region tags and commit branches on devsite.