### PR TITLE
Throttle dialogflow calls.

### DIFF
--- a/dialogflow/api/Test/ContextManagementTests.cs
+++ b/dialogflow/api/Test/ContextManagementTests.cs
@@ -32,22 +32,32 @@ namespace GoogleCloudSamples
             var contextPath = $"projects/{ProjectId}/agent/sessions/{SessionId}/contexts/{_contextId}";
             Assert.Contains($"Created Context: {contextPath}", Stdout);
 
-            RunWithSessionId("contexts:list");
-            Assert.Contains(_contextId, Stdout);
+            _retryRobot.Eventually(() =>
+            {
+                RunWithSessionId("contexts:list");
+                Assert.Contains(_contextId, Stdout);
+            });
         }
 
         [Fact]
         void TestDelete()
         {
             RunWithSessionId("contexts:create", _contextId);
-            RunWithSessionId("contexts:list");
-            Assert.Contains(_contextId, Stdout);
+
+            _retryRobot.Eventually(() =>
+            {
+                RunWithSessionId("contexts:list");
+                Assert.Contains(_contextId, Stdout);
+            });
 
             RunWithSessionId("contexts:delete", _contextId);
             Assert.Contains($"Deleted Context: {_contextId}", Stdout);
 
-            RunWithSessionId("contexts:list");
-            Assert.DoesNotContain(_contextId, Stdout);
+            _retryRobot.Eventually(() =>
+            {
+                RunWithSessionId("contexts:list");
+                Assert.DoesNotContain(_contextId, Stdout);
+            });
         }
     }
 }

--- a/dialogflow/api/Test/DialogflowTest.cs
+++ b/dialogflow/api/Test/DialogflowTest.cs
@@ -94,6 +94,17 @@ namespace GoogleCloudSamples
         private readonly TimeSpan _timeSpan;
         private readonly BlockingCollection<ThrottleToken> _pool =
             new BlockingCollection<ThrottleToken>();
+        /// <summary>
+        /// Creates a throttle token pool.
+        /// </summary>
+        /// <example>
+        /// Throttle number of tokens that can be acquired to 20 per minute.
+        /// new ThrottleTokenPool(20, TimeSpan.FromMinutes(1))
+        /// </example>
+        /// <param name="tokenCount">Number of tokens.  Controls number
+        /// of simultaneous operations than can be executing.</param>
+        /// <param name="timeSpan">Every given timeSpan, a new set
+        /// of tokens becomes available.</param>
         public ThrottleTokenPool(int tokenCount, TimeSpan timeSpan)
         {
             for (int i = 0; i < tokenCount; ++i)
@@ -104,6 +115,10 @@ namespace GoogleCloudSamples
             _timeSpan = timeSpan;
         }
 
+        /// <summary>
+        /// Acquires a token.  Blocks until a token is available.
+        /// </summary>
+        /// <returns>The token.</returns>
         public IDisposable Acquire() => _pool.Take();
 
         internal void Release(ThrottleToken token)

--- a/dialogflow/api/Test/EntityManagementTests.cs
+++ b/dialogflow/api/Test/EntityManagementTests.cs
@@ -41,23 +41,33 @@ namespace GoogleCloudSamples
             Assert.Contains("Waiting for the entity creation operation to complete.", Stdout);
             Assert.Contains("Entity creation completed.", Stdout);
 
-            Run("entities:list", EntityTypeId);
-            Assert.Contains(_entityValue, Stdout);
+            _retryRobot.Eventually(() =>
+            {
+                Run("entities:list", EntityTypeId);
+                Assert.Contains(_entityValue, Stdout);
+            });
         }
 
         [Fact]
         void TestDelete()
         {
             Run("entities:create", EntityTypeId, _entityValue, SynonymsInput);
-            Run("entities:list", EntityTypeId);
-            Assert.Contains(_entityValue, Stdout);
+
+            _retryRobot.Eventually(() =>
+            {
+                Run("entities:list", EntityTypeId);
+                Assert.Contains(_entityValue, Stdout);
+            });
 
             Run("entities:delete", EntityTypeId, _entityValue);
             Assert.Contains("Waiting for the entity deletion operation to complete.", Stdout);
             Assert.Contains($"Deleted Entity: {_entityValue}", Stdout);
 
-            Run("entities:list", EntityTypeId);
-            Assert.DoesNotContain(_entityValue, Stdout);
+            _retryRobot.Eventually(() =>
+            {
+                Run("entities:list", EntityTypeId);
+                Assert.DoesNotContain(_entityValue, Stdout);
+            });
         }
     }
 }

--- a/dialogflow/api/Test/EntityTypeManagementTests.cs
+++ b/dialogflow/api/Test/EntityTypeManagementTests.cs
@@ -31,8 +31,11 @@ namespace GoogleCloudSamples
             Run("entity-types:create", _displayName, _kindName);
             Assert.Contains("Created EntityType:", Stdout);
 
-            Run("entity-types:list");
-            Assert.Contains(_displayName, Stdout);
+            _retryRobot.Eventually(() =>
+            {
+                Run("entity-types:list");
+                Assert.Contains(_displayName, Stdout);
+            });
         }
 
         [Fact]
@@ -42,14 +45,20 @@ namespace GoogleCloudSamples
             // The EntityType ID is needed to delete, the display name is not sufficient.
             var entityTypeId = CreateEntityType(_displayName);
 
-            Run("entity-types:list");
-            Assert.Contains(_displayName, Stdout);
+            _retryRobot.Eventually(() =>
+            {
+                Run("entity-types:list");
+                Assert.Contains(_displayName, Stdout);
+            });
 
             Run("entity-types:delete", entityTypeId);
             Assert.Contains($"Deleted EntityType: {entityTypeId}", Stdout);
 
-            Run("entity-types:list");
-            Assert.DoesNotContain(_displayName, Stdout);
+            _retryRobot.Eventually(() =>
+            {
+                Run("entity-types:list");
+                Assert.DoesNotContain(_displayName, Stdout);
+            });
         }
     }
 }

--- a/dialogflow/api/Test/IntentManagementTests.cs
+++ b/dialogflow/api/Test/IntentManagementTests.cs
@@ -41,8 +41,11 @@ namespace GoogleCloudSamples
             Run("intents:create", _displayName, _messageText, TrainingPartPhrasesArgument);
             Assert.Matches(CreateOutputPattern, Stdout);
 
-            Run("intents:list");
-            Assert.Contains(_displayName, Stdout);
+            _retryRobot.Eventually(() =>
+            {
+                Run("intents:list");
+                Assert.Contains(_displayName, Stdout);
+            });
         }
 
         [Fact]
@@ -54,14 +57,20 @@ namespace GoogleCloudSamples
             // The Intent ID is needed to delete, the display name is not sufficient.
             var intentId = GetIntentId(createOutput: Stdout);
 
-            Run("intents:list");
-            Assert.Contains(_displayName, Stdout);
+            _retryRobot.Eventually(() =>
+            {
+                Run("intents:list");
+                Assert.Contains(_displayName, Stdout);
+            });
 
             Run("intents:delete", intentId);
             Assert.Contains($"Deleted Intent: {intentId}", Stdout);
 
-            Run("intents:list");
-            Assert.DoesNotContain(_displayName, Stdout);
+            _retryRobot.Eventually(() =>
+           {
+               Run("intents:list");
+               Assert.DoesNotContain(_displayName, Stdout);
+           });
         }
     }
 }

--- a/dialogflow/api/Test/SessionEntityTypeManagementTests.cs
+++ b/dialogflow/api/Test/SessionEntityTypeManagementTests.cs
@@ -40,22 +40,32 @@ namespace GoogleCloudSamples
             Assert.Contains("Created SessionEntityType:", Stdout);
             Assert.Contains(_entityTypeDisplayName, Stdout);
 
-            RunWithSessionId("session-entity-types:list");
-            Assert.Contains(_entityTypeDisplayName, Stdout);
+            _retryRobot.Eventually(() =>
+           {
+               RunWithSessionId("session-entity-types:list");
+               Assert.Contains(_entityTypeDisplayName, Stdout);
+           });
         }
 
         [Fact]
         void TestDelete()
         {
             RunWithSessionId("session-entity-types:create", _entityTypeDisplayName, EntityValuesArgument);
-            RunWithSessionId("session-entity-types:list");
-            Assert.Contains(_entityTypeDisplayName, Stdout);
+
+            _retryRobot.Eventually(() =>
+            {
+                RunWithSessionId("session-entity-types:list");
+                Assert.Contains(_entityTypeDisplayName, Stdout);
+            });
 
             RunWithSessionId("session-entity-types:delete", _entityTypeDisplayName);
             Assert.Contains($"Deleted SessionEntityType: {_entityTypeDisplayName}", Stdout);
 
-            RunWithSessionId("session-entity-types:list");
-            Assert.DoesNotContain(_entityTypeDisplayName, Stdout);
+            _retryRobot.Eventually(() =>
+            {
+                RunWithSessionId("session-entity-types:list");
+                Assert.DoesNotContain(_entityTypeDisplayName, Stdout);
+            });
         }
     }
 }

--- a/dialogflow/api/Test/runTests.ps1
+++ b/dialogflow/api/Test/runTests.ps1
@@ -17,4 +17,4 @@ Set-TestTimeout 900
 
 dotnet restore
 dotnet build
-dotnet test --test-adapter-path:. --logger:junit --no-build
+dotnet test --test-adapter-path:. --logger:junit --no-build --no-restore -v n


### PR DESCRIPTION
Also, RetryRobot makes dialogflow tests cope with eventual consistency in the list() method.