### PR TITLE
Delete unused Datastore region tags / samples.

### DIFF
--- a/datastore/api/TaskList/Program.cs
+++ b/datastore/api/TaskList/Program.cs
@@ -109,7 +109,6 @@ namespace GoogleCloudSamples
         }
         // [END datastore_delete_entity]
 
-        // [START datastore_format_results]
         static IEnumerable<string> FormatTasks(IEnumerable<Entity> tasks)
         {
             var results = new List<string>();
@@ -122,7 +121,6 @@ namespace GoogleCloudSamples
             }
             return results;
         }
-        // [END datastore_format_results]
 
         void HandleCommandLine(string commandLine)
         {

--- a/datastore/api/TaskListTest/DatastoreTest.cs
+++ b/datastore/api/TaskListTest/DatastoreTest.cs
@@ -34,10 +34,8 @@ namespace GoogleCloudSamples
             new DateTime(1998, 4, 18, 0, 0, 0, DateTimeKind.Utc);
         private readonly DateTime _endDate =
             new DateTime(2013, 4, 18, 0, 0, 0, DateTimeKind.Utc);
-        // [START datastore_retry]
         private readonly int _retryCount = 3;
         private readonly int _retryDelayMs = 500;
-        // [END datastore_retry]
         private readonly RetryRobot _retryRobot = new RetryRobot()
         {
             RetryWhenExceptions = new[] { typeof(Xunit.Sdk.XunitException) },
@@ -728,27 +726,6 @@ namespace GoogleCloudSamples
                 // [END datastore_property_filtering_run_query]
                 properties.Sort();
                 Assert.NotEmpty(properties);
-            });
-        }
-
-        [Fact(Skip = "https://github.com/GoogleCloudPlatform/google-cloud-dotnet/issues/346")]
-        public void TestDistinctQuery()
-        {
-            UpsertTaskList();
-            Eventually(() =>
-            {
-                // [START datastore_distinct_query]
-                Query query = new Query("Task")
-                {
-                    Projection = { "category", "priority" },
-                    DistinctOn = { "category", "priority" },
-                    Order = {
-                        {"category", PropertyOrder.Types.Direction.Ascending},
-                        {"priority", PropertyOrder.Types.Direction.Ascending}
-                    }
-                };
-                // [END datastore_distinct_query]
-                Assert.False(IsEmpty(_db.RunQuery(query)));
             });
         }
 


### PR DESCRIPTION
These samples/region tags aren't used on cloud.google.com, so I'm deleting them.

Related:

- GoogleCloudPlatform/python-docs-samples#1531
- googleapis/nodejs-datastore#110
- GoogleCloudPlatform/java-docs-samples#1138
- GoogleCloudPlatform/php-docs-samples#631
- GoogleCloudPlatform/ruby-docs-samples#292
- GoogleCloudPlatform/golang-samples#516