### PR TITLE
Fixing Spanner code to not depend on enterprise library nuget packages

### DIFF
--- a/spanner/api/Spanner/Program.cs
+++ b/spanner/api/Spanner/Program.cs
@@ -15,16 +15,14 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Transactions;
+using System.Linq;
 using Google.Cloud.Spanner.Data;
 using CommandLine;
-using System.Transactions;
-using Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling;
-using System.Collections.Generic;
 using log4net;
-using System.Linq;
-using System.Collections.Specialized;
 
 namespace GoogleCloudSamples.Spanner
 {
@@ -397,6 +395,40 @@ namespace GoogleCloudSamples.Spanner
         public string databaseId { get; set; }
     }
 
+    public class RetryRobot
+    {
+        public TimeSpan FirstRetryDelay { get; set; } = TimeSpan.FromSeconds(1000);
+        public float DelayMultiplier { get; set; } = 2;
+        public int MaxTryCount { get; set; } = 7;
+        public Func<Exception, bool> ShouldRetry { get; set; }
+
+        /// <summary>
+        /// Retry action when assertion fails.
+        /// </summary>
+        /// <param name="func"></param>
+        public T Eventually<T>(Func<T> func)
+        {
+            TimeSpan delay = FirstRetryDelay;
+            for (int i = 0; ; ++i)
+            {
+                try
+                {
+                    return func();
+                }
+                catch (Exception e)
+                when (ShouldCatch(e) && i < MaxTryCount)
+                {
+                    Thread.Sleep(delay);
+                    delay *= (int)DelayMultiplier;
+                }
+            }
+        }
+
+        private bool ShouldCatch(Exception e)
+        {
+            return ShouldRetry != null && ShouldRetry(e);
+        }
+    }
 
     public class Program
     {
@@ -912,15 +944,6 @@ namespace GoogleCloudSamples.Spanner
             }
             // [END spanner_list_database_tables]
         }
-
-        // [START spanner_topaz_strategy]
-        internal class CustomTransientErrorDetectionStrategy
-            : ITransientErrorDetectionStrategy
-        {
-            public bool IsTransient(Exception ex) =>
-                ex.IsTransientSpannerFault();
-        }
-        // [END spanner_topaz_strategy]
 
         // [START spanner_read_write_transaction_core]
         public static async Task ReadWriteWithTransactionCoreAsync(
@@ -1461,15 +1484,14 @@ namespace GoogleCloudSamples.Spanner
             string projectId, string instanceId,
             string databaseId, string platform)
         {
-            var retryPolicy =
-                new RetryPolicy<CustomTransientErrorDetectionStrategy>
-                    (RetryStrategy.DefaultExponential);
-
-            var response = platform == s_netCorePlatform
-                ? retryPolicy.ExecuteAsync(() =>
+            var retryRobot = new RetryRobot { MaxTryCount = 3, DelayMultiplier = 2, ShouldRetry = (e) => e.IsTransientSpannerFault() };
+            
+            var response = platform ==                 
+                s_netCorePlatform
+                ? retryRobot.Eventually(() =>
                     QueryDataWithTransactionCoreAsync(projectId,
                         instanceId, databaseId))
-                : retryPolicy.ExecuteAsync(() =>
+                : retryRobot.Eventually(() =>
                     QueryDataWithTransactionAsync(projectId,
                         instanceId, databaseId));
 
@@ -1487,22 +1509,18 @@ namespace GoogleCloudSamples.Spanner
             var response = platform == s_netCorePlatform
                 ? Task.Run(async () =>
                 {
-                    var retryPolicy = new
-                        RetryPolicy<CustomTransientErrorDetectionStrategy>
-                        (RetryStrategy.DefaultExponential);
+                    var retryRobot = new RetryRobot { MaxTryCount = 3, DelayMultiplier = 2, ShouldRetry = (e) => e.IsTransientSpannerFault() };
 
-                    await retryPolicy.ExecuteAsync(
+                    await retryRobot.Eventually(
                         () => ReadWriteWithTransactionCoreAsync(
                             projectId, instanceId, databaseId));
                 })
                 : Task.Run(async () =>
                 {
                     // [START spanner_read_write_retry]
-                    var retryPolicy = new
-                        RetryPolicy<CustomTransientErrorDetectionStrategy>
-                            (RetryStrategy.DefaultExponential);
+                    var retryRobot = new RetryRobot { MaxTryCount = 3, DelayMultiplier = 2, ShouldRetry = (e) => e.IsTransientSpannerFault() };
 
-                    await retryPolicy.ExecuteAsync(() =>
+                    await retryRobot.Eventually(() =>
                         ReadWriteWithTransactionAsync(
                                 projectId, instanceId, databaseId));
                     // [END spanner_read_write_retry]

--- a/spanner/api/Spanner/Program.cs
+++ b/spanner/api/Spanner/Program.cs
@@ -1485,8 +1485,8 @@ namespace GoogleCloudSamples.Spanner
             string databaseId, string platform)
         {
             var retryRobot = new RetryRobot { MaxTryCount = 3, DelayMultiplier = 2, ShouldRetry = (e) => e.IsTransientSpannerFault() };
-            
-            var response = platform ==                 
+
+            var response = platform ==
                 s_netCorePlatform
                 ? retryRobot.Eventually(() =>
                     QueryDataWithTransactionCoreAsync(projectId,

--- a/spanner/api/Spanner/Spanner.csproj
+++ b/spanner/api/Spanner/Spanner.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.1.1-beta" />
-    <PackageReference Include="EnterpriseLibrary.TransientFaultHandling" Version="6.0.1304" />
     <PackageReference Include="Google.Cloud.Spanner.Data" Version="2.0.0-beta02" />
     <PackageReference Include="Google.Cloud.Spanner.V1" Version="2.0.0-beta02" />
     <PackageReference Include="log4net" Version="2.0.8" />


### PR DESCRIPTION
Enterprise library retry nuget package targets .NET Framework 4.6.1. If we reference it, we won't be able to run the code on Linux. We could (potentially) depend on testUtil project that includes retryRobot implementation, but that means that Spanner project has to pull many unnecessary nuget packages for GCP.

Therefore, I've added a tiny implementation of retryRobot and used it to replace retry code from Enterprise library.