### PR TITLE
Fixing dockerfile for GKE

### DIFF
--- a/applications/googlehome-meets-dotnetcontainers/GoogleHomeAspNetCoreDemoServer/Dockerfile
+++ b/applications/googlehome-meets-dotnetcontainers/GoogleHomeAspNetCoreDemoServer/Dockerfile
@@ -5,6 +5,6 @@ EXPOSE 8080 8443
 ENV ASPNETCORE_URLS=http://*:8080
 COPY ./source-context.json /usr/share/dotnet-debugger/agent/
 # Uncomment the below two lines if running on GKE
-#ENV STACKDRIVER_DEBUGGER=module
-#ENV STACKDRIVER_DEBUGGER=1.0
-ENTRYPOINT ["/usr/share/dotnet-debugger/start-debugger.sh", "dotnet", "/app/GoogleHomeAspNetCoreDemoServer.dll"]
+#ENV STACKDRIVER_DEBUGGER_MODULE=module
+#ENV STACKDRIVER_DEBUGGER_VERSION=1.0
+ENTRYPOINT ["/usr/share/dotnet-debugger/start-debugger.sh", "dotnet", "GoogleHomeAspNetCoreDemoServer.dll"]


### PR DESCRIPTION
Fixed environment variables that are required to run stackdriver debugger on GKE.
Also fixed the path to .net executable - we are already in "App" working directory.