### PR TITLE
Extend the timeout to call CreateUptimeCheckConfig.

### DIFF
--- a/monitoring/api/UptimeCheckSample/Program.cs
+++ b/monitoring/api/UptimeCheckSample/Program.cs
@@ -27,6 +27,7 @@ using Newtonsoft.Json.Linq;
 using static Google.Api.MetricDescriptor.Types;
 using Google.Protobuf.WellKnownTypes;
 using System.Net;
+using Google.Api.Gax.Grpc;
 
 namespace GoogleCloudSamples
 {
@@ -110,7 +111,8 @@ namespace GoogleCloudSamples
             var client = UptimeCheckServiceClient.Create();
             string projectName = new ProjectName(projectId).ToString();
             // Create the config.
-            var newConfig = client.CreateUptimeCheckConfig(projectName, config);
+            var newConfig = client.CreateUptimeCheckConfig(projectName, config,
+                CallSettings.FromCallTiming(CallTiming.FromTimeout(TimeSpan.FromMinutes(2))));
             Console.WriteLine(newConfig.Name);
             return 0;
         }

--- a/monitoring/api/UptimeCheckSample/Program.cs
+++ b/monitoring/api/UptimeCheckSample/Program.cs
@@ -14,20 +14,20 @@
  * the License.
  */
 
+using CommandLine;
+using Google.Api;
+using Google.Api.Gax;
+using Google.Api.Gax.Grpc;
+using Google.Cloud.Monitoring.V3;
+using Google.Protobuf.WellKnownTypes;
+using Newtonsoft.Json.Linq;
+using static Google.Api.MetricDescriptor.Types;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Text;
 using System.Threading.Tasks;
-using Google.Cloud.Monitoring.V3;
-using CommandLine;
-using Google.Api.Gax;
-using Google.Api;
-using Newtonsoft.Json.Linq;
-using static Google.Api.MetricDescriptor.Types;
-using Google.Protobuf.WellKnownTypes;
-using System.Net;
-using Google.Api.Gax.Grpc;
 
 namespace GoogleCloudSamples
 {


### PR DESCRIPTION
It can take a long time, causing tests to fail.
Server-side issue tracked in bug 112552528.