### PR TITLE
Use a unique name in the test to avoid slowness.

### DIFF
--- a/monitoring/api/UptimeCheckTest/UptimeCheckTest.cs
+++ b/monitoring/api/UptimeCheckTest/UptimeCheckTest.cs
@@ -62,9 +62,9 @@ namespace GoogleCloudSamples
         public UptimeCheckTestFixture()
         {
             // Create two uptime checks to work with.
-            var output = Cmd.Run("create", "-p", ProjectId);
+            var output = Cmd.Run("create", "-p", ProjectId, "-d", TestUtil.RandomName());
             UptimeCheckConfigNames.Add(output.Stdout.Trim());
-            output = Cmd.Run("create", "-p", ProjectId);
+            output = Cmd.Run("create", "-p", ProjectId, "-d", TestUtil.RandomName());
             UptimeCheckConfigNames.Add(output.Stdout.Trim());
         }
 


### PR DESCRIPTION
Change-Id: I22fc18aea4f35b9b8614659b0fd1c1a72dcdbf34