### PR TITLE
[Storage] Bucket lock samples

### DIFF
--- a/storage/api/README.md
+++ b/storage/api/README.md
@@ -63,7 +63,7 @@ can use [this older sample](
 	  Storage view-bucket-iam-members bucket-name
 	  Storage add-bucket-iam-member bucket-name member
 	  Storage remove-bucket-iam-member bucket-name role member
-	  Storage add-bucket-default-kms-key bucket-name key-ring key-name
+	  Storage add-bucket-default-kms-key bucket-name key-location key-ring key-name
 	  Storage upload-with-kms-key bucket-name key-location
 				      key-ring key-name local-file-path [object-name]
 	  Storage print-acl bucket-name
@@ -80,7 +80,18 @@ can use [this older sample](
 	  Storage disable-requester-pays bucket-name
 	  Storage get-requester-pays bucket-name
 	  Storage generate-encryption-key
-    ```
+	  Storage get-bucket-default-event-based-hold bucket-name
+	  Storage enable-bucket-default-event-based-hold bucket-name
+	  Storage disable-bucket-default-event-based-hold bucket-name
+	  Storage lock-bucket-retention-policy bucket-name
+	  Storage set-bucket-retention-policy bucket-name retention-period
+	  Storage remove-bucket-retention-policy bucket-name
+	  Storage get-bucket-retention-policy bucket-name
+	  Storage set-object-temporary-hold bucket-name object-name
+	  Storage release-object-temporary-hold bucket-name object-name
+	  Storage set-object-event-based-hold bucket-name object-name
+	  Storage release-object-event-based-hold bucket-name object-name
+	    ```
 
 ## Contributing changes
 

--- a/storage/api/Storage/Storage.cs
+++ b/storage/api/Storage/Storage.cs
@@ -868,7 +868,7 @@ namespace GoogleCloudSamples
                 // Use IfMetagenerationMatch to avoid race conditions.
                 IfMetagenerationMatch = bucket.Metageneration
             });
-            Console.WriteLine($"Default event-based hold was enabled for #{bucketName}");
+            Console.WriteLine($"Default event-based hold was enabled for {bucketName}");
         }
         // [END storage_enable_default_event_based_hold]
 
@@ -896,7 +896,7 @@ namespace GoogleCloudSamples
                 // Use IfMetagenerationMatch to avoid race conditions.
                 IfMetagenerationMatch = bucket.Metageneration
             });
-            Console.WriteLine($"Default event-based hold was disabled for #{bucketName}");
+            Console.WriteLine($"Default event-based hold was disabled for {bucketName}");
         }
         // [END storage_disable_default_event_based_hold]
 

--- a/storage/api/Storage/Storage.cs
+++ b/storage/api/Storage/Storage.cs
@@ -1222,12 +1222,10 @@ namespace GoogleCloudSamples
                     case "get-requester-pays":
                         if (args.Length < 2 && PrintUsage()) return -1;
                         return GetRequesterPays(args[1]) ? 1 : 0;
-                        break;
 
                     case "get-bucket-default-event-based-hold":
                         if (args.Length < 2 && PrintUsage()) return -1;
                         return GetBucketDefaultEventBasedHold(args[1]) ? 1 : 0;
-                        break;
 
                     case "enable-bucket-default-event-based-hold":
                         if (args.Length < 2 && PrintUsage()) return -1;

--- a/storage/api/Storage/Storage.csproj
+++ b/storage/api/Storage/Storage.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Storage.V1" Version="2.2.0-beta01" />
+    <PackageReference Include="Google.Cloud.Storage.V1" Version="2.3.0-beta01" />
   </ItemGroup>
 
 </Project>

--- a/storage/api/Storage/Storage.csproj
+++ b/storage/api/Storage/Storage.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Storage.V1" Version="2.3.0-beta01" />
+    <PackageReference Include="Google.Cloud.Storage.V1" Version="2.3.0-beta02" />
   </ItemGroup>
 
 </Project>

--- a/storage/api/StorageTest/StorageTest.cs
+++ b/storage/api/StorageTest/StorageTest.cs
@@ -166,7 +166,6 @@ namespace GoogleCloudSamples
 
         public static void DeleteBucket(string bucketName)
         {
-            // TODO: Add additional lock to clear settings from objects that may contain retention values enabled
             Eventually(() => AssertSucceeded(Run("delete", bucketName)));
         }
 

--- a/storage/api/StorageTest/StorageTest.cs
+++ b/storage/api/StorageTest/StorageTest.cs
@@ -166,6 +166,7 @@ namespace GoogleCloudSamples
 
         public static void DeleteBucket(string bucketName)
         {
+            // TODO: Add additional lock to clear settings from objects that may contain retention values enabled
             Eventually(() => AssertSucceeded(Run("delete", bucketName)));
         }
 
@@ -542,7 +543,7 @@ namespace GoogleCloudSamples
             AssertSucceeded(printedAcl);
             Assert.Contains(userEmail, printedAcl.Stdout);
 
-            // Make sure we print-acl-for-user shows us the user, 
+            // Make sure we print-acl-for-user shows us the user,
             // but not all the ACLs.
             printedAclForUser = Run("print-acl-for-user", _bucketName,
                 "HelloAddObjectOwner.txt", userEmail);
@@ -625,6 +626,86 @@ namespace GoogleCloudSamples
             var client = new HttpClient();
             var response = client.GetAsync(output.Stdout).Result;
             Assert.InRange((int)response.StatusCode, 200, 299);
+        }
+
+        [Fact]
+        public void TestBucketLockBucket()
+        {
+            using (var bucketLock = new BucketFixture())
+            {
+                var retentionPeriod = "5";
+                var setRetentionPolicy = Run("set-bucket-retention-policy", bucketLock.BucketName, retentionPeriod);
+                AssertSucceeded(setRetentionPolicy);
+                var getRetentionPolicy = Run("get-bucket-retention-policy", bucketLock.BucketName);
+                AssertSucceeded(getRetentionPolicy);
+                Assert.Contains($"period: {retentionPeriod}", getRetentionPolicy.Stdout);
+                var enableBucketDefaultEventBasedHold = Run("enable-bucket-default-event-based-hold", _bucketName);
+                AssertSucceeded(enableBucketDefaultEventBasedHold);
+                var getBucketDefaultEventBasedHold = Run("get-bucket-default-event-based-hold", _bucketName);
+                Assert.Equal(1, getBucketDefaultEventBasedHold.ExitCode);
+                Assert.Contains("Default event-based hold: True", getBucketDefaultEventBasedHold.Stdout);
+                var disableBucketDefaultEventBasedHold = Run("disable-bucket-default-event-based-hold", _bucketName);
+                AssertSucceeded(enableBucketDefaultEventBasedHold);
+                getBucketDefaultEventBasedHold = Run("get-bucket-default-event-based-hold", _bucketName);
+                Assert.Equal(0, getBucketDefaultEventBasedHold.ExitCode);
+                Assert.Contains("Default event-based hold: False", getBucketDefaultEventBasedHold.Stdout);
+                var removeRetentionPolicy = Run("remove-bucket-retention-policy", bucketLock.BucketName);
+                AssertSucceeded(setRetentionPolicy);
+                getRetentionPolicy = Run("get-bucket-retention-policy", bucketLock.BucketName);
+                AssertSucceeded(getRetentionPolicy);
+                Assert.DoesNotContain($"period:", getRetentionPolicy.Stdout);
+                setRetentionPolicy = Run("set-bucket-retention-policy", bucketLock.BucketName, retentionPeriod);
+                AssertSucceeded(setRetentionPolicy);
+                var lockRetentionPolicy = Run("lock-bucket-retention-policy", bucketLock.BucketName);
+                AssertSucceeded(lockRetentionPolicy);
+            }
+        }
+
+        [Fact]
+        public void TestBucketLockObject()
+        {
+            using (var bucketLock = new BucketFixture())
+            {
+                var objectName = "HelloBucketLock.txt";
+                try
+                {
+                    var uploaded = Run("upload", bucketLock.BucketName,
+                        "Hello.txt", objectName);
+                    AssertSucceeded(uploaded);
+                    var setTemporaryHold = Run("set-object-temporary-hold", bucketLock.BucketName, objectName);
+                    AssertSucceeded(setTemporaryHold);
+                    var getMetadata = Run("get-metadata", bucketLock.BucketName, objectName);
+                    AssertSucceeded(getMetadata);
+                    Assert.Contains("Temporary hold enabled? True", getMetadata.Stdout);
+                    var releaseTemporaryHold = Run("release-object-temporary-hold", bucketLock.BucketName, objectName);
+                    AssertSucceeded(releaseTemporaryHold);
+                    getMetadata = Run("get-metadata", bucketLock.BucketName, objectName);
+                    AssertSucceeded(getMetadata);
+                    Assert.Contains("Temporary hold enabled? False", getMetadata.Stdout);
+                    var retentionPeriod = "5";
+                    var setRetentionPolicy = Run("set-bucket-retention-policy", bucketLock.BucketName, retentionPeriod);
+                    AssertSucceeded(setRetentionPolicy);
+                    var setEventBasedHold = Run("set-object-event-based-hold", bucketLock.BucketName, objectName);
+                    AssertSucceeded(setEventBasedHold);
+                    getMetadata = Run("get-metadata", bucketLock.BucketName, objectName);
+                    AssertSucceeded(getMetadata);
+                    Assert.Contains("Event-based hold enabled? True", getMetadata.Stdout);
+                    var releaseEventBasedHold = Run("release-object-event-based-hold", bucketLock.BucketName, objectName);
+                    AssertSucceeded(releaseEventBasedHold);
+                    getMetadata = Run("get-metadata", bucketLock.BucketName, objectName);
+                    AssertSucceeded(getMetadata);
+                    Assert.Contains("Event-based hold enabled? False", getMetadata.Stdout);
+                    var removeRetentionPolicy = Run("remove-bucket-retention-policy", bucketLock.BucketName);
+                    AssertSucceeded(removeRetentionPolicy);
+                }
+                finally
+                {
+                    AssertSucceeded(Run("remove-bucket-retention-policy", bucketLock.BucketName));
+                    AssertSucceeded(Run("release-object-temporary-hold", bucketLock.BucketName, objectName));
+                    AssertSucceeded(Run("release-object-event-based-hold", bucketLock.BucketName, objectName));
+                    AssertSucceeded(Run("delete", bucketLock.BucketName, objectName));
+                }
+            }
         }
 
         [Fact]


### PR DESCRIPTION
### Samples
- [x]  Tested samples
- [x]  Define a retention policy
- [x]  Remove a retention policy if not locked
- [x]  Lock a retention policy
- [x]  Set temporary hold
- [x]  Release temporary hold
- [x]  Set event-based hold
- [x]  Release event-based hold
- [x]  Set default event-based hold
- [x]  Release default event-based hold
- [x]  View default event-based hold
- [x]  View bucket retention policy metadata
- [x]  View metadata for object
- [x]  Updated README.md
- [x]  Updated CLI
- [x] enable feature for test projects.
- [x] lint.
- [x] Test against Kokoro when library is released. Right now, I'm only able to test locally.