### PR TITLE
Fix selenium test with --no-sandbox.

### DIFF
--- a/.kokoro-windows/New-BuildEnv.ps1
+++ b/.kokoro-windows/New-BuildEnv.ps1
@@ -45,8 +45,8 @@ if (-not (($chocoPackages.Contains('python 2.7.') -or
     choco install -y --sxs python --version 2.7.6
 }
 
-if (-not $chocoPackages.Contains('selenium-chrome-driver 2.')) {
-    choco install -y selenium-chrome-driver
+if (-not $chocoPackages.Contains('selenium-chrome-driver 2.37')) {
+    choco install -y --sxs selenium-chrome-driver --version 2.37
 }
 if (-not $chocoPackages.Contains('iisexpress')) {
     choco install -y --sxs iisexpress

--- a/.kokoro-windows/New-BuildEnv.ps1
+++ b/.kokoro-windows/New-BuildEnv.ps1
@@ -45,8 +45,8 @@ if (-not (($chocoPackages.Contains('python 2.7.') -or
     choco install -y --sxs python --version 2.7.6
 }
 
-if (-not $chocoPackages.Contains('selenium-chrome-driver 2.37')) {
-    choco install -y --sxs selenium-chrome-driver --version 2.37
+if (-not $chocoPackages.Contains('selenium-chrome-driver 2.')) {
+    choco install -y selenium-chrome-driver
 }
 if (-not $chocoPackages.Contains('iisexpress')) {
     choco install -y --sxs iisexpress

--- a/applications/sudokumb/WebAppTest/WebAppTest.cs
+++ b/applications/sudokumb/WebAppTest/WebAppTest.cs
@@ -33,9 +33,11 @@ namespace Sudokumb
 
         public WebDriverTestFixture()
         {
+            var options = new ChromeOptions();
+            options.AddArgument("no-sandbox");
             WebDriver = new ChromeDriver(
                 ChromeDriverService.CreateDefaultService(),
-                new ChromeOptions(), TimeSpan.FromMinutes(3));
+                options, TimeSpan.FromMinutes(3));
         }
 
         public void Dispose()


### PR DESCRIPTION
Version 2.37 is a few months old, but it's a known good version, and our selenium test started failing with no changes to code or test VM image.