### PR TITLE
Skip Bigquery's TestCopyTable.

### DIFF
--- a/bigquery/api/BigqueryTest/BigqueryTest.cs
+++ b/bigquery/api/BigqueryTest/BigqueryTest.cs
@@ -637,7 +637,7 @@ namespace GoogleCloudSamples
             Assert.True(recordCount == expectedNumberOfRecords);
         }
 
-        [Fact]
+        [Fact(Skip = "https://buganizer.corp.google.com/issues/119614447")]
         public void TestCopyTable()
         {
             string projectId = "bigquery-public-data";


### PR DESCRIPTION
Until someone has time to investigate and fix.