### PR TITLE
Show how to set an environment variable name with a colon.

### DIFF
--- a/appengine/flexible/HelloWorld/Startup.cs
+++ b/appengine/flexible/HelloWorld/Startup.cs
@@ -21,6 +21,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace HelloWorld
@@ -28,6 +29,13 @@ namespace HelloWorld
     // [START gae_flex_quickstart]
     public class Startup
     {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
         // This method gets called by the runtime. Use this method to add services to the container.
         // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
         public void ConfigureServices(IServiceCollection services)
@@ -44,7 +52,8 @@ namespace HelloWorld
 
             app.Run(async (context) =>
             {
-                await context.Response.WriteAsync("Hello World!");
+                string greeting = Configuration["My:Greeting"];
+                await context.Response.WriteAsync(greeting);
             });
         }
     }

--- a/appengine/flexible/HelloWorld/app.yaml
+++ b/appengine/flexible/HelloWorld/app.yaml
@@ -11,3 +11,7 @@ resources:
   cpu: 1
   memory_gb: 0.5
   disk_size_gb: 10
+
+env_variables:
+  # The __ in My__Greeting will be translated to a : by ASP.NET.
+  My__Greeting: Hello AppEngine!

--- a/appengine/flexible/HelloWorld/appsettings.json
+++ b/appengine/flexible/HelloWorld/appsettings.json
@@ -1,0 +1,5 @@
+{
+    "My": {
+        "Greeting": "Hello World!"
+    }
+}


### PR DESCRIPTION
ASP.NET frequently uses environment variable names with colons.

Change-Id: I3f8cdd68e635fd86fce33ff5bcc47409f5f2af2c