### PR TITLE
Fix the TestBatchGetAssetsHistory().

### DIFF
--- a/asset/quickstart/BatchGetAssetsHistoryTest/BatchGetAssetsHistoryTest.cs
+++ b/asset/quickstart/BatchGetAssetsHistoryTest/BatchGetAssetsHistoryTest.cs
@@ -43,13 +43,16 @@ namespace GoogleCloudSamples
         {
             string assetName = String.Format("//storage.googleapis.com/{0}", _bucketName);
             Environment.SetEnvironmentVariable("ASSET_NAME", assetName);
-            var output = s_runner.Run();
-            _testOutput.WriteLine(output.Stdout);
-            string expectedOutput = assetName;
-            if (output.Stdout.Length > 0)
+            RetryRobot robot = new RetryRobot()
             {
-                Assert.Contains(expectedOutput, output.Stdout);
-            }
+                RetryWhenExceptions = new[] { typeof(Xunit.Sdk.XunitException) }
+            };
+            robot.Eventually(() =>
+            {
+                var output = s_runner.Run();
+                _testOutput.WriteLine(output.Stdout);
+                Assert.Contains(assetName, output.Stdout);
+            });
         }
     }
 }

--- a/asset/quickstart/BatchGetAssetsHistoryTest/runTests.ps1
+++ b/asset/quickstart/BatchGetAssetsHistoryTest/runTests.ps1
@@ -20,5 +20,5 @@ BackupAndEdit-TextFile @("..\BatchGetAssetsHistory/BatchGetAssetsHistory.cs") @{
     '"ASSET-NAME"' = $getBucketNameClause
 } {
     dotnet restore
-    dotnet test --test-adapter-path:. --logger:junit
+    dotnet test --test-adapter-path:. --logger:junit -v n
 }

--- a/bigtable/api/HelloWorld/HelloWorld.cs
+++ b/bigtable/api/HelloWorld/HelloWorld.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 // [START dependencies]
+
 using System;
 using System.Linq;
 using System.Threading.Tasks;


### PR DESCRIPTION
The cloud storage API is *eventually* consistent.  Newly created objects may not be immediately visible.  Add retry logic in the test when the new cloud storage object is not found.