### PR TITLE
Make video test less fragile.

### DIFF
--- a/video/api/Test/Tests.cs
+++ b/video/api/Test/Tests.cs
@@ -44,10 +44,6 @@ namespace GoogleCloudSamples.VideoIntelligence
             Command = "Analyze"
         };
 
-        readonly List<string> _POSSIBLE_TEXTS = new List<string>
-        { "Google", "SUR", "ROTO", "Vice President", "58oo9",
-          "LONDRES", "OMAR", "PARIS", "METRO", "RUE", "CARLO"};
-
         [Fact(Skip = "Triggers infinite loop described here: https://github.com/commandlineparser/commandline/commit/95ded2dbcc5285302723e68221cd30a72444ba84")]
         void TestAnalyzeNoArgsSucceeds()
         {
@@ -145,18 +141,8 @@ namespace GoogleCloudSamples.VideoIntelligence
             ConsoleOutput output =
                 _analyze.Run("text", DownloadGcsObject("gs://python-docs-samples-tests/video/googlework_short.mp4"));
             Assert.Equal(0, output.ExitCode);
-
-            var textExists = false;
-            foreach (string word in _POSSIBLE_TEXTS)
-            {
-                if (output.Stdout.Contains(word))
-                {
-                    textExists = true;
-                }
-            }
-            Assert.True(textExists,
-                "Failed to find any of " + string.Join(", ", _POSSIBLE_TEXTS)
-                + " in output\n" + output.Stdout);
+            Assert.Contains("Start time:", output.Stdout);
+            Assert.Contains("Confidence:", output.Stdout);
         }
 
         [Fact]
@@ -166,17 +152,8 @@ namespace GoogleCloudSamples.VideoIntelligence
                 _analyze.Run("text", "gs://python-docs-samples-tests/video/googlework_short.mp4");
             Assert.Equal(0, output.ExitCode);
 
-            var textExists = false;
-            foreach (string word in _POSSIBLE_TEXTS)
-            {
-                if (output.Stdout.Contains(word))
-                {
-                    textExists = true;
-                }
-            }
-            Assert.True(textExists,
-                "Failed to find any of " + string.Join(", ", _POSSIBLE_TEXTS)
-                + " in output\n" + output.Stdout);
+            Assert.Contains("Start time:", output.Stdout);
+            Assert.Contains("Confidence:", output.Stdout);
         }
 
         [Fact]

--- a/video/api/Test/runTests.ps1
+++ b/video/api/Test/runTests.ps1
@@ -13,7 +13,7 @@
 # the License.
 import-module -DisableNameChecking ..\..\..\BuildTools.psm1
 
-Set-TestTimeout 1800
+Set-TestTimeout 2400
 
 dotnet restore
 dotnet build


### PR DESCRIPTION
Verify the output of the code in the samples, not the output of the API.

And extend the time out a little more.

Change-Id: I26da4db3af10ef2473dd97b30d82958d0cec8e5a