### PR TITLE
Fix broken test.

### DIFF
--- a/.kokoro-windows/New-BuildEnv.ps1
+++ b/.kokoro-windows/New-BuildEnv.ps1
@@ -46,7 +46,7 @@ if (-not (($chocoPackages.Contains('python 2.7.') -or
 }
 
 if (-not $chocoPackages.Contains('selenium-chrome-driver 2.')) {
-    choco install -y selenium-chrome-driver
+    choco install -y selenium-chrome-driver --version 2.46
 }
 if (-not $chocoPackages.Contains('iisexpress')) {
     choco install -y --sxs iisexpress


### PR DESCRIPTION
By specifying a version of selenium-chrome-driver that is known to work with the version of chrome installed on the Kokoro test machines.