### PR TITLE
Spanner: Use correct/consistent logic to transfer budget.

### DIFF
--- a/spanner/api/SpannerTest/Tests.cs
+++ b/spanner/api/SpannerTest/Tests.cs
@@ -354,7 +354,7 @@ namespace GoogleCloudSamples.Spanner
             readOutput = _spannerCmd.Run("querySingersTable",
                 _fixture.ProjectId, _fixture.InstanceId, _fixture.DatabaseId);
             Assert.Equal(0, readOutput.ExitCode);
-            // Confirm expected result in output.            
+            // Confirm expected result in output.
             Assert.Contains("Melissa Garcia", readOutput.Stdout);
             Assert.Contains("Russell Morales", readOutput.Stdout);
             Assert.Contains("Jacqueline Long", readOutput.Stdout);
@@ -363,7 +363,7 @@ namespace GoogleCloudSamples.Spanner
             readOutput = _spannerCmd.Run("queryWithParameter",
                 _fixture.ProjectId, _fixture.InstanceId, _fixture.DatabaseId);
             Assert.Equal(0, readOutput.ExitCode);
-            // Confirm expected result in output.            
+            // Confirm expected result in output.
             Assert.Contains("SingerId : 12 FirstName : Melissa LastName : Garcia", readOutput.Stdout);
             // Update records within a transaction using a DML Statement.
             readOutput = _spannerCmd.Run("writeWithTransactionUsingDml",
@@ -374,8 +374,8 @@ namespace GoogleCloudSamples.Spanner
                 _fixture.ProjectId, _fixture.InstanceId, _fixture.DatabaseId);
             Assert.Equal(0, readOutput.ExitCode);
             // Confirm expected result in output.
-            Assert.Contains("1 1 400000", readOutput.Stdout);
-            Assert.Contains("2 2 500000", readOutput.Stdout);
+            Assert.Contains("1 1 500000", readOutput.Stdout);
+            Assert.Contains("2 2 400000", readOutput.Stdout);
             // Update records using a partitioned DML Statement.
             readOutput = _spannerCmd.Run("updateUsingPartitionedDml",
                 _fixture.ProjectId, _fixture.InstanceId, _fixture.DatabaseId);
@@ -385,7 +385,7 @@ namespace GoogleCloudSamples.Spanner
                 _fixture.ProjectId, _fixture.InstanceId, _fixture.DatabaseId);
             Assert.Equal(0, readOutput.ExitCode);
             // Confirm expected result in output.
-            Assert.Contains("1 1 400000", readOutput.Stdout);
+            Assert.Contains("1 1 500000", readOutput.Stdout);
             Assert.Contains("2 2 100000", readOutput.Stdout);
             // Delete multiple records using a partitioned DML Statement.
             readOutput = _spannerCmd.Run("deleteUsingPartitionedDml",


### PR DESCRIPTION
The `WriteWithTransactionUsingDmlCoreAsync` snippet moves $200,000 from Album1 to Album2. However, Album1 is initialized with a budget of $100,000. As a result, you can't work through the [getting started doc](https://cloud.google.com/spanner/docs/getting-started/csharp/) from start to finish. This snippet also defined and checked a `minimumAmountToTransfer`, which isn't consistent with the equivalent snippets for other languages.

In addition, the `ReadWriteWithTransactionCoreAsync` snippet moved $200,000, but in the opposite direction, which was somewhat confusing.

Finally, neither snippet confirmed that the source album's budget was at least as large as the transfer amount.

I made both snippets transfer $100,000 from Album1 to Album2. I also fixed the logic errors and updated the tests as needed.