### PR TITLE
Improvements for samples of job polling

### DIFF
--- a/bigquery/api/Snippets/CopyTable.cs
+++ b/bigquery/api/Snippets/CopyTable.cs
@@ -37,7 +37,7 @@ public class BigQueryCopyTable
         BigQueryJob job = client.CreateCopyJob(
             sourceTableRef, destinationTableRef)
             .PollUntilCompleted() // Wait for the job to complete.
-            .ThrowOnAnyError();  
+            .ThrowOnAnyError();
 
         // Retrieve destination table
         BigQueryTable destinationTable = client.GetTable(destinationTableRef);

--- a/bigquery/api/Snippets/CopyTable.cs
+++ b/bigquery/api/Snippets/CopyTable.cs
@@ -36,7 +36,9 @@ public class BigQueryCopyTable
             destinationDatasetId, "destination_table");
         BigQueryJob job = client.CreateCopyJob(
             sourceTableRef, destinationTableRef)
-            .PollUntilCompleted();  // Wait for the job to complete.
+            .PollUntilCompleted() // Wait for the job to complete.
+            .ThrowOnAnyError();  
+
         // Retrieve destination table
         BigQueryTable destinationTable = client.GetTable(destinationTableRef);
         Console.WriteLine(

--- a/bigquery/api/Snippets/ExtractTable.cs
+++ b/bigquery/api/Snippets/ExtractTable.cs
@@ -33,7 +33,7 @@ public class BigQueryExtractTable
             tableId: "shakespeare",
             destinationUri: destinationUri
         );
-        job.PollUntilCompleted();  // Waits for the job to complete.
+        job = job.PollUntilCompleted().ThrowOnAnyError();  // Waits for the job to complete.
         Console.Write($"Exported table to {destinationUri}.");
     }
 }

--- a/bigquery/api/Snippets/ExtractTableJson.cs
+++ b/bigquery/api/Snippets/ExtractTableJson.cs
@@ -36,7 +36,7 @@ public class BigQueryExtractTableJson
             destinationUri: destinationUri,
             options: jobOptions
         );
-        job.PollUntilCompleted();  // Waits for the job to complete.
+        job = job.PollUntilCompleted().ThrowOnAnyError();  // Waits for the job to complete.
         Console.Write($"Exported table to {destinationUri}.");
     }
 }

--- a/bigquery/api/Snippets/LoadFromFile.cs
+++ b/bigquery/api/Snippets/LoadFromFile.cs
@@ -40,7 +40,8 @@ public class BigQueryLoadFromFile
             // Note that there are methods available for formats other than CSV
             BigQueryJob job = client.UploadCsv(
                 datasetId, tableId, null, stream, uploadCsvOptions);
-            job.PollUntilCompleted();  // Waits for the job to complete.
+            job = job.PollUntilCompleted().ThrowOnAnyError();  // Waits for the job to complete.
+
             // Display the number of rows uploaded
             BigQueryTable table = client.GetTable(datasetId, tableId);
             Console.WriteLine(

--- a/bigquery/api/Snippets/LoadTableGcsCsv.cs
+++ b/bigquery/api/Snippets/LoadTableGcsCsv.cs
@@ -44,7 +44,8 @@ public class BigQueryLoadTableGcsCsv
         var loadJob = client.CreateLoadJob(
             sourceUri: gcsURI, destination: destinationTableRef,
             schema: schema, options: jobOptions);
-        loadJob.PollUntilCompleted();  // Waits for the job to complete.
+        loadJob = loadJob.PollUntilCompleted().ThrowOnAnyError();  // Waits for the job to complete.
+
         // Display the number of rows uploaded
         BigQueryTable table = client.GetTable(destinationTableRef);
         Console.WriteLine(

--- a/bigquery/api/Snippets/LoadTableGcsJson.cs
+++ b/bigquery/api/Snippets/LoadTableGcsJson.cs
@@ -43,7 +43,7 @@ public class BigQueryLoadTableGcsJson
         BigQueryJob loadJob = client.CreateLoadJob(
             sourceUri: gcsURI, destination: destinationTableRef,
             schema: schema, options: jobOptions);
-        loadJob.PollUntilCompleted();  // Waits for the job to complete.
+        loadJob = loadJob.PollUntilCompleted().ThrowOnAnyError();  // Waits for the job to complete.
         // Display the number of rows uploaded
         BigQueryTable table = client.GetTable(destinationTableRef);
         Console.WriteLine(

--- a/bigquery/api/Snippets/LoadTableGcsOrc.cs
+++ b/bigquery/api/Snippets/LoadTableGcsOrc.cs
@@ -44,7 +44,7 @@ public class BigQueryLoadTableGcsOrc
             schema: null,
             options: jobOptions
         );
-        loadJob.PollUntilCompleted();  // Waits for the job to complete.
+        loadJob = loadJob.PollUntilCompleted().ThrowOnAnyError();  // Waits for the job to complete.
         // Display the number of rows uploaded
         BigQueryTable table = client.GetTable(destinationTableRef);
         Console.WriteLine(

--- a/bigquery/api/Snippets/LoadTableGcsOrcTruncate.cs
+++ b/bigquery/api/Snippets/LoadTableGcsOrcTruncate.cs
@@ -44,7 +44,7 @@ public class BigQueryLoadTableGcsOrcTruncate
             // Pass null as the schema because the schema is inferred when
             // loading Orc data
             schema: null, options: jobOptions);
-        loadJob.PollUntilCompleted();  // Waits for the job to complete.
+        loadJob = loadJob.PollUntilCompleted().ThrowOnAnyError();  // Waits for the job to complete.
         // Display the number of rows uploaded
         BigQueryTable table = client.GetTable(destinationTableRef);
         Console.WriteLine(

--- a/bigquery/api/Snippets/Query.cs
+++ b/bigquery/api/Snippets/Query.cs
@@ -33,7 +33,7 @@ public class BigQueryQuery
             parameters: null,
             options: new QueryOptions { UseQueryCache = false });
         // Wait for the job to complete.
-        job.PollUntilCompleted();
+        job = job.PollUntilCompleted().ThrowOnAnyError();
         // Display the results
         foreach (BigQueryRow row in client.GetQueryResults(job.Reference))
         {

--- a/bigquery/api/Snippets/QueryLegacy.cs
+++ b/bigquery/api/Snippets/QueryLegacy.cs
@@ -33,7 +33,7 @@ public class BigQueryQueryLegacy
             parameters: null,
             options: new QueryOptions { UseLegacySql = true });
         // Wait for the job to complete.
-        job.PollUntilCompleted();
+        job = job.PollUntilCompleted().ThrowOnAnyError();
         // Display the results
         foreach (BigQueryRow row in client.GetQueryResults(job.Reference))
         {


### PR DESCRIPTION
- Always assign back to a variable
- Always throw on any error

The return value of PollUntilCompleted() is important; ignoring it leads to issues such as https://github.com/googleapis/google-cloud-dotnet/issues/3169#issuecomment-505347038

The samples now always use the return value; I'm going to update the XML documentation as well. Any suggestions for further action would be welcome too.