### PR TITLE
Remove direct dependencies on gRPC because

### DIFF
--- a/applications/googlehome-meets-dotnetcontainers/GoogleHomeAspNetCoreDemoServer/GoogleHomeAspNetCoreDemoServer.csproj
+++ b/applications/googlehome-meets-dotnetcontainers/GoogleHomeAspNetCoreDemoServer/GoogleHomeAspNetCoreDemoServer.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="Google.Cloud.Vision.V1" Version="1.6.0" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.1" />
-    <PackageReference Include="Grpc.Auth" Version="1.22.0" />
     <PackageReference Include="Google.Apis.Customsearch.v1" Version="1.40.3.1369" />
     <PackageReference Include="Google.Cloud.BigQuery.V2" Version="1.3.0" />
     <PackageReference Include="Google.Cloud.Diagnostics.AspNetCore" Version="3.0.0-beta14" />

--- a/cloudtasks/api/TasksSample/TasksSample.csproj
+++ b/cloudtasks/api/TasksSample/TasksSample.csproj
@@ -7,7 +7,6 @@
   <ItemGroup>
     <PackageReference Include="JUnitTestLogger" Version="0.6.0" />
     <PackageReference Include="Google.Api.Gax.Grpc" Version="2.9.0" />
-    <PackageReference Include="Grpc.Core" Version="1.22.0" PrivateAssets="None" />
     <PackageReference Include="Google.Cloud.Tasks.V2" Version="1.0.0" />
     <PackageReference Include="Google.Cloud.Tasks.V2Beta3" Version="1.0.0-beta07" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />

--- a/dlp/api/DlpSample/DlpSample.csproj
+++ b/dlp/api/DlpSample/DlpSample.csproj
@@ -9,7 +9,6 @@
     <PackageReference Include="Google.Api.Gax.Grpc" Version="2.9.0" />
     <PackageReference Include="Google.Apis.CloudKMS.v1" Version="1.40.3.1668" />
     <PackageReference Include="Google.Cloud.BigQuery.V2" Version="1.3.0" />
-    <PackageReference Include="Grpc.Core" Version="1.22.0" PrivateAssets="None" />
     <PackageReference Include="Google.Cloud.PubSub.V1" Version="1.0.0" />
     <PackageReference Include="Google.Cloud.Dlp.V2" Version="1.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />


### PR DESCRIPTION
they're redundant and make the build more fragile.

Change-Id: I4c4b8d05f66b3cc0961d6587585f62ec0fd03dff