### PR TITLE
Fix: Wrong list of directories chosen for kokoro build.

### DIFF
--- a/.kokoro/main.ps1
+++ b/.kokoro/main.ps1
@@ -38,7 +38,8 @@ try {
         @('iam') # 3: Runs once every 24 hours to avoid bursting active roles limit of 300.
     )
 
-    $union = $groups[2..($groups.Length-1)] | Select-Object
+    $union = $groups[2..($groups.Length-1)] | `
+         % {$_} # Flatten the list
     $groups[0] = $allDirs
     $groups[1] = $allDirs | Where-Object { -not $union.Contains($_) }
 


### PR DESCRIPTION
The problem was that the list of directories selected from the groups was not getting flattened.  The code tried to flatten the list, but it did not work as intended.  Fix that code.

For example, when intending to run group 1, tests from group 3 were also getting run.
https://fusion.corp.google.com/runanalysis/test/prod%3Acloud-devrel%2Fdotnet-docs-samples%2Flinux%2Fsystem_tests/prod%3Acloud-devrel%2Fdotnet-docs-samples%2Flinux%2Fsystem_tests/KOKORO/d5a45250-0025-4a19-8a95-131b80771737/1571664738575/build%20%238118/Targets?target=cloud-devrel%2Fdotnet-docs-samples%2Flinux%2Fsystem_tests&drilldownTab=tests

Change-Id: I0ee0b7df45cec908a68f19b5cf1207b2d00c7e17