### PR TITLE
Storage quickstart now disposes of StorageClient

### DIFF
--- a/storage/api/QuickStart/QuickStart.cs
+++ b/storage/api/QuickStart/QuickStart.cs
@@ -32,21 +32,23 @@ namespace GoogleCloudSamples
             // [START storage_quickstart]
 
             // Instantiates a client.
-            StorageClient storageClient = StorageClient.Create();
+            using(StorageClient storageClient = StorageClient.Create())
+            {
 
-            // The name for the new bucket.
-            string bucketName = projectId + "-test-bucket";
-            try
-            {
-                // Creates the new bucket.
-                storageClient.CreateBucket(projectId, bucketName);
-                Console.WriteLine($"Bucket {bucketName} created.");
-            }
-            catch (Google.GoogleApiException e)
-            when (e.Error.Code == 409)
-            {
-                // The bucket already exists.  That's fine.
-                Console.WriteLine(e.Error.Message);
+                // The name for the new bucket.
+                string bucketName = projectId + "-test-bucket";
+                try
+                {
+                    // Creates the new bucket.
+                    storageClient.CreateBucket(projectId, bucketName);
+                    Console.WriteLine($"Bucket {bucketName} created.");
+                }
+                catch (Google.GoogleApiException e)
+                when (e.Error.Code == 409)
+                {
+                    // The bucket already exists.  That's fine.
+                    Console.WriteLine(e.Error.Message);
+                }
             }
         }
     }


### PR DESCRIPTION
`StorageClient` is disposable, this PR adds a `using` statement to ensure it is properly disposed of.    In this particular app it isn't an issue but if, like me, you copy this code into a high throughput application you will eventually get exceptions due to `HttpClient` running out of available TCP ports.