### PR TITLE
docs(firestore): add samples for distributed counters

### DIFF
--- a/firestore/api/FirestoreTest/FirestoreTest.cs
+++ b/firestore/api/FirestoreTest/FirestoreTest.cs
@@ -230,8 +230,8 @@ namespace GoogleCloudSamples
         {
             return _manageIndexes.Run(args);
         }
-
-		readonly CommandLineRunner _distrubutedCounter = new CommandLineRunner()
+        
+        readonly CommandLineRunner _distrubutedCounter = new CommandLineRunner()
         {
             VoidMain = DistributedCounter.Main,
             Command = "dotnet run"
@@ -241,7 +241,7 @@ namespace GoogleCloudSamples
         {
             return _distrubutedCounter.Run(args);
         }
-		
+
         // QUICKSTART TESTS
         [Fact]
         public void InitializeProjectIdTest()
@@ -840,8 +840,8 @@ namespace GoogleCloudSamples
             RunQueryData("query-create-examples", Environment.GetEnvironmentVariable("FIRESTORE_PROJECT_ID"));
             RunPaginateData("multiple-cursor-conditions", Environment.GetEnvironmentVariable("FIRESTORE_PROJECT_ID"));
         }
-		
-		[Fact]
+        
+        [Fact]
         public void RunDistributedCounterTest()
         {
             var output = RunDistributedCounter("run-distributed-counter", Environment.GetEnvironmentVariable("FIRESTORE_PROJECT_ID"));

--- a/firestore/api/FirestoreTest/FirestoreTest.cs
+++ b/firestore/api/FirestoreTest/FirestoreTest.cs
@@ -231,6 +231,17 @@ namespace GoogleCloudSamples
             return _manageIndexes.Run(args);
         }
 
+		readonly CommandLineRunner _distrubutedCounter = new CommandLineRunner()
+        {
+            VoidMain = DistributedCounter.Main,
+            Command = "dotnet run"
+        };
+
+        protected ConsoleOutput RunDistributedCounter(params string[] args)
+        {
+            return _distrubutedCounter.Run(args);
+        }
+		
         // QUICKSTART TESTS
         [Fact]
         public void InitializeProjectIdTest()
@@ -828,6 +839,16 @@ namespace GoogleCloudSamples
             Assert.Contains("Index creation completed!", manageIndexesOutput.Stdout);
             RunQueryData("query-create-examples", Environment.GetEnvironmentVariable("FIRESTORE_PROJECT_ID"));
             RunPaginateData("multiple-cursor-conditions", Environment.GetEnvironmentVariable("FIRESTORE_PROJECT_ID"));
+        }
+		
+		[Fact]
+        public void RunDistributedCounterTest()
+        {
+            var output = RunDistributedCounter("run-distributed-counter", Environment.GetEnvironmentVariable("FIRESTORE_PROJECT_ID"));
+            Assert.Contains("Created Cloud Firestore client with project ID", output.Stdout);
+            Assert.Contains("Distributed counter initialized.", output.Stdout);
+            Assert.Contains("Distributed counter incremented.", output.Stdout);
+            Assert.DoesNotContain("Total count: 0", output.Stdout);
         }
     }
 }

--- a/firestore/api/FirestoreTest/FirestoreTest.cs
+++ b/firestore/api/FirestoreTest/FirestoreTest.cs
@@ -230,7 +230,7 @@ namespace GoogleCloudSamples
         {
             return _manageIndexes.Run(args);
         }
-        
+
         readonly CommandLineRunner _distrubutedCounter = new CommandLineRunner()
         {
             VoidMain = DistributedCounter.Main,
@@ -840,7 +840,7 @@ namespace GoogleCloudSamples
             RunQueryData("query-create-examples", Environment.GetEnvironmentVariable("FIRESTORE_PROJECT_ID"));
             RunPaginateData("multiple-cursor-conditions", Environment.GetEnvironmentVariable("FIRESTORE_PROJECT_ID"));
         }
-        
+
         [Fact]
         public void RunDistributedCounterTest()
         {

--- a/firestore/api/FirestoreTest/FirestoreTest.cs
+++ b/firestore/api/FirestoreTest/FirestoreTest.cs
@@ -840,7 +840,7 @@ namespace GoogleCloudSamples
             var output = RunDistributedCounter("distributed-counter", Environment.GetEnvironmentVariable("FIRESTORE_PROJECT_ID"));
             Assert.Contains("Distributed counter created.", output.Stdout);
             Assert.Contains("Distributed counter incremented.", output.Stdout);
-            Assert.DoesNotContain("Total count: 0", output.Stdout);
+            Assert.Contains("Total count: 1", output.Stdout);
         }
     }
 }

--- a/firestore/api/FirestoreTest/FirestoreTest.cs
+++ b/firestore/api/FirestoreTest/FirestoreTest.cs
@@ -14,20 +14,13 @@
  * the License.
  */
 
+using Google.Apis.Auth.OAuth2;
+using Google.Cloud.Firestore;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Net.Http;
-using System.Net.Http.Headers;
-using System.IO;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Xunit;
-using Google.Cloud.Firestore;
-using Google.Apis.Auth.OAuth2;
-using Google.Apis.Services;
-using Newtonsoft.Json;
-
 
 namespace GoogleCloudSamples
 {
@@ -844,9 +837,8 @@ namespace GoogleCloudSamples
         [Fact]
         public void RunDistributedCounterTest()
         {
-            var output = RunDistributedCounter("run-distributed-counter", Environment.GetEnvironmentVariable("FIRESTORE_PROJECT_ID"));
-            Assert.Contains("Created Cloud Firestore client with project ID", output.Stdout);
-            Assert.Contains("Distributed counter initialized.", output.Stdout);
+            var output = RunDistributedCounter("distributed-counter", Environment.GetEnvironmentVariable("FIRESTORE_PROJECT_ID"));
+            Assert.Contains("Distributed counter created.", output.Stdout);
             Assert.Contains("Distributed counter incremented.", output.Stdout);
             Assert.DoesNotContain("Total count: 0", output.Stdout);
         }

--- a/firestore/api/FirestoreTest/FirestoreTest.csproj
+++ b/firestore/api/FirestoreTest/FirestoreTest.csproj
@@ -25,6 +25,7 @@
     <ProjectReference Include="..\TransactionsAndBatchedWrites\TransactionsAndBatchedWrites.csproj" />
     <ProjectReference Include="..\PaginateData\PaginateData.csproj" />
     <ProjectReference Include="..\ManageIndexes\ManageIndexes.csproj" />
+    <ProjectReference Include="..\SolutionCounter\SolutionCounter.csproj" />
     <ProjectReference Include="..\..\..\testutil\testutil.csproj" />
   </ItemGroup>
 </Project>

--- a/firestore/api/FirestoreTest/runTests.ps1
+++ b/firestore/api/FirestoreTest/runTests.ps1
@@ -32,7 +32,7 @@ $dataCollection = "kokoro-test-data-"+$randomString
 BackupAndEdit-TextFile "FirestoreTest.cs", "..\Quickstart\Program.cs", "..\AddData\Program.cs", `
 "..\DataModel\Program.cs", "..\DeleteData\Program.cs", "..\ListenData\Program.cs", `
 "..\GetData\Program.cs", "..\ManageIndexes\Program.cs", "..\OrderLimitData\Program.cs", `
-"..\PaginateData\Program.cs", "..\QueryData\Program.cs", "..\TransactionsAndBatchedWrites\Program.cs" `
+"..\PaginateData\Program.cs", "..\QueryData\Program.cs", "..\SolutionCounter\Program.cs", "..\TransactionsAndBatchedWrites\Program.cs" `
 	@{'db.Collection("users")' = 'db.Collection("'+$usersCollection+'")';
 	  'db.Collection("cities")' = 'db.Collection("'+$citiesCollection+'")';
 	  'db.Collection("data")' = 'db.Collection("'+$dataCollection+'")';

--- a/firestore/api/SolutionCounter/Program.cs
+++ b/firestore/api/SolutionCounter/Program.cs
@@ -1,0 +1,209 @@
+﻿/*
+ * Copyright (c) 2019 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Google.Cloud.Firestore;
+
+namespace GoogleCloudSamples
+{
+    // Counter is a collection of documents (shards)
+    // to realize counter with high frequency.
+
+    // [START counter_classes]
+
+    // counters/${ID}
+    /// <summary>
+    /// Defines the <see cref="Counter" />
+    /// </summary>
+    [FirestoreData]
+    public class Counter
+    {
+        /// <summary>
+        /// Gets or sets the NumShards
+        /// </summary>
+        [FirestoreProperty]
+        public int NumShards { get; set; }
+    }
+
+    // Shard is a single counter, which is used in a group
+    // of other shards within Counter.
+
+    // counters/${ID}/shards/${NUM}
+    /// <summary>
+    /// Defines the <see cref="Shard" />
+    /// </summary>
+    [FirestoreData]
+    public class Shard
+    {
+        /// <summary>
+        /// Gets or sets the Count
+        /// </summary>
+        [FirestoreProperty]
+        public int Count { get; set; }
+    }
+
+    // [END fs_counter_classes]
+
+    /// <summary>
+    /// Defines the <see cref="DistributedCounter" />
+    /// </summary>
+    public class DistributedCounter
+    { 
+        public static string Usage = @"Usage:
+C:\> dotnet run command YOUR_PROJECT_ID
+
+Where command is one of
+    run-distributed-counter
+";
+        /// <summary>
+        /// Gets or sets the FireStoreDb
+        /// </summary>
+        public static FirestoreDb FirestoreDb { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ShardsCounter
+        /// </summary>
+        public static Counter ShardsCounter { get; set; }
+
+        /// <summary>
+        /// The InitFireStoreDb
+        /// </summary>
+        public static void InitFirestoreDb(string project)
+        {
+            var projectId = project;
+            if (string.IsNullOrEmpty(projectId))
+                throw new ArgumentException("ArgumentException: failed read Firestore Project ID");
+
+            FirestoreDb = FirestoreDb.Create(projectId: projectId);
+            Console.WriteLine($"Created Cloud Firestore client with project ID: {project}");
+        }
+
+        /// <summary>
+        /// The InitShardsCounter
+        /// </summary>
+        /// <param name="numShards">The numShards<see cref="int"/></param>
+        public static void InitShardsCounter(int numShards)
+        {
+            // Initialize whole global count of shards
+            // in ShardsCounter property 
+            ShardsCounter = new Counter
+            {
+                NumShards = numShards
+            };
+        }
+
+        // [START fs_create_counter]
+
+        /// <summary>
+        /// The InitCounterAsync creates a given number of shards as
+        /// sub collection of specified document.
+        /// </summary>
+        /// <param name="docRef">The docRef<see cref="DocumentReference"/></param>
+        /// <returns>The <see cref="Task"/></returns>
+        public static async Task InitCounterAsync(DocumentReference docRef)
+        {
+            CollectionReference colRef = docRef.Collection("shards");
+
+            // Initialize each shard with count=0
+            for (var i = 0; i < ShardsCounter.NumShards; i++)
+            {
+                await colRef.Document(i.ToString()).SetAsync(new Shard { Count = 0 });
+            }
+        }
+
+        // [END fs_create_counter]
+
+        // [START fs_increment_counter]
+
+        /// <summary>
+        /// The IncrementCounterAsync increments a randomly picked shard.
+        /// </summary>
+        /// <param name="docRef">The docRef<see cref="DocumentReference"/></param>
+        /// <returns>The <see cref="Task"/></returns>
+        public static async Task IncrementCounterAsync(DocumentReference docRef)
+        {
+            var rand = new Random();
+            var docId = rand.Next(0, ShardsCounter.NumShards);
+            var shardRef = docRef.Collection("shards").Document(docId.ToString());
+            await shardRef.UpdateAsync("Count", FieldValue.Increment(1));
+        }
+
+        // [END fs_increment_counter]
+
+        // [START fs_get_count]
+
+        /// <summary>
+        /// The GetCount returns a total count across all shards.
+        /// </summary>
+        /// <param name="docRef">The docRef<see cref="DocumentReference"/></param>
+        /// <returns>The <see cref="int"/></returns>
+        public static int GetCount(DocumentReference docRef)
+        {
+            var snapshotList = docRef.Collection("shards").GetSnapshotAsync().Result;
+            return snapshotList.Sum(snap => snap.GetValue<int>("Count"));
+        }
+        // [END fs_get_count]
+
+        private static void RunCodeSample(string project)
+        {
+            InitFirestoreDb(project);
+            InitShardsCounter(5);
+
+            var docRef = FirestoreDb.Collection("counter_samples").Document("DCounter");
+
+            Console.WriteLine("Application start ...");
+            InitCounterAsync(docRef);
+            Console.WriteLine("Distributed counter initialized.");
+
+            IncrementCounterAsync(docRef);
+            Console.WriteLine("Distributed counter incremented.");
+
+            var countTotal = GetCount(docRef);
+
+            Console.WriteLine($"Total count: {countTotal}");
+            Console.WriteLine("Application stopped ...");
+        }
+
+        /// <summary>
+        /// The Main
+        /// </summary>
+        /// <param name="args">The args<see cref="string[]"/></param>
+        public static void Main(string[] args)
+        {
+            if (args.Length < 2)
+            {
+                Console.Write(Usage);
+                return;
+            }
+            string command = args[0].ToLower();
+            string project = string.Join(" ",
+                new ArraySegment<string>(args, 1, args.Length - 1));
+            switch (command)
+            {
+                case "run-distributed-counter":
+                    RunCodeSample(project);
+                    break;
+
+                default:
+                    Console.Write(Usage);
+                    return;
+            }
+        }
+    }
+}

--- a/firestore/api/SolutionCounter/Program.cs
+++ b/firestore/api/SolutionCounter/Program.cs
@@ -30,8 +30,8 @@ namespace GoogleCloudSamples
     /// </summary>
     public class DistributedCounter
     {
-        private static Random s_rand = new Random();
-        private static object s_randLock = new object();
+        private static readonly Random s_rand = new Random();
+        private static readonly object s_randLock = new object();
         private const string Usage = @"Usage:
 C:\> dotnet run command YOUR_PROJECT_ID
 

--- a/firestore/api/SolutionCounter/Program.cs
+++ b/firestore/api/SolutionCounter/Program.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2019 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -64,7 +64,7 @@ namespace GoogleCloudSamples
     /// Defines the <see cref="DistributedCounter" />
     /// </summary>
     public class DistributedCounter
-    { 
+    {
         public static string Usage = @"Usage:
 C:\> dotnet run command YOUR_PROJECT_ID
 

--- a/firestore/api/SolutionCounter/Program.cs
+++ b/firestore/api/SolutionCounter/Program.cs
@@ -56,7 +56,6 @@ Where command is one of
         /// subcollection of specified document.
         /// </summary>
         /// <param name="docRef">The document reference <see cref="DocumentReference"/></param>
-        /// <returns>The <see cref="Task"/></returns>
         private static async Task CreateCounterAsync(DocumentReference docRef, int numOfShards)
         {
             CollectionReference colRef = docRef.Collection("shards");
@@ -118,10 +117,10 @@ Where command is one of
                     const int numberOfShards = 5;
                     var docRef = db.Collection("counter_samples").Document("DCounter");
 
-                    CreateCounterAsync(docRef, numberOfShards).Wait();
+                    Task.Run(() => CreateCounterAsync(docRef, numberOfShards)).WaitWithUnwrappedExceptions();
                     Console.WriteLine("Distributed counter created.");
 
-                    IncrementCounterAsync(docRef, numberOfShards).Wait();
+                    Task.Run(() => IncrementCounterAsync(docRef, numberOfShards)).WaitWithUnwrappedExceptions();
                     Console.WriteLine("Distributed counter incremented.");
 
                     var countTotal = Task.Run(() => GetCountAsync(docRef)).ResultWithUnwrappedExceptions();

--- a/firestore/api/SolutionCounter/Program.cs
+++ b/firestore/api/SolutionCounter/Program.cs
@@ -168,10 +168,10 @@ Where command is one of
             var docRef = FirestoreDb.Collection("counter_samples").Document("DCounter");
 
             Console.WriteLine("Application start ...");
-            InitCounterAsync(docRef);
+            InitCounterAsync(docRef).Wait();
             Console.WriteLine("Distributed counter initialized.");
 
-            IncrementCounterAsync(docRef);
+            IncrementCounterAsync(docRef).Wait();
             Console.WriteLine("Distributed counter incremented.");
 
             var countTotal = GetCount(docRef);

--- a/firestore/api/SolutionCounter/SolutionCounter.csproj
+++ b/firestore/api/SolutionCounter/SolutionCounter.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <StartupObject>GoogleCloudSamples.DistributedCounter</StartupObject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.3.0" />
+    <PackageReference Include="Google.Cloud.Firestore" Version="1.0.0" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Previously made samples for [Go](https://github.com/GoogleCloudPlatform/golang-samples/pull/959) and [Python](https://github.com/GoogleCloudPlatform/python-docs-samples/pull/2412) are already merged and posted to Distributed Counters page, so, as promised, I'm pushing similar samples for C#.