### PR TITLE
Adds explicit authentication with JSON credentials to BQ snippets

### DIFF
--- a/bigquery/api/Snippets/AuthenticateServiceAccount.cs
+++ b/bigquery/api/Snippets/AuthenticateServiceAccount.cs
@@ -1,0 +1,32 @@
+﻿using Google.Apis.Auth.OAuth2;
+using Google.Cloud.BigQuery.V2;
+using System;
+
+public class BigQueryAuthenticateServiceAccount
+{
+    public void AuthenticateWithServiceAccount(string projectId,
+                                               string jsonPath)
+    {
+        // [START bigquery_client_json_credentials]
+        var credentials = GoogleCredential.FromFile(jsonPath);
+        var client = BigQueryClient.Create(projectId, credentials);
+        // [END bigquery_client_json_credentials]
+
+        // Use the client
+        string query = @"
+            SELECT name FROM `bigquery-public-data.usa_names.usa_1910_2013`
+            WHERE state = 'TX'
+            LIMIT 100";
+        BigQueryJob job = client.CreateQueryJob(
+            sql: query,
+            parameters: null,
+            options: new QueryOptions { UseQueryCache = false });
+        // Wait for the job to complete.
+        job = job.PollUntilCompleted().ThrowOnAnyError();
+        // Display the results
+        foreach (BigQueryRow row in client.GetQueryResults(job.Reference))
+        {
+            Console.WriteLine($"{row["name"]}");
+        }
+    }
+}

--- a/bigquery/api/Snippets/AuthenticateServiceAccount.cs
+++ b/bigquery/api/Snippets/AuthenticateServiceAccount.cs
@@ -1,4 +1,18 @@
-﻿using Google.Apis.Auth.OAuth2;
+﻿// Copyright(c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+//
+using Google.Apis.Auth.OAuth2;
 using Google.Cloud.BigQuery.V2;
 using System;
 

--- a/bigquery/api/Snippets/AuthenticateServiceAccount.cs
+++ b/bigquery/api/Snippets/AuthenticateServiceAccount.cs
@@ -12,6 +12,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 //
+
 using Google.Apis.Auth.OAuth2;
 using Google.Cloud.BigQuery.V2;
 using System;
@@ -28,7 +29,8 @@ public class BigQueryAuthenticateServiceAccount
 
         // Use the client
         string query = @"
-            SELECT name FROM `bigquery-public-data.usa_names.usa_1910_2013`
+            SELECT name
+            FROM `bigquery-public-data.usa_names.usa_1910_2013`
             WHERE state = 'TX'
             LIMIT 100";
         BigQueryJob job = client.CreateQueryJob(

--- a/bigquery/api/Snippets/Snippets.csproj
+++ b/bigquery/api/Snippets/Snippets.csproj
@@ -14,6 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Google.Apis.Auth" Version="1.43.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/bigquery/api/Snippets/Test.cs
+++ b/bigquery/api/Snippets/Test.cs
@@ -51,7 +51,7 @@ public class BigQueryTest : IDisposable, IClassFixture<RandomBucketFixture>
     {
         var snippet = new BigQueryAuthenticateServiceAccount();
         snippet.AuthenticateWithServiceAccount(_projectId, _jsonPath);
-        var outputLines = _stringOut.ToString().Trim().Split(new[] { '\n' });
+        var outputLines = _stringOut.ToString().Trim().Split(Environment.NewLine);
         Assert.Equal(100, outputLines.Count());
     }
 
@@ -60,7 +60,7 @@ public class BigQueryTest : IDisposable, IClassFixture<RandomBucketFixture>
     {
         var snippet = new BigQueryBrowseTable();
         snippet.BrowseTable(_projectId);
-        var outputLines = _stringOut.ToString().Trim().Split(new[] { '\n' });
+        var outputLines = _stringOut.ToString().Trim().Split(Environment.NewLine);
         Assert.Equal(10, outputLines.Count());
     }
 
@@ -227,7 +227,7 @@ public class BigQueryTest : IDisposable, IClassFixture<RandomBucketFixture>
     {
         var snippet = new BigQueryQuery();
         snippet.Query(_projectId);
-        var outputLines = _stringOut.ToString().Trim().Split(new[] { '\n' });
+        var outputLines = _stringOut.ToString().Trim().Split(Environment.NewLine);
         Assert.Equal(100, outputLines.Count());
     }
 
@@ -236,7 +236,7 @@ public class BigQueryTest : IDisposable, IClassFixture<RandomBucketFixture>
     {
         var snippet = new BigQueryQueryLegacy();
         snippet.QueryLegacy(_projectId);
-        var outputLines = _stringOut.ToString().Trim().Split(new[] { '\n' });
+        var outputLines = _stringOut.ToString().Trim().Split(Environment.NewLine);
         Assert.Equal(100, outputLines.Count());
     }
 

--- a/bigquery/api/Snippets/Test.cs
+++ b/bigquery/api/Snippets/Test.cs
@@ -27,6 +27,7 @@ using System.Linq;
 public class BigQueryTest : IDisposable, IClassFixture<RandomBucketFixture>
 {
     private readonly string _projectId;
+    private readonly string _jsonPath;
     private readonly BigQueryClient _client;
     readonly List<BigQueryDataset> _tempDatasets = new List<BigQueryDataset>();
     readonly StorageClient _storage;
@@ -37,11 +38,21 @@ public class BigQueryTest : IDisposable, IClassFixture<RandomBucketFixture>
     public BigQueryTest(RandomBucketFixture randomBucketFixture)
     {
         _projectId = Environment.GetEnvironmentVariable("GOOGLE_PROJECT_ID");
+        _jsonPath = System.Environment.GetEnvironmentVariable("GOOGLE_APPLICATION_CREDENTIALS");
         _client = BigQueryClient.Create(_projectId);
         _storage = StorageClient.Create();
         _bucketName = randomBucketFixture.BucketName;
         _stringOut = new StringWriter();
         Console.SetOut(_stringOut);
+    }
+
+    [Fact]
+    public void TestAuthenticateServiceAccount()
+    {
+        var snippet = new BigQueryAuthenticateServiceAccount();
+        snippet.AuthenticateWithServiceAccount(_projectId, _jsonPath);
+        var outputLines = _stringOut.ToString().Trim().Split(new[] { '\n' });
+        Assert.Equal(100, outputLines.Count());
     }
 
     [Fact]


### PR DESCRIPTION
This pull request adds the following region tag:
- bigquery_client_json_credentials

The Python canonical is here:
https://github.com/GoogleCloudPlatform/python-docs-samples/blob/1a87fb3e076d60ec6bde274c9aecf7dc5296a43b/bigquery/cloud-client/authenticate_service_account.py