### PR TITLE
[Dialogflow]: Cleanup after some tests so as to not use up quota.

### DIFF
--- a/dialogflow/api/Test/DetectIntentTextsTest.cs
+++ b/dialogflow/api/Test/DetectIntentTextsTest.cs
@@ -12,14 +12,13 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-using System;
 using Xunit;
 
 namespace GoogleCloudSamples
 {
     public class DetectIntentTextsTest : DialogflowTest
     {
-        [Fact(Skip = "b/110877421")]
+        [Fact(Skip = "https://github.com/GoogleCloudPlatform/dotnet-docs-samples/issues/935")]
         void TestDetectIntentFromTexts()
         {
             var texts = new[] { "hello", "book a meeting room", "Mountain View" };

--- a/dialogflow/api/Test/DialogflowTest.cs
+++ b/dialogflow/api/Test/DialogflowTest.cs
@@ -13,14 +13,12 @@
 // the License.
 
 using System;
-using System.Linq;
-using System.Collections.Generic;
-using System.Text.RegularExpressions;
-using Xunit;
 using System.Collections.Concurrent;
-using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
-using System.Diagnostics;
+using System.Threading.Tasks;
 
 namespace GoogleCloudSamples
 {
@@ -64,12 +62,21 @@ namespace GoogleCloudSamples
             if (string.IsNullOrEmpty(displayName))
                 displayName = TestUtil.RandomName();
             Run("entity-types:create", displayName, kindName);
-            var outputPattern = new Regex(
-                $"Created EntityType: projects/{ProjectId}/agent/entityTypes/(?<entityTypeId>.*)"
-            );
-            string id = outputPattern.Match(Stdout).Groups["entityTypeId"].Value;
-            CleanupAfterTest("entities:delete", id);
+
+            return SetEntityTypeForCleanupAfterTest(Stdout);
+        }
+
+        public string SetEntityTypeForCleanupAfterTest(string stdout)
+        {
+            string id = GetEntityTypeIdFromStdout(stdout);
+            CleanupAfterTest("entity-types:delete", id);
             return id;
+        }
+
+        public string GetEntityTypeIdFromStdout(string stdout)
+        {
+            var outputPattern = new Regex($"Created EntityType: projects/{ProjectId}/agent/entityTypes/(?<entityTypeId>.*)");
+            return outputPattern.Match(stdout).Groups["entityTypeId"].Value;
         }
 
         public readonly CommandLineRunner _dialogflow = new CommandLineRunner()

--- a/dialogflow/api/Test/EntityTypeManagementTests.cs
+++ b/dialogflow/api/Test/EntityTypeManagementTests.cs
@@ -12,7 +12,6 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-using System;
 using Xunit;
 
 namespace GoogleCloudSamples
@@ -30,6 +29,8 @@ namespace GoogleCloudSamples
 
             Run("entity-types:create", _displayName, _kindName);
             Assert.Contains("Created EntityType:", Stdout);
+
+            SetEntityTypeForCleanupAfterTest(Stdout);
 
             _retryRobot.Eventually(() =>
             {
@@ -54,6 +55,7 @@ namespace GoogleCloudSamples
             Run("entity-types:delete", entityTypeId);
             Assert.Contains($"Deleted EntityType: {entityTypeId}", Stdout);
 
+            _retryRobot.MaxTryCount = _retryRobot.MaxTryCount * 2;
             _retryRobot.Eventually(() =>
             {
                 Run("entity-types:list");

--- a/dialogflow/api/Test/SessionEntityTypeManagementTests.cs
+++ b/dialogflow/api/Test/SessionEntityTypeManagementTests.cs
@@ -12,7 +12,6 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-using System;
 using Xunit;
 
 namespace GoogleCloudSamples
@@ -41,10 +40,12 @@ namespace GoogleCloudSamples
             Assert.Contains(_entityTypeDisplayName, Stdout);
 
             _retryRobot.Eventually(() =>
-           {
-               RunWithSessionId("session-entity-types:list");
-               Assert.Contains(_entityTypeDisplayName, Stdout);
-           });
+            {
+                RunWithSessionId("session-entity-types:list");
+                Assert.Contains(_entityTypeDisplayName, Stdout);
+            });
+
+            CleanupAfterTest(() => RunWithSessionId("session-entity-types:delete", _entityTypeDisplayName));
         }
 
         [Fact]

--- a/dialogflow/api/Test/runTests.ps1
+++ b/dialogflow/api/Test/runTests.ps1
@@ -17,5 +17,4 @@ Set-TestTimeout 1800
 
 dotnet restore
 dotnet build
-# TODO: Fix bug 110877421.
-# dotnet test --test-adapter-path:. --logger:junit --no-build --no-restore -v n
+dotnet test --test-adapter-path:. --logger:junit --no-build --no-restore -v n


### PR DESCRIPTION
Dialogflow tests have been off for a while because they were failing because they had reached quota in entity and intent they could create.
All tests now clean up after themselves.
Still one test is off because it is failing, see #935 .