### PR TITLE
Specifies UTF-8 encoding for output of Translation response 

### DIFF
--- a/translate/api/QuickStart/Program.cs
+++ b/translate/api/QuickStart/Program.cs
@@ -21,7 +21,7 @@ public class QuickStart
 {
     public static void Main(string[] args)
     {
-        Console.OutputEncoding = System.Text.Encoding.Unicode;
+        Console.OutputEncoding = System.Text.Encoding.UTF8;
         TranslationClient client = TranslationClient.Create();
         var response = client.TranslateText("Hello World.", "ru");
         Console.WriteLine(response.TranslatedText);

--- a/translate/api/Snippets/TranslateText.cs
+++ b/translate/api/Snippets/TranslateText.cs
@@ -21,6 +21,7 @@ public partial class TranslateSample
 {
     public string TranslateText()
     {
+        Console.OutputEncoding = System.Text.Encoding.UTF8;
         TranslationClient client = TranslationClient.Create();
         var response = client.TranslateText(
             text: "Hello World.",


### PR DESCRIPTION
This updates two code samples:

- [START translate_translate_text]
- [START translate_quickstart]

This change allows the console to output non Latin characters (e.g. Cyrillic, Chinese, Greek).