### PR TITLE
Changed scripts to use Alias IP ranges

### DIFF
--- a/compute/sqlserver/powershell/README.md
+++ b/compute/sqlserver/powershell/README.md
@@ -1,21 +1,20 @@
-# PowerShell examples for SQL Server
+## Creating a SQL Server Availability Group in GCP using Alias IP Ranges
 
-In this folder you will find some examples on how to use PowerShell to manage SQL Server in Google Cloud Platform (GCP)
+The following PowerShell scripts will help you setup a SQL Server Availability Group using [Alias IP Ranges](https://cloud.google.com/compute/docs/alias-ip/) in GCP. Alias IP lets you assign additional IPs to a instance. To create an Availability Group we need two extra IPs per node (one for the Windows Failover Cluster and another for the Listener). 
 
-## Creating a SQL Server Availability Group
 
-The following PowerShell scripts will help you setup a SQL Server Availability Group. 
-
+Below is a description of every script
   * [parameters-config.ps1](parameters-config.ps1) - Specify the parameters that are used by the other scripts.
   * [create-sql-instance-availability-group.ps1](create-sql-instance-availability-group.ps1) - **Usually this is the only script that needs to be run**. It does the following steps:
       1. Creates two SQL Server instances
       2. Adds the two instances to a Windows AD domain
       3. Creates a Windows Server Failover Cluster (WSFC)
       4. Creates a SQL Server Availability Group
-  * [create-availability-group.ps1](create-availability-group.ps1) - Script to create the Availability Group. It is called by the script *create-sql-instance-availability-group.ps1*.
+  * [create-availability-group.ps1](create-availability-group.ps1) - Create the Availability Group. It is called by *create-sql-instance-availability-group.ps1*.
   * [create-sql-instance-availability-group-prerequisites.ps1](create-sql-instance-availability-group-prerequisites.ps1) - (Optional) Set up the pre-requisites needed to create an Availability Group:
      1. Creates a Custom Network in GCP
      2. Creates firewall rules for WinRM and RDP
      3. Creates a Windows AD domain with one domain controller
-  * [create-sql-instance-availability-group-cleanup.ps1](create-sql-instance-availability-group-cleanup.ps1) - (Optional) Delete the SQL Server instances, the domain controller and the custom network. *WARNING: Use with caution. Use in cases where you are just testing the scripts*.
+  * [create-sql-instance-availability-group-cleanup.ps1](create-sql-instance-availability-group-cleanup.ps1) - (Optional) Delete the SQL Server instances, the domain controller and the custom network. *WARNING: Use with caution. Used in cases where you are just testing the scripts*.
   * [create-sql-instance-availability-group.Tests.ps1](create-sql-instance-availability-group.Tests.ps1) - (Optional) Use Pester to unit test the scripts.
+  * [validate-availability-group.ps1](validate-availability-group.ps1) - (Optional) Validate that the Availability Group is working.

--- a/compute/sqlserver/powershell/create-sql-instance-availability-group.Tests.ps1
+++ b/compute/sqlserver/powershell/create-sql-instance-availability-group.Tests.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright(c) 2016 Google Inc.
+﻿# Copyright(c) 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -11,20 +11,48 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under
 # the License.
-
+#
 # Tests for the create-sql-instance-availabilit y-group.ps1 script
-# Requirements: The Pester module must be installed in the computer
-# Install-Module Pester
-
-# Find the name of the source PowerShell script that we want to test
-$path = Split-Path -Parent $MyInvocation.MyCommand.Path
-$src_file = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.", ".")
+# Requirements: 
+#  The Pester module must be installed in the computer (Install-Module Pester)
+#
+######################################################################################
+# IMPORTANT: 
+# Before you test the scripts make sure you understand the pre-requisites to create
+# a SQL Server Availability Group:
+#
+#   1) A Windows AD Domain and Domain Controller
+#   2) A VPC network with two subnets, one for each SQL Server instance
+#
+# For automated testing we need to assign a password to the variable $domain_pwd,
+# which is the password for an account that can add computers to the domain. This
+# can be done by modifying the file parameters-config.ps1 or assigning a value to
+# the $domain_pwd variable. We assume is the (domain\Admistrator) but it can be
+# changed in the "parameters-config.ps1" file.
+#
+# Take a look at "create-sql-instance-availability-group-prerequisites.ps1" for an
+# example of creating the pre-requisites. Also check "parameters-config.ps1" for the 
+# default parameters.
+######################################################################################
 
 $ErrorActionPreference = 'Stop'
 Set-Location $PSScriptRoot
 
-# Run the source PowerShell script
-. "$path\$src_file"
+# Find the path of this script
+$path = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+
+# Generate a random password for the domain administrator
+# If using an existing AD Domain you will need to change this instruction
+$domain_pwd = -join(33..122 | %{[char]$_} | Get-Random -C 36)
+
+# Run the PowerShell script that creates the pre-requisites
+# If using an existing AD Domain you can comment this section
+. "$path\create-sql-instance-availability-group-prerequisites.ps1"
+
+# Run the PowerShell script that creates the Availability Group
+. "$path\create-sql-instance-availability-group.ps1"
+
 
 ## Run tests to verify that the PowerShell script ran succesfully
 Write-Host "$(Get-Date) Testing that Availability Group was created succesfully"
@@ -32,21 +60,15 @@ Write-Host "$(Get-Date) Testing that Availability Group was created succesfully"
 ## Validate that the Availability Group was created
 Describe "Availability-Group-Created" {
   It "Availability Group has two nodes that are synchronized" {
+    
+    $session_options = New-PSSessionOption -SkipCACheck -SkipCNCheck `
+      -SkipRevocationCheck
 
-    # Run the Cmdlet to test the Availability Group
-    $results = Invoke-Command -ComputerName $node1 -Credential $cred -ScriptBlock {
-      param($node1, $name_ag)
-
-      Test-SqlAvailabilityGroup `
-        -Path "SQLSERVER:\SQL\$($node1)\DEFAULT\AvailabilityGroups\$($name_ag)"
-    } -ArgumentList $node1, $name_ag
-
-    # TEST: Should have two nodes and they should be in a "Synchronized" state
-    [string]$results[0].HealthState | Should Match "Healthy"
-
-
-    # Use SMO instead of PowerShell Cmdlet to query the DatabaseReplicaStates
-    $results = Invoke-Command -ComputerName $node1 -Credential $cred -ScriptBlock {
+    # Use SMO to query the DatabaseReplicaStates
+    $results = Invoke-Command -ComputerName $ip_address1 -UseSSL `
+      -Credential $cred -SessionOption $session_options `
+      -ScriptBlock {
+      
       param($name_ag)
 
       [System.Reflection.Assembly]::LoadWithPartialName("Microsoft.SqlServer.Smo") | 
@@ -75,9 +97,12 @@ Describe "Availability-Group-can-switch-nodes" {
   It "Availability Group can switch nodes" {
 
     # Connect to Listener and return @@SERVERNAME. Should match Node 1.
-    $results = Invoke-Command -ComputerName $node1 -Credential $cred `
+    $results = Invoke-Command -ComputerName $ip_address1 -UseSSL `
+      -Credential $cred -SessionOption $session_options `
       -ScriptBlock { 
       param($name_ag_listener)
+
+      Import-Module SQLPS -DisableNameChecking
 
       Invoke-Sqlcmd `
         -Query "SELECT ServerName = @@SERVERNAME" `
@@ -88,7 +113,9 @@ Describe "Availability-Group-can-switch-nodes" {
     [string]$results[0].ServerName | Should Match $node1
 
     # Switch to Node 2
-    Invoke-Command -ComputerName $node2 -Credential $cred -ScriptBlock {
+    Invoke-Command -ComputerName $ip_address2 -UseSSL `
+      -Credential $cred -SessionOption $session_options `
+      -ScriptBlock {
       param($node2, $name_ag)
 
       Switch-SqlAvailabilityGroup `
@@ -99,7 +126,9 @@ Describe "Availability-Group-can-switch-nodes" {
 
 
     # Connect to Listener and return @@SERVERNAME. Should match Node 2.
-    $results = Invoke-Command -ComputerName $node2 -Credential $cred -ScriptBlock {
+    $results = Invoke-Command -ComputerName $ip_address2 -UseSSL `
+      -Credential $cred -SessionOption $session_options `
+      -ScriptBlock {
       param($name_ag_listener)
 
       Invoke-Sqlcmd `
@@ -111,7 +140,9 @@ Describe "Availability-Group-can-switch-nodes" {
     [string]$results[0].ServerName | Should Match $node2
 
     # Switch to Node 1 again
-    Invoke-Command -ComputerName $node1 -Credential $cred -ScriptBlock {
+    Invoke-Command -ComputerName $ip_address1 -UseSSL `
+      -Credential $cred -SessionOption $session_options `
+      -ScriptBlock {
       param($node1, $name_ag)
 
       Switch-SqlAvailabilityGroup `

--- a/compute/sqlserver/powershell/parameters-config.ps1
+++ b/compute/sqlserver/powershell/parameters-config.ps1
@@ -1,5 +1,5 @@
 ﻿#Requires -Version 5
-# Copyright(c) 2016 Google Inc.
+# Copyright(c) 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -26,7 +26,8 @@
 #.NOTES
 # AUTHOR: Anibal Santiago - @SQLThinker
 ##############################################################################
-
+cls
+Set-Location $PSScriptRoot
 
 #####################################################################################
 # We assume you have created a network in Google Cloud called wsfcnet
@@ -34,33 +35,39 @@
 #####################################################################################
 $force_delete   = $False                 # If $True delete the nodes if they exist
 
-# Node and subNet parameters
+# Node and subnet parameters
 $node1          = 'cluster-sql1'         # Name of node 1
 $node2          = 'cluster-sql2'         # Name of node 2
-$ip_node1       = '10.0.0.4'             # IP address of node 1
-$ip_node2       = '10.1.0.4'             # IP address of node 2
 $network        = 'wsfcnet'              # Name of the Custom network in GCP. Must already be created in Google Cloud
-$subnet1_name   = 'wsfcsubnet1'          # Name of SubNet 1. Must already be created in Google Cloud. (Ex. 10.0.0.0/24)
-$subnet2_name   = 'wsfcsubnet2'          # Name of SubNet 2. Must already be created in Google Cloud. (Ex. 10.1.0.0/24)
+$subnet1_name   = 'wsfcsubnet1'          # Name of Subnet 1. Must already be created in Google Cloud. (Ex. 10.0.0.0/16)
+$subnet2_name   = 'wsfcsubnet2'          # Name of Subnet 2. Must already be created in Google Cloud. (Ex. 10.1.0.0/16)
 $size_gb        = '200'                  # Size in GB for the boot disk of the nodes
-$netmask        = 16                     # Netmask for Windows nodes. Has to be broader than the GCP netmask.
-                                         # For example wsfcsubnet1/wsfcsubnet2 are /24 so Windows netmask is /16
+$disk_type      = 'pd-standard'          # Type of disk: pd-ssd (recommended) or pd-standard (only option in free trial account)
+
 # Windows Cluster parameters
 $name_wsfc       = 'cluster-dbclus'      # Name for the Windows Failover Cluster (WSFC)
-$ip_wsfc1        = '10.0.1.4'            # IP address of WSFC in SubNet 1 (must be outside the range $subnet1_name)
-$ip_ag_listener1 = '10.0.1.5'            # IP address of Availability Group listener in SubNet 1 (must be outside the range of $subnet1_name)
-$ip_wsfc2        = '10.1.1.4'            # IP address of WSFC in SubNet 2 (must be outside the range $subnet2_name)
-$ip_ag_listener2 = '10.1.1.5'            # IP address of Availability Group listener in SubNet 2 (must be outside the range of $subnet2_name)
+
+$ip_node1        = '10.0.0.4'            # IP address of node 1 in Subnet 1
+$ip_wsfc1        = '10.0.0.5'            # IP address of WSFC in Subnet 1        (choose from $ip_alias1 address range)
+$ip_ag_listener1 = '10.0.0.6'            # IP address of AG listener in Subnet 1 (choose from $ip_alias1 address range)
+
+$ip_node2        = '10.1.0.4'            # IP address of node 2 in Subnet 2
+$ip_wsfc2        = '10.1.0.5'            # IP address of WSFC in Subnet 2        (choose from $ip_alias2 address range)
+$ip_ag_listener2 = '10.1.0.6'            # IP address of AG listener in Subnet 2 (choose from $ip_alias2 address range)
+
 $name_ag         = 'cluster-ag'          # Name of the SQL Server Availability Group
-$name_ag_listener= 'cluster-listene'     # Name of the SQL Server Availability Group Listener (15 characters maximum)
+$name_ag_listener= 'ag-listener'         # Name of the SQL Server Availability Group Listener (15 characters maximum)
+
 
 # Domain/user parameters
 $config_user     = 'Config.User'          # Local user to create in the instance. It will be used for the initial remote connection.
 $ip_domain_cntr  = '10.2.0.100'           # IP address of the Windows Domain controller. This will be used as the local DNS server.
+$domain_cntr     = 'dc-windows'           # Hostname of the domain controller. Will be used when creating a shared folder for Quorum.
 $domain          = 'dbeng.com'            # Name of the Windows Active Directory domain
 $domain_netbios  = 'dbeng'                # Name of the Windows Active Directory domain in Netbios (15 characters max)
 $domain_cred     = 'dbeng\Administrator'  # Account to use to add computers into the domain
-$domain_pwd      =  $null #'MyPassword'    # Password for the $domain_cred account. Type $null to prompt for a password.
+#$domain_pwd      = 'MyPassword'          # Password for the $domain_cred account. Leave commented to prompt the user for a password.
+
 
 # Database parameters
 $db_name        = 'TestDB'               # Name of the database to create
@@ -74,55 +81,67 @@ $log_size       = 1024                   # Initial size of the transaction log i
 $log_growth     = 256                    # Auto growth size of the transaction log in MB
 
 
-# Image Project for SQL Server images (windows-sql-cloud)
-# If you are installing SQL Server by yourself, then choose a project with Windows Server 2012 (windows-cloud)
-$image_project = `
-   'windows-sql-cloud'
-  # 'windows-cloud'
-
 # Image Family for the instance. Uncomment only one of the variables below
-# Check the command: gcloud compute images list --filter="PROJECT:windows-cloud" or gcloud compute images list --filter="PROJECT:windows-sql-cloud"
-$image_family = `
-  # 'sql-ent-2012-win-2012-r2'   # SQL Server 2012 Enterprise Edition on Windows Server 2012 R2
-  # 'sql-std-2012-win-2012-r2'   # SQL Server 2012 Standard Edition on Windows Server 2012 R2
-  # 'sql-web-2012-win-2012-r2'   # SQL Server 2012 Web Edition on Windows Server 2012 R2
-  # 'sql-ent-2014-win-2012-r2'   # SQL Server 2014 Enterprise Edition on Windows Server 2012 R2
-  # 'sql-std-2014-win-2012-r2'   # SQL Server 2014 Standard Edition on Windows Server 2012 R2
-  # 'sql-web-2014-win-2012-r2'   # SQL Server 2014 Web Edition on Windows Server 2012 R2
-  # 'sql-ent-2016-win-2012-r2'   # SQL Server 2016 Enterprise Edition on Windows Server 2012 R2
-   'sql-ent-2016-win-2016'      # SQL Server 2016 Enterprise Edition on Windows Server 2016 
-  # 'sql-exp-2016-win-2012-r2'   # SQL Server 2016 Express Edition on Windows Server 2012 R2
-  # 'sql-exp-2016-win-2016'      # SQL Server 2016 Express Edition on Windows Server 2016
-  # 'sql-std-2016-win-2012-r2'   # SQL Server 2016 Standard Edition on Windows Server 2012 R2
-  # 'sql-std-2016-win-2016'      # SQL Server 2016 Standard Edition on Windows Server 2016
-  # 'sql-web-2016-win-2012-r2'   # SQL Server 2016 Web Edition on Windows Server 2012 R2
-  # 'sql-web-2016-win-2016'      # SQL Server 2016 Web Edition on Windows Server 2016
-  # 'windows-2012-r2'            # Windows Server 2012 R2 (without SQL Server)
-  # 'windows-2016'               # Windows Server 2016 (without SQL Server) 
+# Check the command: gcloud compute images list --format='table(family)' | findstr sql
+$image_family = 'sql-std-2017-win-2019'
+  # 'sql-ent-2012-win-2012-r2'
+  # 'sql-std-2012-win-2012-r2'
+  # 'sql-web-2012-win-2012-r2'
+  # 'sql-ent-2014-win-2012-r2'
+  # 'sql-ent-2014-win-2016'
+  # 'sql-std-2014-win-2012-r2'
+  # 'sql-web-2014-win-2012-r2'
+  # 'sql-ent-2016-win-2012-r2'
+  # 'sql-ent-2016-win-2016'
+  # 'sql-ent-2016-win-2019'
+  # 'sql-std-2016-win-2012-r2'
+  # 'sql-std-2016-win-2016'
+  # 'sql-std-2016-win-2019'
+  # 'sql-web-2016-win-2012-r2'
+  # 'sql-web-2016-win-2016'
+  # 'sql-web-2016-win-2019'
+  # 'sql-ent-2017-win-2016'
+  # 'sql-ent-2017-win-2019'
+  # 'sql-exp-2017-win-2012-r2'
+  # 'sql-exp-2017-win-2016'
+  # 'sql-exp-2017-win-2019'
+  # 'sql-std-2017-win-2016'
+  # 'sql-std-2017-win-2019'
+  # 'sql-web-2017-win-2016'
+  # 'sql-web-2017-win-2019'
 
 
 # Machine Type. Uncomment only one of the variables below.
-# Check the command: gcloud compute machine-types list --filter="ZONE:us-central1-f"
-$machine_type = `
-  # 'f1-micro'        # 1 vCPU, 0.6 GB RAM
-  # 'g1-small'        # 1 vCPU, 1.7 GB RAM
-  # 'n1-highcpu-2'    # 2 vCPUs, 1.8 GB RAM
-  # 'n1-highcpu-4'    # 4 vCPUs, 3.6 GB RAM
-  # 'n1-highcpu-8'    # 8 vCPUs, 7.2 GB RAM
-  # 'n1-highcpu-16'   # 16 vCPUs, 14.4 GB RAM
-  # 'n1-highmem-2'    # 2 vCPUs, 13 GB RAM
-  'n1-highmem-4'    # 4 vCPUs, 26 GB RAM
-  # 'n1-highmem-8'    # 8 vCPUs, 52 GB RAM
-  # 'n1-highmem-16'   # 16 vCPUs, 104 GB RAM
-  # 'n1-standard-1'   # 1 vCPU, 3.75 GB RAM
-  # 'n1-standard-2'   # 2 vCPUs, 7.5 GB RAM
-  # 'n1-standard-4'   # 4 vCPUs, 15 GB RAM
-  # 'n1-standard-8'   # 8 vCPUs, 30 GB RAM
-  # 'n1-standard-16'  # 16 vCPUs, 60 GB RAM
+# Check the command: gcloud compute machine-types list --filter="ZONE:us-central1-f" --format='table(name, description)'
+$machine_type = 'n1-standard-4'
+  # 'f1-micro'       # 1 vCPU (shared physical core) and 0.6 GB RAM
+  # 'g1-small'       # 1 vCPU (shared physical core) and 1.7 GB RAM
+  # 'n1-highcpu-16'  # 16 vCPUs, 14.4 GB RAM
+  # 'n1-highcpu-2'   # 2 vCPUs, 1.8 GB RAM
+  # 'n1-highcpu-32'  # 32 vCPUs, 28.8 GB RAM
+  # 'n1-highcpu-4'   # 4 vCPUs, 3.6 GB RAM
+  # 'n1-highcpu-64'  # 64 vCPUs, 57.6 GB RAM
+  # 'n1-highcpu-8'   # 8 vCPUs, 7.2 GB RAM
+  # 'n1-highcpu-96'  # 96 vCPUs, 86 GB RAM
+  # 'n1-highmem-16'  # 16 vCPUs, 104 GB RAM
+  # 'n1-highmem-2'   # 2 vCPUs, 13 GB RAM
+  # 'n1-highmem-32'  # 32 vCPUs, 208 GB RAM
+  # 'n1-highmem-4'   # 4 vCPUs, 26 GB RAM
+  # 'n1-highmem-64'  # 64 vCPUs, 416 GB RAM
+  # 'n1-highmem-8'   # 8 vCPUs, 52 GB RAM
+  # 'n1-highmem-96'  # 96 vCPUs, 624 GB RAM
+  # 'n1-standard-1'  # 1 vCPU, 3.75 GB RAM
+  # 'n1-standard-16' # 16 vCPUs, 60 GB RAM
+  # 'n1-standard-2'  # 2 vCPUs, 7.5 GB RAM
+  # 'n1-standard-32' # 32 vCPUs, 120 GB RAM
+  # 'n1-standard-4'  # 4 vCPUs, 15 GB RAM
+  # 'n1-standard-64' # 64 vCPUs, 240 GB RAM
+  # 'n1-standard-8'  # 8 vCPUs, 30 GB RAM
+  # 'n1-standard-96' # 96 vCPUs, 360 GB RAM
 
 # Zone where the instance will be located. Uncomment only one of the variables below.
-# Check the command: gcloud compute zones list
-$zone = `
+# Check the command: gcloud compute zones list --format='table(name)'
+$zone = 'us-east1-b'
   # 'asia-east1-a'
   # 'asia-east1-b'
   # 'asia-east1-c'
@@ -132,7 +151,7 @@ $zone = `
   # 'us-central1-a'
   # 'us-central1-b'
   # 'us-central1-c'
-    'us-central1-f'
+  # 'us-central1-f'
   # 'us-east1-b'
   # 'us-east1-c'
   # 'us-east1-d'
@@ -141,9 +160,15 @@ $zone = `
 
 
 # Create a credential object for the domain admin account. It will be used to add the instances to the domain later on.
-if (!($domain_pwd)) {
-  $cred = Get-Credential -Credential $domain_cred }
-else {
-  $Pwd = ConvertTo-SecureString $domain_pwd -AsPlainText -Force 
-  $cred = New-Object System.Management.Automation.PSCredential $domain_cred, $Pwd 
+# Skip if running in Node 1 as we copy this file to Node 1 to create the WSFC locally. No need to create the Credential
+# if running locally.
+$hostname = [System.Net.Dns]::GetHostName()
+
+if ( $hostname.ToLower() -ne $node1.ToLower() ) {
+  if (!($domain_pwd)) {
+    $cred = Get-Credential -Credential $domain_cred }
+  else {
+    $Pwd = ConvertTo-SecureString $domain_pwd -AsPlainText -Force 
+    $cred = New-Object System.Management.Automation.PSCredential $domain_cred, $Pwd
+  }
 }

--- a/compute/sqlserver/powershell/validate-availability-group.ps1
+++ b/compute/sqlserver/powershell/validate-availability-group.ps1
@@ -1,0 +1,142 @@
+﻿#Requires -Version 5
+# Copyright(c) 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+###############################################################################
+#.SYNOPSIS
+# Validate that the Availability Group is working
+#
+#.DESCRIPTION
+# This script can be used to check that the Availability group is working as 
+# expected. It checks that the nodes are synchronized and failover is working. 
+
+
+Set-Location $PSScriptRoot
+
+################################################################################
+# Read the parameters for this script. They are found in the file 
+# parameters-config.ps1. We assume it is in the same folder as this script
+################################################################################
+. ".\parameters-config.ps1"
+
+
+# Domain password. Comment this section so the script will prompt for the password.
+# $domain_pwd = 'Password here' if you don't want to be prompted for the password.
+
+
+# IP addresses of the nodes. It can be the Internal IP or external IP (natIP).
+# Use Internal IP if running from a server inside the GCP VPC
+#$ip_address1 = $(gcloud compute instances describe $node1 --format='get(networkInterfaces[0].networkIP)')
+#$ip_address2 = $(gcloud compute instances describe $node2 --format='get(networkInterfaces[0].networkIP)')
+$ip_address1 = $(gcloud compute instances describe $node1 --format='get(networkInterfaces[0].accessConfigs[0].natIP)')
+$ip_address2 = $(gcloud compute instances describe $node2 --format='get(networkInterfaces[0].accessConfigs[0].natIP)')
+
+
+## Run tests to verify that the PowerShell script ran succesfully
+Write-Host "$(Get-Date) Testing that Availability Group was created succesfully"
+
+## Validate that the Availability Group was created
+
+$session_options = New-PSSessionOption -SkipCACheck -SkipCNCheck `
+  -SkipRevocationCheck
+
+# Use SMO to query the DatabaseReplicaStates
+$results = Invoke-Command -ComputerName $ip_address1 -UseSSL `
+  -Credential $cred -SessionOption $session_options `
+  -ScriptBlock {
+    param($name_ag)
+
+    [System.Reflection.Assembly]::LoadWithPartialName("Microsoft.SqlServer.Smo") | 
+      Out-Null
+    $sql_server = New-Object `
+      -TypeName Microsoft.SqlServer.Management.Smo.Server `
+      -ArgumentList 'localhost'
+    
+    $sql_server.AvailabilityGroups[$($name_ag)].DatabaseReplicaStates | 
+      Select-Object `
+        AvailabilityReplicaServerName, `
+        AvailabilityDatabaseName, `
+        SynchronizationState
+  } -ArgumentList $name_ag
+
+
+# Display the results
+Write-Host "`r`n`r`nVerify that both nodes are syncronized"
+$results | FT
+
+
+
+## Validate that the Availability Group can switch nodes
+# Connect to Listener and return @@SERVERNAME
+$results = Invoke-Command -ComputerName $ip_address1 -UseSSL `
+  -Credential $cred -SessionOption $session_options `
+  -ScriptBlock { 
+    param($name_ag_listener)
+
+    Import-Module SQLPS -DisableNameChecking
+
+    Invoke-Sqlcmd `
+      -Query "SELECT ServerName = @@SERVERNAME" `
+      -ServerInstance $name_ag_listener
+  } -ArgumentList $name_ag_listener
+
+# Display the results. Should match Node 1.
+Write-Host "Before doing a failover $node1 should be the primary node"
+$results | Select-Object ServerName,PSComputerName | FT
+
+Write-Host "*** Doing a failover to instance $node2 ***`r`n"
+
+
+# Switch to Node 2
+Invoke-Command -ComputerName $ip_address2 -UseSSL `
+  -Credential $cred -SessionOption $session_options `
+  -ScriptBlock {
+    param($node2, $name_ag)
+
+    Switch-SqlAvailabilityGroup `
+      -Path "SQLSERVER:\SQL\$($node2)\DEFAULT\AvailabilityGroups\$($name_ag)"
+
+      Start-Sleep 15
+  } -ArgumentList $node2, $name_ag
+
+
+# Connect to Listener and return @@SERVERNAME
+$results = Invoke-Command -ComputerName $ip_address2 -UseSSL `
+  -Credential $cred -SessionOption $session_options `
+  -ScriptBlock {
+    param($name_ag_listener) 
+
+    Invoke-Sqlcmd `
+      -Query "SELECT ServerName = @@SERVERNAME" `
+      -ServerInstance $name_ag_listener
+  } -ArgumentList $name_ag_listener
+
+# Display the results. Should match Node 2.
+Write-Host "After the failover $node2 should be the primary node"
+$results | Select-Object ServerName,PSComputerName | FT
+
+
+Write-Host "*** Doing a failover back to instance $node1 again ***`r`n"
+
+# Switch to Node 1 again
+Invoke-Command -ComputerName $ip_address1 -UseSSL `
+  -Credential $cred -SessionOption $session_options `
+  -ScriptBlock {
+    param($node1, $name_ag)
+
+    Switch-SqlAvailabilityGroup `
+      -Path "SQLSERVER:\SQL\$($node1)\DEFAULT\AvailabilityGroups\$($name_ag)"
+  } -ArgumentList $node1, $name_ag
+
+Write-Host "*** End of validation ***`r`n"


### PR DESCRIPTION
Changed the scripts to use Alias IP ranges. This makes the process simpler as we no longer need to create routes to trick Windows into using the two extra IPs needed to set up Availability Groups. Now we just assign two extra IPs to the SQL Server VMs.