### PR TITLE
fix: removed not about supported enhanced models for Speech-to-Text

### DIFF
--- a/speech/api/Recognize/Recognize.cs
+++ b/speech/api/Recognize/Recognize.cs
@@ -250,8 +250,6 @@ namespace GoogleCloudSamples
                 SampleRateHertz = 8000,
                 LanguageCode = "en-US",
                 UseEnhanced = true,
-                // A model must be specified to use an enhanced model.
-                // Currently, only 'phone_call' is supported.
                 Model = "phone_call",
             }, RecognitionAudio.FromFile(filePath));
             foreach (var result in response.Results)


### PR DESCRIPTION
Speech-to-Text now supports more enhanced models than just phone_call. The comment in the samle needs to be updated to reflect this.

This pull request affects the following region tags:

- speech_transcribe_enhanced_model