### PR TITLE
Fix invalid permission name

### DIFF
--- a/.kokoro-windows/Initialize-GoogleProjectForTesting.ps1
+++ b/.kokoro-windows/Initialize-GoogleProjectForTesting.ps1
@@ -80,7 +80,7 @@ roles/clouddebugger.user
 roles/cloudiot.admin
 roles/cloudkms.admin
 roles/cloudkms.cryptoKeyEncrypterDecrypter
-roles/cloudkms.cryptoKeySignerVerifier
+roles/cloudkms.signerVerifier
 roles/cloudsql.client
 roles/cloudsql.editor
 roles/cloudtasks.admin


### PR DESCRIPTION
This is what I get for going from memory rather than consulting the
docs:
https://cloud.google.com/kms/docs/reference/permissions-and-roles#predefined_roles