### PR TITLE
Dependency cleanup on several projects.

### DIFF
--- a/.kokoro/main.ps1
+++ b/.kokoro/main.ps1
@@ -35,7 +35,10 @@ try {
         $false,  # 0: Everything.
         $false,  # 1: Everything not in another group.
         @('video', 'applications'),  # 2
-        @('iam') # 3: Runs once every 24 hours to avoid bursting active roles limit of 300.
+        @('iam'), # 3: Runs once every 24 hours to avoid bursting active roles limit of 300.
+        # 4: There's no shard 4, so this is effectively not currently running on Linux.
+        # Needed because of BouncyCastle and M2Mqtt dependecies that don't support .NET Core.
+        @('iot') 
     )
 
     $union = $groups[2..($groups.Length-1)] | `

--- a/auth/Auth.sln
+++ b/auth/Auth.sln
@@ -1,11 +1,12 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29806.167
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AuthSample", "AuthSample\AuthSample.csproj", "{A8C8B8BF-6D60-419E-9112-E09B2B9C00D5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AuthSample", "AuthSample\AuthSample.csproj", "{A8C8B8BF-6D60-419E-9112-E09B2B9C00D5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AuthTest", "AuthTest\AuthTest.csproj", "{E1618FF2-ED5B-4EB7-9A46-9BDFBAC72293}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AuthTest", "AuthTest\AuthTest.csproj", "{E1618FF2-ED5B-4EB7-9A46-9BDFBAC72293}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "testutil", "..\testutil\testutil.csproj", "{6AE2A2E1-895E-4E72-BDCB-E373EF763CD2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -16,33 +17,48 @@ Global
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{A8C8B8BF-6D60-419E-9112-E09B2B9C00D5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A8C8B8BF-6D60-419E-9112-E09B2B9C00D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A8C8B8BF-6D60-419E-9112-E09B2B9C00D5}.Debug|x64.ActiveCfg = Debug|x64
-		{A8C8B8BF-6D60-419E-9112-E09B2B9C00D5}.Debug|x64.Build.0 = Debug|x64
-		{A8C8B8BF-6D60-419E-9112-E09B2B9C00D5}.Debug|x86.ActiveCfg = Debug|x86
-		{A8C8B8BF-6D60-419E-9112-E09B2B9C00D5}.Debug|x86.Build.0 = Debug|x86
+		{A8C8B8BF-6D60-419E-9112-E09B2B9C00D5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A8C8B8BF-6D60-419E-9112-E09B2B9C00D5}.Debug|x64.Build.0 = Debug|Any CPU
+		{A8C8B8BF-6D60-419E-9112-E09B2B9C00D5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A8C8B8BF-6D60-419E-9112-E09B2B9C00D5}.Debug|x86.Build.0 = Debug|Any CPU
 		{A8C8B8BF-6D60-419E-9112-E09B2B9C00D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A8C8B8BF-6D60-419E-9112-E09B2B9C00D5}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A8C8B8BF-6D60-419E-9112-E09B2B9C00D5}.Release|x64.ActiveCfg = Release|x64
-		{A8C8B8BF-6D60-419E-9112-E09B2B9C00D5}.Release|x64.Build.0 = Release|x64
-		{A8C8B8BF-6D60-419E-9112-E09B2B9C00D5}.Release|x86.ActiveCfg = Release|x86
-		{A8C8B8BF-6D60-419E-9112-E09B2B9C00D5}.Release|x86.Build.0 = Release|x86
+		{A8C8B8BF-6D60-419E-9112-E09B2B9C00D5}.Release|x64.ActiveCfg = Release|Any CPU
+		{A8C8B8BF-6D60-419E-9112-E09B2B9C00D5}.Release|x64.Build.0 = Release|Any CPU
+		{A8C8B8BF-6D60-419E-9112-E09B2B9C00D5}.Release|x86.ActiveCfg = Release|Any CPU
+		{A8C8B8BF-6D60-419E-9112-E09B2B9C00D5}.Release|x86.Build.0 = Release|Any CPU
 		{E1618FF2-ED5B-4EB7-9A46-9BDFBAC72293}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E1618FF2-ED5B-4EB7-9A46-9BDFBAC72293}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E1618FF2-ED5B-4EB7-9A46-9BDFBAC72293}.Debug|x64.ActiveCfg = Debug|x64
-		{E1618FF2-ED5B-4EB7-9A46-9BDFBAC72293}.Debug|x64.Build.0 = Debug|x64
-		{E1618FF2-ED5B-4EB7-9A46-9BDFBAC72293}.Debug|x86.ActiveCfg = Debug|x86
-		{E1618FF2-ED5B-4EB7-9A46-9BDFBAC72293}.Debug|x86.Build.0 = Debug|x86
+		{E1618FF2-ED5B-4EB7-9A46-9BDFBAC72293}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E1618FF2-ED5B-4EB7-9A46-9BDFBAC72293}.Debug|x64.Build.0 = Debug|Any CPU
+		{E1618FF2-ED5B-4EB7-9A46-9BDFBAC72293}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E1618FF2-ED5B-4EB7-9A46-9BDFBAC72293}.Debug|x86.Build.0 = Debug|Any CPU
 		{E1618FF2-ED5B-4EB7-9A46-9BDFBAC72293}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E1618FF2-ED5B-4EB7-9A46-9BDFBAC72293}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E1618FF2-ED5B-4EB7-9A46-9BDFBAC72293}.Release|x64.ActiveCfg = Release|x64
-		{E1618FF2-ED5B-4EB7-9A46-9BDFBAC72293}.Release|x64.Build.0 = Release|x64
-		{E1618FF2-ED5B-4EB7-9A46-9BDFBAC72293}.Release|x86.ActiveCfg = Release|x86
-		{E1618FF2-ED5B-4EB7-9A46-9BDFBAC72293}.Release|x86.Build.0 = Release|x86
+		{E1618FF2-ED5B-4EB7-9A46-9BDFBAC72293}.Release|x64.ActiveCfg = Release|Any CPU
+		{E1618FF2-ED5B-4EB7-9A46-9BDFBAC72293}.Release|x64.Build.0 = Release|Any CPU
+		{E1618FF2-ED5B-4EB7-9A46-9BDFBAC72293}.Release|x86.ActiveCfg = Release|Any CPU
+		{E1618FF2-ED5B-4EB7-9A46-9BDFBAC72293}.Release|x86.Build.0 = Release|Any CPU
+		{6AE2A2E1-895E-4E72-BDCB-E373EF763CD2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6AE2A2E1-895E-4E72-BDCB-E373EF763CD2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6AE2A2E1-895E-4E72-BDCB-E373EF763CD2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6AE2A2E1-895E-4E72-BDCB-E373EF763CD2}.Debug|x64.Build.0 = Debug|Any CPU
+		{6AE2A2E1-895E-4E72-BDCB-E373EF763CD2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6AE2A2E1-895E-4E72-BDCB-E373EF763CD2}.Debug|x86.Build.0 = Debug|Any CPU
+		{6AE2A2E1-895E-4E72-BDCB-E373EF763CD2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6AE2A2E1-895E-4E72-BDCB-E373EF763CD2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6AE2A2E1-895E-4E72-BDCB-E373EF763CD2}.Release|x64.ActiveCfg = Release|Any CPU
+		{6AE2A2E1-895E-4E72-BDCB-E373EF763CD2}.Release|x64.Build.0 = Release|Any CPU
+		{6AE2A2E1-895E-4E72-BDCB-E373EF763CD2}.Release|x86.ActiveCfg = Release|Any CPU
+		{6AE2A2E1-895E-4E72-BDCB-E373EF763CD2}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C1CBD2FA-ECC6-473D-B93B-89F613822FA7}
 	EndGlobalSection
 EndGlobal

--- a/auth/AuthSample/Program.cs
+++ b/auth/AuthSample/Program.cs
@@ -19,12 +19,11 @@ using CommandLine;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
-using Google.Cloud.Storage.V1;
-using System;
-using System.IO;
-using System.Net.Http;
 using Google.Cloud.Language.V1;
+using Google.Cloud.Storage.V1;
 using Grpc.Auth;
+using System;
+using System.Net.Http;
 
 namespace GoogleCloudSamples
 {

--- a/auth/AuthTest/AuthTest.cs
+++ b/auth/AuthTest/AuthTest.cs
@@ -14,10 +14,8 @@
  * the License.
  */
 
-using System;
-using System.Diagnostics;
-using System.IO;
 using Newtonsoft.Json.Linq;
+using System;
 using Xunit;
 
 namespace GoogleCloudSamples

--- a/auth/AuthTest/AuthTest.csproj
+++ b/auth/AuthTest/AuthTest.csproj
@@ -6,7 +6,6 @@
   <ItemGroup>
     <PackageReference Include="JUnitTestLogger" Version="0.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0-preview-20181205-02" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/dlp/api/DlpSample/DlpSample.csproj
+++ b/dlp/api/DlpSample/DlpSample.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
@@ -6,12 +6,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.3.0" />
-    <PackageReference Include="Google.Api.Gax.Grpc" Version="2.10.0" />
-    <PackageReference Include="Google.Apis.CloudKMS.v1" Version="1.44.1.1885" />
-    <PackageReference Include="Google.Cloud.BigQuery.V2" Version="1.4.0" />
-    <PackageReference Include="Grpc.Core" Version="2.27.0" PrivateAssets="None" />
-    <PackageReference Include="Google.Cloud.PubSub.V1" Version="1.1.0" />
     <PackageReference Include="Google.Cloud.Dlp.V2" Version="1.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Google.Cloud.BigQuery.V2" Version="1.4.0" />
+    <PackageReference Include="Google.Cloud.PubSub.V1" Version="1.1.0" />
   </ItemGroup>
 </Project>

--- a/dlp/api/DlpSample/RedactSamples.cs
+++ b/dlp/api/DlpSample/RedactSamples.cs
@@ -1,4 +1,18 @@
-﻿using Google.Api.Gax.ResourceNames;
+﻿// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax.ResourceNames;
 using Google.Cloud.Dlp.V2;
 using Google.Protobuf;
 using System;

--- a/dlp/api/DlpTest/DlpTest.csproj
+++ b/dlp/api/DlpTest/DlpTest.csproj
@@ -11,8 +11,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Google.Apis.CloudKMS.v1" Version="1.43.0.1856" />
-    <PackageReference Include="Google.Cloud.Dlp.V2" Version="1.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DlpSample\DlpSample.csproj" />

--- a/iam/api/Access/Access.csproj
+++ b/iam/api/Access/Access.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Google.Apis.Iam.v1" Version="1.44.1.1883" />
     <PackageReference Include="Google.Apis.Cloudresourcemanager.v1" Version="1.44.1.1887" />
   </ItemGroup>
 

--- a/iam/api/AccessTest/AccessTest.csproj
+++ b/iam/api/AccessTest/AccessTest.csproj
@@ -15,10 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    <PackageReference Include="Google.Apis.Iam.v1" Version="1.43.0.1835" />
-    <PackageReference Include="Google.Apis.Cloudresourcemanager.v1" Version="1.43.0.1859" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Access\Access.csproj" />
     <ProjectReference Include="..\..\..\testutil\testutil.csproj" />

--- a/iam/api/CustomRolesTest/CustomRolesTest.csproj
+++ b/iam/api/CustomRolesTest/CustomRolesTest.csproj
@@ -2,12 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Apis.Iam.v1" Version="1.43.0.1835" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/iam/api/Iam.sln
+++ b/iam/api/Iam.sln
@@ -1,0 +1,49 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29806.167
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Access", "Access\Access.csproj", "{7A80803D-68C5-4669-A967-BB85F38419B0}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AccessTest", "AccessTest\AccessTest.csproj", "{AFB00345-DD91-40C0-AC34-D3A6B4AC8D42}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "testutil", "..\..\testutil\testutil.csproj", "{5F74B143-822C-4514-B5B9-796EF116E44B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CustomRoles", "CustomRoles\CustomRoles.csproj", "{C1E5EF2A-B046-4B69-9D60-495D7E8EEC32}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CustomRolesTest", "CustomRolesTest\CustomRolesTest.csproj", "{F9CEEBC1-3FA9-4A25-9460-D162F6CC02B5}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7A80803D-68C5-4669-A967-BB85F38419B0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7A80803D-68C5-4669-A967-BB85F38419B0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7A80803D-68C5-4669-A967-BB85F38419B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7A80803D-68C5-4669-A967-BB85F38419B0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AFB00345-DD91-40C0-AC34-D3A6B4AC8D42}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AFB00345-DD91-40C0-AC34-D3A6B4AC8D42}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AFB00345-DD91-40C0-AC34-D3A6B4AC8D42}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AFB00345-DD91-40C0-AC34-D3A6B4AC8D42}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5F74B143-822C-4514-B5B9-796EF116E44B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5F74B143-822C-4514-B5B9-796EF116E44B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5F74B143-822C-4514-B5B9-796EF116E44B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5F74B143-822C-4514-B5B9-796EF116E44B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C1E5EF2A-B046-4B69-9D60-495D7E8EEC32}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C1E5EF2A-B046-4B69-9D60-495D7E8EEC32}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C1E5EF2A-B046-4B69-9D60-495D7E8EEC32}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C1E5EF2A-B046-4B69-9D60-495D7E8EEC32}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F9CEEBC1-3FA9-4A25-9460-D162F6CC02B5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F9CEEBC1-3FA9-4A25-9460-D162F6CC02B5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F9CEEBC1-3FA9-4A25-9460-D162F6CC02B5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F9CEEBC1-3FA9-4A25-9460-D162F6CC02B5}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {88D7E660-B70C-45A9-9A3C-B99A548081CC}
+	EndGlobalSection
+EndGlobal

--- a/iot/api/CloudIotMqttExample/CloudIotMqttExample.csproj
+++ b/iot/api/CloudIotMqttExample/CloudIotMqttExample.csproj
@@ -1,20 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <StartupObject>GoogleCloudSamples.CloudIotMqttExample</StartupObject>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.3.0" />
     <PackageReference Include="Google.Apis.CloudIot.v1" Version="1.44.1.1880" />
-    <PackageReference Include="Google.Cloud.PubSub.V1" Version="1.1.0" />
     <PackageReference Include="M2Mqtt" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
     <ProjectReference Include="..\..\..\commandlineutil\Lib\CommandLineUtil.csproj" />
     <PackageReference Include="jose-jwt" Version="2.4.0" />
     <PackageReference Include="BouncyCastle" Version="1.8.4" />
-    <PackageReference Include="JWT" Version="4.0.0" />
-    <PackageReference Include="NodaTime" Version="2.4.2" />
+    <PackageReference Include="NodaTime" Version="2.4.7" />
   </ItemGroup>
   <ItemGroup>
   </ItemGroup>

--- a/iot/api/CloudIotMqttExample/Program.cs
+++ b/iot/api/CloudIotMqttExample/Program.cs
@@ -12,26 +12,26 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-using System;
-using uPLibrary.Networking.M2Mqtt;
-using System.Security.Cryptography;
-using Org.BouncyCastle.OpenSsl;
-using Org.BouncyCastle.Crypto.Parameters;
-using Org.BouncyCastle.Security;
-using Org.BouncyCastle.Crypto;
-using System.IO;
-using System.Collections.Generic;
-using System.Text;
-using System.Security.Cryptography.X509Certificates;
 using CommandLine;
-using uPLibrary.Networking.M2Mqtt.Messages;
-using uPLibrary.Networking.M2Mqtt.Exceptions;
-using NodaTime;
-using Google.Apis.CloudIot.v1;
 using Google.Apis.Auth.OAuth2;
-using Google.Apis.Services;
+using Google.Apis.CloudIot.v1;
 using Google.Apis.CloudIot.v1.Data;
+using Google.Apis.Services;
+using NodaTime;
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.OpenSsl;
+using Org.BouncyCastle.Security;
+using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using uPLibrary.Networking.M2Mqtt;
+using uPLibrary.Networking.M2Mqtt.Exceptions;
+using uPLibrary.Networking.M2Mqtt.Messages;
 
 namespace GoogleCloudSamples
 {

--- a/iot/api/CloudIotMqttExampleTest/CloudIotMqttTest.cs
+++ b/iot/api/CloudIotMqttExampleTest/CloudIotMqttTest.cs
@@ -12,20 +12,16 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-using Google.Cloud.Iam.V1;
+using Google.Apis.CloudIot.v1.Data;
 using Google.Cloud.PubSub.V1;
 using Grpc.Core;
-using Xunit;
 using System;
-using Google.Api;
-using System.IO;
-using Xunit.Abstractions;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Collections.Generic;
-using Google.Apis.CloudIot.v1.Data;
-using Policy = Google.Cloud.Iam.V1.Policy;
+using System.IO;
+using Xunit;
+using Xunit.Abstractions;
 using Binding = Google.Cloud.Iam.V1.Binding;
+using Policy = Google.Cloud.Iam.V1.Policy;
 using SetIamPolicyRequest = Google.Cloud.Iam.V1.SetIamPolicyRequest;
 
 namespace GoogleCloudSamples

--- a/iot/api/CloudIotMqttExampleTest/CloudIotMqttTest.csproj
+++ b/iot/api/CloudIotMqttExampleTest/CloudIotMqttTest.csproj
@@ -1,15 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Apis.CloudIot.v1" Version="1.43.0.1853" />
     <PackageReference Include="Google.Cloud.PubSub.V1" Version="1.1.0" />
     <PackageReference Include="JUnitTestLogger" Version="0.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
@@ -18,8 +16,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CloudIotMqttExample\CloudIotMqttExample.csproj" />
-<ProjectReference Include="..\CloudIotSample\CloudIotSample.csproj" />
-
+    <ProjectReference Include="..\CloudIotSample\CloudIotSample.csproj" />
     <ProjectReference Include="..\..\..\testutil\testutil.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/iot/api/CloudIotSample/CloudIotSample.csproj
+++ b/iot/api/CloudIotSample/CloudIotSample.csproj
@@ -1,21 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <StartupObject>GoogleCloudSamples.CloudIotSample</StartupObject>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.3.0" />
-    <PackageReference Include="Google.Apis.CloudIot.v1" Version="1.43.0.1853" />
-    <PackageReference Include="Google.Cloud.PubSub.V1" Version="1.1.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Google.Apis.CloudIot.v1" Version="1.44.1.1880" />
     <ProjectReference Include="..\..\..\commandlineutil\Lib\CommandLineUtil.csproj" />
-    <PackageReference Include="NodaTime" Version="2.4.4" />
-    <PackageReference Include="M2Mqtt" Version="4.3.0" />
-  </ItemGroup>
-  <ItemGroup>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\CloudIotMqttExample\CloudIotMqttExample.csproj" />
   </ItemGroup>
 </Project>

--- a/iot/api/CloudIotSample/Program.cs
+++ b/iot/api/CloudIotSample/Program.cs
@@ -14,22 +14,16 @@
  * the License.
  */
 
-using Google.Apis.Auth.OAuth2;
-using Google.Apis.Services;
-using System;
 using CommandLine;
+using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudIot.v1;
 using Google.Apis.CloudIot.v1.Data;
-using System.Linq;
-using System.IO;
-using Newtonsoft.Json.Linq;
-using Newtonsoft.Json;
+using Google.Apis.Services;
+using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Text;
-using NodaTime;
-using uPLibrary.Networking.M2Mqtt;
-using uPLibrary.Networking.M2Mqtt.Messages;
-using uPLibrary.Networking.M2Mqtt.Exceptions;
 
 namespace GoogleCloudSamples
 {

--- a/iot/api/CloudIotTest/CloudIotTest.cs
+++ b/iot/api/CloudIotTest/CloudIotTest.cs
@@ -12,15 +12,15 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+using Google.Apis.CloudIot.v1.Data;
 using Google.Cloud.PubSub.V1;
 using Grpc.Core;
-using Xunit;
 using System;
-using System.IO;
-using Google.Apis.CloudIot.v1.Data;
 using System.Collections.Generic;
-using Policy = Google.Cloud.Iam.V1.Policy;
+using System.IO;
+using Xunit;
 using Binding = Google.Cloud.Iam.V1.Binding;
+using Policy = Google.Cloud.Iam.V1.Policy;
 using SetIamPolicyRequest = Google.Cloud.Iam.V1.SetIamPolicyRequest;
 
 namespace GoogleCloudSamples

--- a/iot/api/CloudIotTest/CloudIotTest.csproj
+++ b/iot/api/CloudIotTest/CloudIotTest.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Apis.CloudIot.v1" Version="1.43.0.1853" />
     <PackageReference Include="Google.Cloud.PubSub.V1" Version="1.1.0" />
     <PackageReference Include="JUnitTestLogger" Version="0.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />

--- a/jobs/api/v3/JobsTest/JobsTest.csproj
+++ b/jobs/api/v3/JobsTest/JobsTest.csproj
@@ -5,8 +5,6 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Apis.CloudTalentSolution.v3" Version="1.43.0.1856" />
-    <PackageReference Include="Google.Apis.JobService.v2" Version="1.37.0.1439" />
     <PackageReference Include="JUnitTestLogger" Version="0.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
Some of the tests projects had dependencies on explicit versions of the Apiary libraries instead of on the projects containing the samples for the Apiary libraries. With the latest Apiary releases, version conflicts appeared.
Similar issues with external libraries like Newtonsoft.Json.
And, cleared some unused dependencies as well.

A similar thing will probably happen when we release gRPC libraries in the comming weeks.