### PR TITLE
Makes the Windows environment used for testing support .NET Core 3.1.

### DIFF
--- a/.kokoro-windows/New-BuildEnv.ps1
+++ b/.kokoro-windows/New-BuildEnv.ps1
@@ -26,8 +26,8 @@ if (-not $chocoPackages.Contains('Microsoft .NET Core SDK - 2.1.4')) {
     choco install -y --sxs dotnetcore-sdk --version 2.2.203
 }
 
-if (-not $chocoPackages.Contains('.NET Core SDK 1.1.')) {
-    choco install -y --sxs dotnetcore-sdk --version 1.1.2    
+if (-not $chocoPackages.Contains('.NET Core SDK 3.1.')) {
+    choco install -y --sxs dotnetcore-sdk --version 3.1.201
 }
 
 dotnet --info


### PR DESCRIPTION
Towards #1013.
Makes then Windows environment used for testing support .NET Core 3.1.
  * Stop supporting .NET Core 1.1 as well.