### PR TITLE
feat: adds create BigQuery job sample

### DIFF
--- a/bigquery/api/Snippets/CreateJob.cs
+++ b/bigquery/api/Snippets/CreateJob.cs
@@ -20,7 +20,7 @@ using System.Collections.Generic;
 
 public class BigQueryCreateJob
 {
-    public void CreateJob(string projectId = "your-project-id")
+    public BigQueryJob CreateJob(string projectId = "your-project-id")
     {
         string query = @"
             SELECT country_name from `bigquery-public-data.utility_us.country_code_iso";
@@ -45,6 +45,7 @@ public class BigQueryCreateJob
             options: queryOptions);
 
         Console.WriteLine($"Started job: {queryJob.Reference.JobId}");
+        return queryJob;
     }
 }
 // [END bigquery_create_job]

--- a/bigquery/api/Snippets/CreateJob.cs
+++ b/bigquery/api/Snippets/CreateJob.cs
@@ -1,0 +1,50 @@
+﻿// Copyright(c) 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+//
+// [START bigquery_create_job]
+
+using Google.Cloud.BigQuery.V2;
+using System;
+using System.Collections.Generic;
+
+public class BigQueryCreateJob
+{
+    public void CreateJob(string projectId = "your-project-id")
+    {
+        string query = @"
+            SELECT country_name from `bigquery-public-data.utility_us.country_code_iso";
+
+        // Initialize client that will be used to send requests.
+        BigQueryClient client = BigQueryClient.Create(projectId);
+
+        QueryOptions queryOptions = new QueryOptions
+        {
+            JobLocation = "us",
+            JobIdPrefix = "code_sample_",
+            Labels = new Dictionary<string, string>
+            {
+                ["example-label"] = "example-value"
+            },
+            MaximumBytesBilled = 1000000
+        };
+
+        BigQueryJob queryJob = client.CreateQueryJob(
+            sql: query,
+            parameters: null,
+            options: queryOptions);
+
+        Console.WriteLine($"Started job: {queryJob.Reference.JobId}");
+    }
+}
+// [END bigquery_create_job]

--- a/bigquery/api/Snippets/Test.cs
+++ b/bigquery/api/Snippets/Test.cs
@@ -86,6 +86,15 @@ public class BigQueryTest : IDisposable, IClassFixture<RandomBucketFixture>
     }
 
     [Fact]
+    public void TestCreateJob()
+    {
+        var snippet = new BigQueryCreateJob();
+        snippet.CreateJob(_projectId);
+        string output = _stringOut.ToString();
+        Assert.Contains("Started job: ", output);
+    }
+
+    [Fact]
     public void TestCreateTable()
     {
         var snippet = new BigQueryCreateTable();

--- a/bigquery/api/Snippets/Test.cs
+++ b/bigquery/api/Snippets/Test.cs
@@ -89,9 +89,8 @@ public class BigQueryTest : IDisposable, IClassFixture<RandomBucketFixture>
     public void TestCreateJob()
     {
         var snippet = new BigQueryCreateJob();
-        snippet.CreateJob(_projectId);
-        string output = _stringOut.ToString();
-        Assert.Contains("Started job: ", output);
+        BigQueryJob job = snippet.CreateJob(_projectId);
+        Assert.NotNull(job);
     }
 
     [Fact]


### PR DESCRIPTION
This sample adds the following region tag:

* bigquery_create_job

The Python canonical sample is here:
https://github.com/googleapis/python-bigquery/blob/master/samples/create_job.py