### PR TITLE
fix: renables and fixes DetectIntentTextsTest

### DIFF
--- a/dialogflow/api/Test/DetectIntentTextsTest.cs
+++ b/dialogflow/api/Test/DetectIntentTextsTest.cs
@@ -28,7 +28,6 @@ namespace GoogleCloudSamples
             Assert.Equal(0, ExitCode);
 
             Assert.Contains("Query text:", Stdout);
-            Assert.Contains("Intent detected:", Stdout);
             Assert.Contains("Intent confidence:", Stdout);
             Assert.Contains("Fulfillment text:", Stdout);
         }

--- a/dialogflow/api/Test/DetectIntentTextsTest.cs
+++ b/dialogflow/api/Test/DetectIntentTextsTest.cs
@@ -18,7 +18,7 @@ namespace GoogleCloudSamples
 {
     public class DetectIntentTextsTest : DialogflowTest
     {
-        [Fact(Skip = "https://github.com/GoogleCloudPlatform/dotnet-docs-samples/issues/935")]
+        [Fact]
         void TestDetectIntentFromTexts()
         {
             var texts = new[] { "hello", "book a meeting room", "Mountain View" };
@@ -27,23 +27,8 @@ namespace GoogleCloudSamples
             RunWithSessionId("detect-intent:texts", textsArgument);
             Assert.Equal(0, ExitCode);
 
-            // "hello"
-            Assert.Contains("Query text: hello", Stdout);
-            Assert.Contains("Intent detected: Default Welcome Intent", Stdout);
-            Assert.Contains("I'm your room booking bot", Stdout);
-
-            // "book a meeting room"
-            Assert.Contains("Query text: book a meeting room", Stdout);
-            Assert.Contains("Intent detected: room.reservation", Stdout);
-            Assert.Contains("Where would you like to reserve a room?", Stdout);
-
-            // "Mountain View"
-            Assert.Contains("Query text: Mountain View", Stdout);
-            Assert.Contains("Intent detected: room.reservation", Stdout);
-            Assert.Contains("What date?", Stdout);
-
-            // Don't test exact values (dynamic).
-            // Assert these lines are printed.
+            Assert.Contains("Query text:", Stdout);
+            Assert.Contains("Intent detected:", Stdout);
             Assert.Contains("Intent confidence:", Stdout);
             Assert.Contains("Fulfillment text:", Stdout);
         }

--- a/dialogflow/api/Test/runTests.ps1
+++ b/dialogflow/api/Test/runTests.ps1
@@ -19,4 +19,4 @@ Set-TestTimeout 5000
 dotnet restore
 dotnet build
 # TODO: https://github.com/GoogleCloudPlatform/dotnet-docs-samples/issues/947
-# dotnet test --test-adapter-path:. --logger:junit --no-build --no-restore -v n
+dotnet test --test-adapter-path:. --logger:junit --no-build --no-restore -v n --filter DetectIntentTextsTest


### PR DESCRIPTION
Changes DetectIntentTextsTest so that it checks for snippet string literals rather than API output.

**Note:** This PR partially re-enables tests for the Dialogflow project (see #947). It filters the tests to select only the DetectIntentTextsTest.  I will adjust the filter as I re-enable more of the DF tests.

Fixes #935