### PR TITLE
fix(spanner): DeleteSampleData sample

### DIFF
--- a/spanner/api/Spanner/Program.cs
+++ b/spanner/api/Spanner/Program.cs
@@ -2016,11 +2016,11 @@ namespace GoogleCloudSamples.Spanner
             // Make the request.
             using (var connection = new SpannerConnection(connectionString))
             {
-                await DeleteTable(connection, "UpcomingAlbums");
-                await DeleteTable(connection, "UpcomingSingers");
+                await DeleteTableAsync(connection, "UpcomingAlbums");
+                await DeleteTableAsync(connection, "UpcomingSingers");
                 return 0;
             }
-            async Task DeleteTable(SpannerConnection connection, string table)
+            async Task DeleteTableAsync(SpannerConnection connection, string table)
             {
                 try
                 {

--- a/spanner/api/Spanner/Program.cs
+++ b/spanner/api/Spanner/Program.cs
@@ -2016,11 +2016,11 @@ namespace GoogleCloudSamples.Spanner
             // Make the request.
             using (var connection = new SpannerConnection(connectionString))
             {
-                DeleteTable(connection, "UpcomingAlbums");
-                DeleteTable(connection, "UpcomingSingers");
+                await DeleteTable(connection, "UpcomingAlbums");
+                await DeleteTable(connection, "UpcomingSingers");
                 return 0;
             }
-            async void DeleteTable(SpannerConnection connection, string table)
+            async Task DeleteTable(SpannerConnection connection, string table)
             {
                 try
                 {


### PR DESCRIPTION
[PR#1111](https://github.com/GoogleCloudPlatform/dotnet-docs-samples/pull/1111) failing [TestDeleteSampleData](https://source.cloud.google.com/results/invocations/873b1a6a-39fd-4d49-b254-817029ee8a3a/targets/github%2Fdotnet-docs-samples%2Fspanner%2Fapi%2FSpannerTest%2FTestResults/tests) Test as in sample was not added `await` while deleting the tables.
It's giving below error:
`Error: Google.Cloud.Spanner.Data.SpannerException : Cannot drop table UpcomingSingers with interleaved tables: UpcomingAlbums.`