### PR TITLE
Redirects stderr to stdout when running tests.

### DIFF
--- a/BuildTools.psm1
+++ b/BuildTools.psm1
@@ -337,15 +337,6 @@ function Run-TestScripts($TimeoutSeconds=300) {
     Run-TestScriptsOnce $scripts $TimeoutSeconds 'Starting' $results
     # Rename all the test logs to a name Sponge will find.
     Get-ChildItem -Recurse TestResults.xml | Rename-Item -Force -NewName 01_sponge_log.xml
-    # Retry the failures once.
-    $failed = $results['Failed']
-    if ($failed) {
-        $results['Failed'] = @()
-        Run-TestScriptsOnce ($failed | Get-Item) $TimeoutSeconds `
-            'Retrying' $results
-        # Rename all the test logs to a name Sponge will find.
-        Get-ChildItem -Recurse TestResults.xml | Rename-Item -Force -NewName 02_sponge_log.xml
-    }
 
     # Print a final summary.
     Write-Output ("=" * 79)

--- a/BuildTools.psm1
+++ b/BuildTools.psm1
@@ -263,7 +263,7 @@ function Run-TestScriptsOnce([array]$Scripts, [int]$TimeoutSeconds,
         Write-Output "$verb $relativePath..."
         $job = Start-Job -ArgumentList $relativePath, $script.Directory, `
             ('.\"{0}"' -f $script.Name) {
-            $ErrorActionPreference = "Stop"
+            $ErrorActionPreference = "Continue"
             Write-Output ("-" * 79)
             Write-Output $args[0]
             Set-Location $args[1]

--- a/applications/googlehome-meets-dotnetcontainers/runTests.ps1
+++ b/applications/googlehome-meets-dotnetcontainers/runTests.ps1
@@ -12,5 +12,4 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-dotnet restore
-dotnet build
+dotnet build 2>&1 | %{ "$_" }

--- a/applications/leaderboard/LeaderboardTest/runTests.ps1
+++ b/applications/leaderboard/LeaderboardTest/runTests.ps1
@@ -15,6 +15,4 @@
 Import-Module ..\..\..\BuildTools.psm1 -DisableNameChecking
 Set-TestTimeout 600
 
-dotnet restore
-dotnet build
-dotnet test --test-adapter-path:. --logger:junit --no-build --no-restore -v detailed
+dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }

--- a/asset/api/runTests.ps1
+++ b/asset/api/runTests.ps1
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-dotnet test --test-adapter-path:. --logger:junit
+dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }

--- a/asset/quickstart/BatchGetAssetsHistoryTest/runTests.ps1
+++ b/asset/quickstart/BatchGetAssetsHistoryTest/runTests.ps1
@@ -19,6 +19,5 @@ BackupAndEdit-TextFile @("..\BatchGetAssetsHistory/BatchGetAssetsHistory.cs") @{
     "YOUR-GOOGLE-PROJECT-ID" = $env:GOOGLE_PROJECT_ID;
     '"ASSET-NAME"' = $getBucketNameClause
 } {
-    dotnet restore
-    dotnet test --test-adapter-path:. --logger:junit
+    dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }
 }

--- a/asset/quickstart/ExportAssetsTest/runTests.ps1
+++ b/asset/quickstart/ExportAssetsTest/runTests.ps1
@@ -19,6 +19,5 @@ BackupAndEdit-TextFile @("..\ExportAssets\ExportAssets.cs") @{
     "YOUR-GOOGLE-PROJECT-ID" = $env:GOOGLE_PROJECT_ID;
     '"YOUR-BUCKET-NAME"' = $getBucketNameClause
 } {
-    dotnet restore
-	dotnet test --test-adapter-path:. --logger:junit
+    dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }
 }

--- a/auth/AuthTest/runTests.ps1
+++ b/auth/AuthTest/runTests.ps1
@@ -12,5 +12,4 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-dotnet restore
-dotnet test --test-adapter-path:. --logger:junit
+dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }

--- a/bigquery/api/SimpleApp/runTests.ps1
+++ b/bigquery/api/SimpleApp/runTests.ps1
@@ -17,6 +17,5 @@ Import-Module ..\..\..\BuildTools.psm1 -DisableNameChecking
 BackupAndEdit-TextFile @(".\Program.cs") `
     @{"YOUR-PROJECT-ID" = $env:GOOGLE_PROJECT_ID} `
 {
-	dotnet restore
-	dotnet test --test-adapter-path:. --logger:junit
+    dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }
 }

--- a/bigquery/api/Snippets/runTests.ps1
+++ b/bigquery/api/Snippets/runTests.ps1
@@ -11,5 +11,5 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under
 # the License.
-dotnet restore
-dotnet test --test-adapter-path:. --logger:junit
+
+dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }

--- a/bigquery/data-transfer/api/QuickStartTest/runTests.ps1
+++ b/bigquery/data-transfer/api/QuickStartTest/runTests.ps1
@@ -17,6 +17,5 @@ Import-Module ..\..\..\..\BuildTools.psm1 -DisableNameChecking
 BackupAndEdit-TextFile "..\QuickStart\QuickStart.cs" `
     @{"YOUR-PROJECT-ID" = $env:GOOGLE_PROJECT_ID} `
 {
-    dotnet restore
-    dotnet test --test-adapter-path:. --logger:junit
+    dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }
 }

--- a/bigtable/api/BigtableTest/runTests.ps1
+++ b/bigtable/api/BigtableTest/runTests.ps1
@@ -21,7 +21,5 @@ BackupAndEdit-TextFile "..\QuickStart\QuickStart.cs", "..\HelloWorld\HelloWorld.
     @{"YOUR-PROJECT-ID" = $env:GOOGLE_PROJECT_ID;
     "YOUR-INSTANCE-ID" = $env:TEST_BIGTABLE_INSTANCE;} `
 {
-    dotnet restore
-    dotnet build
-    dotnet test --test-adapter-path:. --logger:junit -v n
+    dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }
 }

--- a/commandlineutil/SampleTest/runTests.ps1
+++ b/commandlineutil/SampleTest/runTests.ps1
@@ -12,4 +12,4 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-dotnet test --test-adapter-path:. --logger:junit
+dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }

--- a/datastore/api/QuickStartTest/runTests.ps1
+++ b/datastore/api/QuickStartTest/runTests.ps1
@@ -16,6 +16,5 @@ Import-Module ..\..\..\BuildTools.psm1 -DisableNameChecking
 BackupAndEdit-TextFile "..\QuickStart\QuickStart.cs" `
     @{"YOUR-PROJECT-ID" = $env:GOOGLE_PROJECT_ID} `
 {
-    dotnet restore
-    dotnet test --test-adapter-path:. --logger:junit
+    dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }
 }

--- a/datastore/api/TaskListTest/runTests.ps1
+++ b/datastore/api/TaskListTest/runTests.ps1
@@ -14,6 +14,5 @@
 Import-Module -DisableNameChecking ..\..\..\BuildTools.psm1
 
 Set-TestTimeout 900
-dotnet restore
-dotnet build
-dotnet test --test-adapter-path:. --logger:junit --no-build -v n
+
+dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }

--- a/dialogflow/api/Test/runTests.ps1
+++ b/dialogflow/api/Test/runTests.ps1
@@ -16,7 +16,5 @@ import-module -DisableNameChecking ..\..\..\BuildTools.psm1
 
 Set-TestTimeout 5000
 
-dotnet restore
-dotnet build
 # TODO: https://github.com/GoogleCloudPlatform/dotnet-docs-samples/issues/947
-dotnet test --test-adapter-path:. --logger:junit --no-build --no-restore -v n --filter DetectIntentTextsTest
+dotnet test --test-adapter-path:. --logger:junit --filter DetectIntentTextsTest 2>&1 | %{ "$_" }

--- a/endpoints/getting-started/src/runTests.ps1
+++ b/endpoints/getting-started/src/runTests.ps1
@@ -20,7 +20,7 @@ try {
 	$job = Run-Kestrel $url
 	Set-Location ../IO.SwaggerTest
 	$env:ASPNETCORE_URLS = $url
-	dotnet test --test-adapter-path:. --logger:junit
+	dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }
 } finally {
 	Stop-Job $job
 	Receive-Job $job

--- a/error-reporting/api/test/runTests.ps1
+++ b/error-reporting/api/test/runTests.ps1
@@ -11,7 +11,5 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under
 # the License.
-Import-Module ..\..\..\BuildTools.psm1 -DisableNameChecking
 
-dotnet restore
-dotnet test --test-adapter-path:. --logger:junit
+dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }

--- a/firestore/api/FirestoreTest/FirestoreTest.csproj
+++ b/firestore/api/FirestoreTest/FirestoreTest.csproj
@@ -5,6 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/firestore/api/FirestoreTest/runTests.ps1
+++ b/firestore/api/FirestoreTest/runTests.ps1
@@ -15,11 +15,6 @@
 
 Import-Module -DisableNameChecking ..\..\..\BuildTools.psm1
 
-dotnet build
-if ($LASTEXITCODE) {
-	throw "Build failed."
-}
-
 $randomString = ""
 1..10 | ForEach-Object {
 	$char = [char] (65 + (Get-Random 26) )
@@ -44,6 +39,5 @@ BackupAndEdit-TextFile "FirestoreTest.cs", "..\Quickstart\Program.cs", "..\AddDa
 	  'YOUR_COLLECTION_NAME' = $citiesCollection;
 	  } `
 {
-    dotnet restore
-    dotnet test
+    dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }
 }

--- a/functions/helloworld/runTests.ps1
+++ b/functions/helloworld/runTests.ps1
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-dotnet test --test-adapter-path:. --logger:junit
+dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }

--- a/iam/api/AccessTest/runTests.ps1
+++ b/iam/api/AccessTest/runTests.ps1
@@ -12,6 +12,4 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-Import-Module -DisableNameChecking ..\..\..\BuildTools.psm1
-
-dotnet test --test-adapter-path:. --logger:junit
+dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }

--- a/iam/api/CustomRolesTest/CustomRolesTest.csproj
+++ b/iam/api/CustomRolesTest/CustomRolesTest.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/iam/api/CustomRolesTest/runTests.ps1
+++ b/iam/api/CustomRolesTest/runTests.ps1
@@ -12,7 +12,4 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-Import-Module -DisableNameChecking ..\..\..\BuildTools.psm1
-
-dotnet restore
-dotnet test
+dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }

--- a/iam/api/QuickStartTest/QuickStartTest.csproj
+++ b/iam/api/QuickStartTest/QuickStartTest.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/iam/api/QuickStartTest/runTests.ps1
+++ b/iam/api/QuickStartTest/runTests.ps1
@@ -11,7 +11,5 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under
 # the License.
-import-module -DisableNameChecking ..\..\..\BuildTools.psm1
 
-dotnet restore
-dotnet test
+dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }

--- a/iam/api/QuickStartV2Test/runTests.ps1
+++ b/iam/api/QuickStartV2Test/runTests.ps1
@@ -11,7 +11,5 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under
 # the License.
-import-module -DisableNameChecking ..\..\..\BuildTools.psm1
 
-dotnet restore
-dotnet test --logger:junit
+dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }

--- a/iam/api/ServiceAccountTests/ServiceAccountTests.csproj
+++ b/iam/api/ServiceAccountTests/ServiceAccountTests.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/iam/api/ServiceAccountTests/runTests.ps1
+++ b/iam/api/ServiceAccountTests/runTests.ps1
@@ -11,7 +11,5 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under
 # the License.
-import-module -DisableNameChecking ..\..\..\BuildTools.psm1
 
-dotnet restore
-dotnet test
+dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }

--- a/iot/api/CloudIotMqttExampleTest/runTests.ps1
+++ b/iot/api/CloudIotMqttExampleTest/runTests.ps1
@@ -11,4 +11,5 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under
 # the License.
-dotnet test --test-adapter-path:. --logger:junit
+
+dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }

--- a/iot/api/CloudIotTest/runTests.ps1
+++ b/iot/api/CloudIotTest/runTests.ps1
@@ -11,4 +11,5 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under
 # the License.
-dotnet test --test-adapter-path:. --logger:junit
+
+dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }

--- a/jobs/api/v3/JobsTest/runTests.ps1
+++ b/jobs/api/v3/JobsTest/runTests.ps1
@@ -11,5 +11,5 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under
 # the License.
-dotnet restore
-dotnet test --test-adapter-path:. --logger:junit
+
+dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }

--- a/kms/api/runTests.ps1
+++ b/kms/api/runTests.ps1
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-dotnet test --test-adapter-path:. --logger:junit
+dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }

--- a/language/api/AnalyzeTest/runTests.ps1
+++ b/language/api/AnalyzeTest/runTests.ps1
@@ -13,5 +13,4 @@
 # the License.
 
 # See: https://github.com/GoogleCloudPlatform/dotnet-docs-samples/issues/1059
-# dotnet restore
-# dotnet test --test-adapter-path:. --logger:junit
+# dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }

--- a/logging/api/LoggingTest/runTests.ps1
+++ b/logging/api/LoggingTest/runTests.ps1
@@ -18,6 +18,5 @@ $filesToProcess = "..\LoggingSample\Program.cs", "..\QuickStart\QuickStart.cs"
 BackupAndEdit-TextFile $filesToProcess `
     @{"YOUR-PROJECT-ID" = $env:GOOGLE_PROJECT_ID} `
 {
-    dotnet restore
-    dotnet test --test-adapter-path:. --logger:junit
+    dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }
 }

--- a/monitoring/api/AlertSnippets/runTests.ps1
+++ b/monitoring/api/AlertSnippets/runTests.ps1
@@ -13,5 +13,4 @@
 # the License.
 
 # https://github.com/GoogleCloudPlatform/dotnet-docs-samples/issues/1068
-# dotnet test --test-adapter-path:. --logger:junit -v n
-
+# dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }

--- a/secretmanager/api/runTests.ps1
+++ b/secretmanager/api/runTests.ps1
@@ -12,7 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-Import-Module ..\..\BuildTools.psm1 -DisableNameChecking
-
-dotnet restore
-dotnet test --test-adapter-path:. --logger:junit
+dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }

--- a/spanner/api/SpannerTest/runTests.ps1
+++ b/spanner/api/SpannerTest/runTests.ps1
@@ -20,5 +20,5 @@ Set-TestTimeout 1800
 BackupAndEdit-TextFile "..\QuickStart\Program.cs" `
     @{"YOUR-PROJECT-ID" = $env:GOOGLE_PROJECT_ID} `
 {
-    dotnet test --test-adapter-path:. --logger:junit -v n
+    dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }
 }

--- a/storage/api/runTests.ps1
+++ b/storage/api/runTests.ps1
@@ -16,11 +16,9 @@ Import-Module ..\..\BuildTools.psm1 -DisableNameChecking
 BackupAndEdit-TextFile @("Storage\Storage.cs", "QuickStart\QuickStart.cs") `
     @{"YOUR-PROJECT-ID" = $env:GOOGLE_PROJECT_ID} `
 {
-    dotnet restore
-    dotnet build
-    dotnet test --test-adapter-path:. --logger:junit --no-build .\StorageTest\StorageTest.csproj
+    dotnet test --test-adapter-path:. --logger:junit .\StorageTest\StorageTest.csproj 2>&1 | %{ "$_" } 
     if ($LASTEXITCODE -ne 0) { throw "FAILED" }
-    dotnet run --no-build --project .\QuickStart\QuickStart.csproj
+    dotnet run --project .\QuickStart\QuickStart.csproj
     if ($LASTEXITCODE -ne 0) { throw "FAILED" }
 }
 

--- a/texttospeech/api/TextToSpeechTest/runTests.ps1
+++ b/texttospeech/api/TextToSpeechTest/runTests.ps1
@@ -12,5 +12,4 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-dotnet restore
-dotnet test --test-adapter-path:. --logger:junit
+dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }

--- a/translate/api/Snippets/runTests.ps1
+++ b/translate/api/Snippets/runTests.ps1
@@ -12,5 +12,4 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-dotnet restore
-dotnet test --test-adapter-path:. --logger:junit
+dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }

--- a/translate/api/Tests/runTests.ps1
+++ b/translate/api/Tests/runTests.ps1
@@ -12,5 +12,4 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-dotnet restore
-dotnet test --test-adapter-path:. --logger:junit
+dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }

--- a/video/api/Test/runTests.ps1
+++ b/video/api/Test/runTests.ps1
@@ -15,6 +15,4 @@ import-module -DisableNameChecking ..\..\..\BuildTools.psm1
 
 Set-TestTimeout 2400
 
-dotnet restore
-dotnet build
-dotnet test --test-adapter-path:. --logger:junit --no-build
+dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }

--- a/vision/api/VisionTest/runTests.ps1
+++ b/vision/api/VisionTest/runTests.ps1
@@ -15,5 +15,4 @@ Import-Module ..\..\..\BuildTools.psm1
 
 Set-TestTimeout 600
 
-dotnet restore
-dotnet test --test-adapter-path:. --logger:junit
+dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }


### PR DESCRIPTION
  * This avoids PS failing when dotnet test writes to stderr.
  * Will hopefully improve the quality of test failure messages.

See: https://stackoverflow.com/a/20950421/1122643

I'm testing first with Asset, if it fixes the failure we had there, I'll do this for all files.

(Draft while trial and error)