### PR TITLE
Update DeleteNotificationConfigSnippets.g.cs

### DIFF
--- a/securitycenter/api/src/DeleteNotificationConfigSnippets.g.cs
+++ b/securitycenter/api/src/DeleteNotificationConfigSnippets.g.cs
@@ -32,4 +32,4 @@ public class DeleteNotificationConfigSnippets
         return true;
     }
 }
-// [END] scc_delete_notification_config]
+// [END scc_delete_notification_config]


### PR DESCRIPTION
Fix typo in the region tag, removing an extraneous "]". The region tag should work after this fix.