### PR TITLE
[Spanner]: reduce time to delete the old databases and backups to 48 hrs

### DIFF
--- a/spanner/api/Spanner.Samples.Tests/SpannerFixture.cs
+++ b/spanner/api/Spanner.Samples.Tests/SpannerFixture.cs
@@ -77,8 +77,8 @@ public class SpannerFixture : IAsyncLifetime, ICollectionFixture<SpannerFixture>
             .Where(c => c.DatabaseName.DatabaseId.StartsWith("my-db-") || c.DatabaseName.DatabaseId.StartsWith("my-restore-db-"));
         var databasesToDelete = new List<string>();
 
-        // Delete all the databases created before 72 hrs.
-        var timestamp = DateTimeOffset.UtcNow.AddHours(-72).ToUnixTimeMilliseconds();
+        // Delete all the databases created before 48 hrs.
+        var timestamp = DateTimeOffset.UtcNow.AddHours(-48).ToUnixTimeMilliseconds();
         foreach (var database in databases)
         {
             var databaseId = database.DatabaseName.DatabaseId.Replace("my-restore-db-", "").Replace("my-db-", "");


### PR DESCRIPTION
Refer comment [here](https://github.com/GoogleCloudPlatform/dotnet-docs-samples/pull/1178#issuecomment-690140550)