### PR TITLE
Give the Firestore Reactive sample the correct tag

### DIFF
--- a/functions/firebase/FirestoreReactive/Function.cs
+++ b/functions/firebase/FirestoreReactive/Function.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// [START functions_firestore_reactive]
+// [START functions_firebase_reactive]
 using CloudNative.CloudEvents;
 using Google.Cloud.Firestore;
 using Google.Cloud.Functions.Framework;
@@ -80,4 +80,4 @@ namespace FirestoreReactive
         }
     }
 }
-// [END functions_firestore_reactive]
+// [END functions_firebase_reactive]


### PR DESCRIPTION
(It's a pity that it's tagged as Firebase when it's actually Firestore, but never mind... that's the tag everything uses.)