### PR TITLE
[Spanner]: Delete five oldest databases if instance reaches the database limit

### DIFF
--- a/spanner/api/Spanner.Samples.Tests/SpannerFixture.cs
+++ b/spanner/api/Spanner.Samples.Tests/SpannerFixture.cs
@@ -77,8 +77,7 @@ public class SpannerFixture : IAsyncLifetime, ICollectionFixture<SpannerFixture>
     {
         DatabaseAdminClient databaseAdminClient = DatabaseAdminClient.Create();
         var instanceName = InstanceName.FromProjectInstance(ProjectId, InstanceId);
-        var databases = databaseAdminClient.ListDatabases(instanceName)
-            .Where(c => c.DatabaseName.DatabaseId.StartsWith("my-db-") || c.DatabaseName.DatabaseId.StartsWith("my-restore-db-"));
+        var databases = databaseAdminClient.ListDatabases(instanceName);
 
         if (databases.Count() < 95)
         {


### PR DESCRIPTION
Fixes #1189 

Before starting the test Check the databases available on instance, if it's more than  94 delete the old five databases.
Removed delete backup logic as we have separate database for same and we never delete it.