### PR TITLE
Fix Cloud Spanner Leaderboard test flakiness.

### DIFF
--- a/applications/leaderboard/Leaderboard/Leaderboard.csproj
+++ b/applications/leaderboard/Leaderboard/Leaderboard.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/applications/leaderboard/Leaderboard/Leaderboard.csproj
+++ b/applications/leaderboard/Leaderboard/Leaderboard.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Spanner.Data" Version="3.0.0-beta02" />
+    <PackageReference Include="Google.Cloud.Spanner.Data" Version="3.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/applications/leaderboard/Leaderboard/Program.cs
+++ b/applications/leaderboard/Leaderboard/Program.cs
@@ -212,13 +212,12 @@ namespace GoogleCloudSamples.Leaderboard
                 $"Data Source=projects/{projectId}/instances/{instanceId}"
                 + $"/databases/{databaseId}";
 
-            using (TransactionScope scope = new TransactionScope(
-               TransactionScopeAsyncFlowOption.Enabled))
+            Int64 numberOfPlayers = 0;
+            using (var connection = new SpannerConnection(connectionString))
             {
-                Int64 numberOfPlayers = 0;
-                using (var connection = new SpannerConnection(connectionString))
+                await connection.OpenAsync();
+                await connection.RunWithRetriableTransactionAsync(async (transaction) =>
                 {
-                    await connection.OpenAsync();
                     // Execute a SQL statement to get current number of records
                     // in the Players table to use as an incrementing value 
                     // for each PlayerName to be inserted.
@@ -260,8 +259,7 @@ namespace GoogleCloudSamples.Leaderboard
                         cmdBatch.Add(cmdInsert);
                     }
                     await cmdBatch.ExecuteNonQueryAsync();
-                    scope.Complete();
-                }
+                });
             }
             Console.WriteLine("Done inserting player records...");
         }
@@ -273,14 +271,13 @@ namespace GoogleCloudSamples.Leaderboard
             $"Data Source=projects/{projectId}/instances/{instanceId}"
             + $"/databases/{databaseId}";
 
-            using (TransactionScope scope = new TransactionScope(
-               TransactionScopeAsyncFlowOption.Enabled))
+            // Insert 4 score records into the Scores table for each player
+            // in the Players table.
+            using (var connection = new SpannerConnection(connectionString))
             {
-                // Insert 4 score records into the Scores table for each player
-                // in the Players table.
-                using (var connection = new SpannerConnection(connectionString))
+                await connection.OpenAsync();
+                await connection.RunWithRetriableTransactionAsync(async (transaction) =>
                 {
-                    await connection.OpenAsync();
                     Random r = new Random();
                     bool playerRecordsFound = false;
                     SpannerBatchCommand cmdBatch =
@@ -332,13 +329,12 @@ namespace GoogleCloudSamples.Leaderboard
                         else
                         {
                             await cmdBatch.ExecuteNonQueryAsync();
-                            scope.Complete();
                             Console.WriteLine(
                                 "Done inserting score records..."
                             );
                         }
                     }
-                }
+                });
             }
         }
 

--- a/applications/leaderboard/Leaderboard/Program.cs
+++ b/applications/leaderboard/Leaderboard/Program.cs
@@ -223,26 +223,10 @@ namespace GoogleCloudSamples.Leaderboard
                     // for each PlayerName to be inserted.
                     var cmd = connection.CreateSelectCommand(
                         @"SELECT Count(PlayerId) as PlayerCount FROM Players");
-                    using (var reader = await cmd.ExecuteReaderAsync())
-                    {
-                        while (await reader.ReadAsync())
-                        {
-                            long parsedValue;
-                            if (reader["PlayerCount"] != DBNull.Value)
-                            {
-                                bool result = Int64.TryParse(
-                                    reader.GetFieldValue<string>("PlayerCount"),
-                                        out parsedValue);
-                                if (result)
-                                {
-                                    numberOfPlayers = parsedValue;
-                                }
-                            }
-                        }
-                    }
+                    numberOfPlayers = await cmd.ExecuteScalarAsync<long>();
                     // Insert 100 player records into the Players table.
                     SpannerBatchCommand cmdBatch = connection.CreateBatchDmlCommand();
-                    for (var x = 1; x <= 100; x++)
+                    for (int i = 0; i < 100; i++)
                     {
                         numberOfPlayers++;
                         SpannerCommand cmdInsert = connection.CreateDmlCommand(
@@ -288,11 +272,8 @@ namespace GoogleCloudSamples.Leaderboard
                     {
                         while (await reader.ReadAsync())
                         {
-                            if (!playerRecordsFound)
-                            {
-                                playerRecordsFound = true;
-                            }
-                            for (var x = 1; x <= 4; x++)
+                            playerRecordsFound = true;
+                            for (int i = 0; i < 4; i++)
                             {
                                 DateTime randomTimestamp = DateTime.Now
                                         .AddYears(r.Next(-2, 1))

--- a/applications/leaderboard/Leaderboard/Program.cs
+++ b/applications/leaderboard/Leaderboard/Program.cs
@@ -212,7 +212,7 @@ namespace GoogleCloudSamples.Leaderboard
                 $"Data Source=projects/{projectId}/instances/{instanceId}"
                 + $"/databases/{databaseId}";
 
-            Int64 numberOfPlayers = 0;
+            long numberOfPlayers = 0;
             using (var connection = new SpannerConnection(connectionString))
             {
                 await connection.OpenAsync();

--- a/applications/leaderboard/LeaderboardTest/LeaderboardTest.csproj
+++ b/applications/leaderboard/LeaderboardTest/LeaderboardTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/applications/leaderboard/LeaderboardTest/Tests.cs
+++ b/applications/leaderboard/LeaderboardTest/Tests.cs
@@ -82,7 +82,7 @@ namespace GoogleCloudSamples.Leaderboard
                 _fixture.ProjectId, _fixture.InstanceId, _fixture.DatabaseId);
         }
 
-        [Fact(Skip = "https://github.com/GoogleCloudPlatform/dotnet-docs-samples/issues/928")]
+        [Fact]
         void TestLeaderboard()
         {
             // Insert Player records.
@@ -92,13 +92,7 @@ namespace GoogleCloudSamples.Leaderboard
             // Insert Scores records.
             ConsoleOutput insertScoresOutput = _spannerCmd.Run("insert",
                 _fixture.ProjectId, _fixture.InstanceId, _fixture.DatabaseId, "scores");
-            Assert.Equal(0, insertScoresOutput.ExitCode);
-            insertScoresOutput = _spannerCmd.Run("insert",
-                _fixture.ProjectId, _fixture.InstanceId, _fixture.DatabaseId, "scores");
-            Assert.Equal(0, insertScoresOutput.ExitCode);
-            insertScoresOutput = _spannerCmd.Run("insert",
-                _fixture.ProjectId, _fixture.InstanceId, _fixture.DatabaseId, "scores");
-            Assert.Equal(0, insertScoresOutput.ExitCode);
+            Assert.Equal(0, insertScoresOutput.ExitCode);           
             insertScoresOutput = _spannerCmd.Run("insert",
                 _fixture.ProjectId, _fixture.InstanceId, _fixture.DatabaseId, "scores");
             Assert.Equal(0, insertScoresOutput.ExitCode);

--- a/applications/leaderboard/LeaderboardTest/runTests.ps1
+++ b/applications/leaderboard/LeaderboardTest/runTests.ps1
@@ -13,6 +13,6 @@
 # the License.
 
 Import-Module ..\..\..\BuildTools.psm1 -DisableNameChecking
-Set-TestTimeout 600
+Set-TestTimeout 300
 
 dotnet test --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }

--- a/applications/leaderboard/README.md
+++ b/applications/leaderboard/README.md
@@ -50,7 +50,7 @@ If you only want to run the complete sample refer to the application in the Lead
     ```
 
     ```
-    PS > dotnet run createSampleDatabase your-project-id my-instance my-database
+    PS > dotnet run create your-project-id my-instance my-database
     Waiting for operation to complete...
     Operation status: RanToCompletion
     Created sample database my-database on instance my-instance

--- a/applications/leaderboard/README.md
+++ b/applications/leaderboard/README.md
@@ -50,10 +50,10 @@ If you only want to run the complete sample refer to the application in the Lead
     ```
 
     ```
-    PS > dotnet run create your-project-id my-instance my-database
+    PS > dotnet run create your-project-id your-instance your-database
     Waiting for operation to complete...
     Operation status: RanToCompletion
-    Created sample database my-database on instance my-instance
+    Created sample database your-database on instance your-instance
     ```
 
 ## Contributing changes

--- a/applications/leaderboard/step4/Leaderboard.csproj
+++ b/applications/leaderboard/step4/Leaderboard.csproj
@@ -2,13 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.3.0" />
-    <PackageReference Include="Google.Cloud.Spanner.Data" Version="2.1.0" />
-    <PackageReference Include="Google.Cloud.Spanner.V1" Version="2.1.0" />
+    <PackageReference Include="Google.Cloud.Spanner.Data" Version="3.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/applications/leaderboard/step5/Leaderboard.csproj
+++ b/applications/leaderboard/step5/Leaderboard.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/applications/leaderboard/step5/Leaderboard.csproj
+++ b/applications/leaderboard/step5/Leaderboard.csproj
@@ -2,13 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.3.0" />
-    <PackageReference Include="Google.Cloud.Spanner.Data" Version="2.1.0" />
-    <PackageReference Include="Google.Cloud.Spanner.V1" Version="2.1.0" />
+    <PackageReference Include="Google.Cloud.Spanner.Data" Version="3.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/applications/leaderboard/step5/Program.cs
+++ b/applications/leaderboard/step5/Program.cs
@@ -150,7 +150,7 @@ namespace GoogleCloudSamples.Leaderboard
                 $"Data Source=projects/{projectId}/instances/{instanceId}"
                 + $"/databases/{databaseId}";
 
-            Int64 numberOfPlayers = 0;
+            long numberOfPlayers = 0;
             using (var connection = new SpannerConnection(connectionString))
             {
                 await connection.OpenAsync();
@@ -161,26 +161,10 @@ namespace GoogleCloudSamples.Leaderboard
                     // for each PlayerName to be inserted.
                     var cmd = connection.CreateSelectCommand(
                         @"SELECT Count(PlayerId) as PlayerCount FROM Players");
-                    using (var reader = await cmd.ExecuteReaderAsync())
-                    {
-                        while (await reader.ReadAsync())
-                        {
-                            long parsedValue;
-                            if (reader["PlayerCount"] != DBNull.Value)
-                            {
-                                bool result = Int64.TryParse(
-                                    reader.GetFieldValue<string>("PlayerCount"),
-                                        out parsedValue);
-                                if (result)
-                                {
-                                    numberOfPlayers = parsedValue;
-                                }
-                            }
-                        }
-                    }
+                    numberOfPlayers = await cmd.ExecuteScalarAsync<long>();
                     // Insert 100 player records into the Players table.
                     SpannerBatchCommand cmdBatch = connection.CreateBatchDmlCommand();
-                    for (var x = 1; x <= 100; x++)
+                    for (int i = 0; i < 100; i++)
                     {
                         numberOfPlayers++;
                         SpannerCommand cmdInsert = connection.CreateDmlCommand(
@@ -226,11 +210,8 @@ namespace GoogleCloudSamples.Leaderboard
                     {
                         while (await reader.ReadAsync())
                         {
-                            if (!playerRecordsFound)
-                            {
-                                playerRecordsFound = true;
-                            }
-                            for (var x = 1; x <= 4; x++)
+                            playerRecordsFound = true;
+                            for (int i = 0; i < 4; i++)
                             {
                                 DateTime randomTimestamp = DateTime.Now
                                         .AddYears(r.Next(-2, 1))

--- a/applications/leaderboard/step6/Leaderboard.csproj
+++ b/applications/leaderboard/step6/Leaderboard.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/applications/leaderboard/step6/Leaderboard.csproj
+++ b/applications/leaderboard/step6/Leaderboard.csproj
@@ -2,13 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.3.0" />
-    <PackageReference Include="Google.Cloud.Spanner.Data" Version="2.1.0" />
-    <PackageReference Include="Google.Cloud.Spanner.V1" Version="2.1.0" />
+    <PackageReference Include="Google.Cloud.Spanner.Data" Version="3.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/applications/leaderboard/step6/Program.cs
+++ b/applications/leaderboard/step6/Program.cs
@@ -169,7 +169,7 @@ namespace GoogleCloudSamples.Leaderboard
                 $"Data Source=projects/{projectId}/instances/{instanceId}"
                 + $"/databases/{databaseId}";
 
-            Int64 numberOfPlayers = 0;
+            long numberOfPlayers = 0;
             using (var connection = new SpannerConnection(connectionString))
             {
                 await connection.OpenAsync();
@@ -180,26 +180,10 @@ namespace GoogleCloudSamples.Leaderboard
                     // for each PlayerName to be inserted.
                     var cmd = connection.CreateSelectCommand(
                         @"SELECT Count(PlayerId) as PlayerCount FROM Players");
-                    using (var reader = await cmd.ExecuteReaderAsync())
-                    {
-                        while (await reader.ReadAsync())
-                        {
-                            long parsedValue;
-                            if (reader["PlayerCount"] != DBNull.Value)
-                            {
-                                bool result = Int64.TryParse(
-                                    reader.GetFieldValue<string>("PlayerCount"),
-                                        out parsedValue);
-                                if (result)
-                                {
-                                    numberOfPlayers = parsedValue;
-                                }
-                            }
-                        }
-                    }
+                    numberOfPlayers = await cmd.ExecuteScalarAsync<long>();
                     // Insert 100 player records into the Players table.
                     SpannerBatchCommand cmdBatch = connection.CreateBatchDmlCommand();
-                    for (var x = 1; x <= 100; x++)
+                    for (int i = 0; i < 100; i++)
                     {
                         numberOfPlayers++;
                         SpannerCommand cmdInsert = connection.CreateDmlCommand(
@@ -245,11 +229,8 @@ namespace GoogleCloudSamples.Leaderboard
                     {
                         while (await reader.ReadAsync())
                         {
-                            if (!playerRecordsFound)
-                            {
-                                playerRecordsFound = true;
-                            }
-                            for (var x = 1; x <= 4; x++)
+                            playerRecordsFound = true;
+                            for (int i = 0; i < 4; i++)
                             {
                                 DateTime randomTimestamp = DateTime.Now
                                         .AddYears(r.Next(-2, 1))


### PR DESCRIPTION
- Updates insert methods to use RunWithRetriableTransactionAsync()
- Updates Google.Cloud.Spanner.Data to latest version
- Shortens test time