### PR TITLE
[BigQuery]: Added clarity around Autodetect in uploadCsvOptions

### DIFF
--- a/bigquery/api/Snippets/LoadFromFile.cs
+++ b/bigquery/api/Snippets/LoadFromFile.cs
@@ -32,7 +32,7 @@ public class BigQueryLoadFromFile
         var uploadCsvOptions = new UploadCsvOptions()
         {
             SkipLeadingRows = 1,  // Skips the file headers
-            Autodetect = true
+            Autodetect = true // Set to false if the table already exists
         };
         using (FileStream stream = File.Open(filePath, FileMode.Open))
         {


### PR DESCRIPTION
Added a comment to clarify the correct setting for Autodetect. 

If the table is pre-existing, then the default setting of "Autodetect = true" will result in a SCHEME_INCOMPATIBLE error in the BQ job logs. Setting this to false allows the upload to proceed without error.  