### PR TITLE
docs: Wrap samples with future prefix

### DIFF
--- a/securitycenter/api/src/CreateNotificationConfigSnippets.g.cs
+++ b/securitycenter/api/src/CreateNotificationConfigSnippets.g.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+// [START securitycenter_create_notification_config]
 // [START scc_create_notification_config]
 
 using Google.Api.Gax.ResourceNames;
@@ -48,3 +49,4 @@ public class CreateNotificationConfigSnippets
     }
 }
 // [END scc_create_notification_config]
+// [END securitycenter_create_notification_config]

--- a/securitycenter/api/src/DeleteNotificationConfigSnippets.g.cs
+++ b/securitycenter/api/src/DeleteNotificationConfigSnippets.g.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+// [START securitycenter_delete_notification_config]
 // [START scc_delete_notification_config]
 
 using Google.Cloud.SecurityCenter.V1;
@@ -33,3 +34,4 @@ public class DeleteNotificationConfigSnippets
     }
 }
 // [END scc_delete_notification_config]
+// [END securitycenter_delete_notification_config]

--- a/securitycenter/api/src/GetNotificationConfigSnippets.g.cs
+++ b/securitycenter/api/src/GetNotificationConfigSnippets.g.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// [START securitycenter_get_notification_config]
 // [START scc_get_notification_config]
 
 using Google.Cloud.SecurityCenter.V1;
@@ -31,3 +32,4 @@ public class GetNotificationConfigSnippets
     }
 }
 // [END scc_get_notification_config]
+// [END securitycenter_get_notification_config]

--- a/securitycenter/api/src/ListNotificationConfigSnippets.g.cs
+++ b/securitycenter/api/src/ListNotificationConfigSnippets.g.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+// [START securitycenter_list_notification_configs]
 // [START scc_list_notification_configs]
 
 using Google.Api.Gax.ResourceNames;
@@ -39,3 +40,4 @@ public class ListNotificationConfigSnippets
     }
 }
 // [END scc_list_notification_configs]
+// [END securitycenter_list_notification_configs]

--- a/securitycenter/api/src/UpdateNotificationConfigSnippets.g.cs
+++ b/securitycenter/api/src/UpdateNotificationConfigSnippets.g.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+// [START securitycenter_update_notification_config]
 // [START scc_update_notification_config]
 
 using Google.Cloud.SecurityCenter.V1;
@@ -47,3 +48,4 @@ public class UpdateNotificationConfigSnippets
     }
 }
 // [END scc_update_notification_config]
+// [END securitycenter_update_notification_config]


### PR DESCRIPTION
Standardizing Security Command Center samples to use 'securitycenter' prefixing. 

- Wrapped existing samples to keep published doclinks unbroken
- Replace region tags that aren't published. 

Once this PR is through, published sample inclusions will be updated to use the new prefix, then I'll come through again and remove the unused block wraps.