### PR TITLE
docs: homogenize region tags

### DIFF
--- a/spanner/api/Spanner/GetBackupOperations.cs
+++ b/spanner/api/Spanner/GetBackupOperations.cs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// [START [spanner_list_backup_operations]
-// [START [spanner_get_backup_operations]
+// [START spanner_list_backup_operations]
+// [START spanner_get_backup_operations]
 
 using Google.Cloud.Spanner.Admin.Database.V1;
 using Google.Cloud.Spanner.Common.V1;
@@ -53,5 +53,5 @@ namespace GoogleCloudSamples.Spanner
         }
     }
 }
-// [END [spanner_get_backup_operations]
-// [START [spanner_list_backup_operations]
+// [END spanner_get_backup_operations]
+// [END spanner_list_backup_operations]

--- a/spanner/api/Spanner/GetBackupOperations.cs
+++ b/spanner/api/Spanner/GetBackupOperations.cs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// [START spanner_get_backup_operations]
+// [START [spanner_list_backup_operations]
+// [START [spanner_get_backup_operations]
 
 using Google.Cloud.Spanner.Admin.Database.V1;
 using Google.Cloud.Spanner.Common.V1;
@@ -52,4 +53,5 @@ namespace GoogleCloudSamples.Spanner
         }
     }
 }
-// [END spanner_get_backup_operations]
+// [END [spanner_get_backup_operations]
+// [START [spanner_list_backup_operations]

--- a/spanner/api/Spanner/GetBackups.cs
+++ b/spanner/api/Spanner/GetBackups.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// [START spanner_list_backups]
 // [START spanner_get_backups]
 
 using Google.Api.Gax;
@@ -99,3 +100,4 @@ namespace GoogleCloudSamples.Spanner
     }
 }
 // [END spanner_get_backups]
+// [END spanner_list_backups]

--- a/spanner/api/Spanner/RestoreDatabase.cs
+++ b/spanner/api/Spanner/RestoreDatabase.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// [START spanner_restore_backup]
 // [START spanner_restore_database]
 
 using Google.Cloud.Spanner.Admin.Database.V1;
@@ -60,3 +61,4 @@ namespace GoogleCloudSamples.Spanner
     }
 }
 // [END spanner_restore_database]
+// [END spanner_restore_backup]


### PR DESCRIPTION
These samples' region tags slightly differ from identical snippets in different languages. The following is the remedy:

1. Merge this PR to fix GitHub source (keep old tag for now)
2. Fix doc code includes to represent the better region tag
3. Submit a second PR to clean-up redundant region tag wrapping