### PR TITLE
docs: update some region tags missed in PR 1233

### DIFF
--- a/iam/api/Access/AddMember.cs
+++ b/iam/api/Access/AddMember.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// [START iam_modify_policy_add_member]
 // [START iam_modify_policy_member]
 
 using System.Linq;
@@ -27,3 +28,4 @@ public partial class AccessManager
     }
 }
 // [END iam_modify_policy_member]
+// [END iam_modify_policy_add_member]

--- a/spanner/api/Spanner/GetDatabaseOperations.cs
+++ b/spanner/api/Spanner/GetDatabaseOperations.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// [START spanner_list_database_operations]
 // [START spanner_get_database_operations]
 
 using Google.Cloud.Spanner.Admin.Database.V1;
@@ -52,3 +53,4 @@ namespace GoogleCloudSamples.Spanner
     }
 }
 // [END spanner_get_database_operations]
+// [END spanner_list_database_operations]


### PR DESCRIPTION
Making this change to standardize the region tag. Once this is merged, doc includes will be updated, then I'll come back through and remove inner tags.