### PR TITLE
docs: cleanup tagging

### DIFF
--- a/iam/api/Access/AddMember.cs
+++ b/iam/api/Access/AddMember.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 // [START iam_modify_policy_add_member]
-// [START iam_modify_policy_member]
 
 using System.Linq;
 using Google.Apis.CloudResourceManager.v1.Data;
@@ -27,5 +26,4 @@ public partial class AccessManager
         return policy;
     }
 }
-// [END iam_modify_policy_member]
 // [END iam_modify_policy_add_member]

--- a/spanner/api/Spanner/GetBackupOperations.cs
+++ b/spanner/api/Spanner/GetBackupOperations.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 // [START spanner_list_backup_operations]
-// [START spanner_get_backup_operations]
 
 using Google.Cloud.Spanner.Admin.Database.V1;
 using Google.Cloud.Spanner.Common.V1;
@@ -53,5 +52,4 @@ namespace GoogleCloudSamples.Spanner
         }
     }
 }
-// [END spanner_get_backup_operations]
 // [END spanner_list_backup_operations]

--- a/spanner/api/Spanner/GetBackups.cs
+++ b/spanner/api/Spanner/GetBackups.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 // [START spanner_list_backups]
-// [START spanner_get_backups]
 
 using Google.Api.Gax;
 using Google.Cloud.Spanner.Admin.Database.V1;
@@ -99,5 +98,4 @@ namespace GoogleCloudSamples.Spanner
         }
     }
 }
-// [END spanner_get_backups]
 // [END spanner_list_backups]

--- a/spanner/api/Spanner/GetDatabaseOperations.cs
+++ b/spanner/api/Spanner/GetDatabaseOperations.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 // [START spanner_list_database_operations]
-// [START spanner_get_database_operations]
 
 using Google.Cloud.Spanner.Admin.Database.V1;
 using Google.Cloud.Spanner.Common.V1;
@@ -52,5 +51,4 @@ namespace GoogleCloudSamples.Spanner
         }
     }
 }
-// [END spanner_get_database_operations]
 // [END spanner_list_database_operations]

--- a/spanner/api/Spanner/RestoreDatabase.cs
+++ b/spanner/api/Spanner/RestoreDatabase.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 // [START spanner_restore_backup]
-// [START spanner_restore_database]
 
 using Google.Cloud.Spanner.Admin.Database.V1;
 using Google.Cloud.Spanner.Common.V1;
@@ -60,5 +59,4 @@ namespace GoogleCloudSamples.Spanner
         }
     }
 }
-// [END spanner_restore_database]
 // [END spanner_restore_backup]


### PR DESCRIPTION
Finalizing the work started in https://github.com/GoogleCloudPlatform/dotnet-docs-samples/pull/1233 and https://github.com/GoogleCloudPlatform/dotnet-docs-samples/pull/1236. This PR removes "inner" tags now that the new tagging is live in docs.