### PR TITLE
feat(IAP): Changes the IAP sample to use Application Default Credentials.

### DIFF
--- a/identity-aware-proxy/IAPClientTest/IAPClientTests.cs
+++ b/identity-aware-proxy/IAPClientTest/IAPClientTests.cs
@@ -30,8 +30,7 @@ namespace IAP.Samples.Tests
         public async Task IAPClient_InvokeAsync()
         {
             IAPClient client = new IAPClient();
-            HttpResponseMessage response = await client.InvokeRequestAsync(
-                _fixture.IAPClientId, _fixture.CredentialsFilePath, _fixture.IAPUri);
+            HttpResponseMessage response = await client.InvokeRequestAsync(_fixture.IAPClientId, _fixture.IAPUri);
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }

--- a/identity-aware-proxy/IAPClientTest/IAPFixture.cs
+++ b/identity-aware-proxy/IAPClientTest/IAPFixture.cs
@@ -20,14 +20,12 @@ namespace IAP.Samples.Tests
     [CollectionDefinition(nameof(IAPFixture))]
     public class IAPFixture : ICollectionFixture<IAPFixture>
     {
-        public string CredentialsFilePath { get; }
         public string IAPClientId { get; }
         public string IAPUri { get; }
         public string IAPTokenExpectedAudience { get; }
 
         public IAPFixture()
         {
-            CredentialsFilePath = GetEnvVarOrThrow("GOOGLE_APPLICATION_CREDENTIALS");
             IAPClientId = GetEnvVarOrThrow("TEST_IAP_CLIENT_ID");
             IAPUri = GetEnvVarOrThrow("TEST_IAP_URI");
             // The IAP token target audience is of the form /projects/<projectID>/apps/<iap-app-name>

--- a/identity-aware-proxy/IAPClientTest/IAPTokenVerificationTests.cs
+++ b/identity-aware-proxy/IAPClientTest/IAPTokenVerificationTests.cs
@@ -32,8 +32,7 @@ namespace IAP.Samples.Tests
         {
             // Let's use our IAPClient, so we make sure that we can actually verify a valid IAP token.
             IAPClient client = new IAPClient();
-            HttpResponseMessage response = await client.InvokeRequestAsync(
-                _fixture.IAPClientId, _fixture.CredentialsFilePath, _fixture.IAPUri);
+            HttpResponseMessage response = await client.InvokeRequestAsync(_fixture.IAPClientId, _fixture.IAPUri);
             // The application we are making a request to simply bounces the IAP token back to us.
             string bouncedToken = await response.Content.ReadAsStringAsync();
 


### PR DESCRIPTION
The [docs](https://cloud.google.com/iap/docs/authentication-howto#obtaining_an_oidc_token_for_the_default_service_account) where this sample is surfaced refers to using default credentials only.