### PR TITLE
feat: add NUMERIC column to table with all data types

### DIFF
--- a/spanner/api/Spanner/Program.cs
+++ b/spanner/api/Spanner/Program.cs
@@ -2908,6 +2908,7 @@ namespace GoogleCloudSamples.Spanner
                     LastContactDate DATE,
                     OutdoorVenue BOOL,
                     PopularityScore FLOAT64,
+                    Revenue NUMERIC,
                     LastUpdateTime TIMESTAMP NOT NULL 
                         OPTIONS (allow_commit_timestamp=true)
                 ) PRIMARY KEY (VenueId)";


### PR DESCRIPTION
The `spanner_create_table_with_datatypes` should create a table with all supported data types in Cloud Spanner. The .NET samples (as well as some other client languages) missed a `NUMERIC` column as this data type was added later than the originally supported data types. This change adds a `NUMERIC` column to the sample to bring it up to date with the samples of
the other client languages, and to bring it in line with the description of the sample.

See also https://cloud.google.com/spanner/docs/samples/spanner-create-table-with-datatypes#spanner_create_table_with_datatypes-java

Fixes #1254