### PR TITLE
fix: use earliest version time for CreateBackup

### DIFF
--- a/spanner/api/Spanner.Samples.Tests/CreateBackupTest.cs
+++ b/spanner/api/Spanner.Samples.Tests/CreateBackupTest.cs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Cloud.Spanner.Data;
 using Grpc.Core;
+using System;
 using Xunit;
 
 [Collection(nameof(SpannerFixture))]
@@ -28,9 +30,15 @@ public class CreateBackupTest
     [Fact]
     public void TestCreateBackup()
     {
+        string connectionString = $"Data Source=projects/{_spannerFixture.ProjectId}/instances/{_spannerFixture.InstanceId}/databases/{_spannerFixture.BackupDatabaseId}";
+        using var connection = new SpannerConnection(connectionString);
+        connection.Open();
+        var currentTimestamp = (DateTime) connection.CreateSelectCommand("SELECT CURRENT_TIMESTAMP").ExecuteScalar();
+
         CreateBackupSample createBackupSample = new CreateBackupSample();
         // Backup already exists since it was created in the test setup so it should throw an exception.
-        var exception = Assert.Throws<RpcException>(() => createBackupSample.CreateBackup(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.BackupDatabaseId, _spannerFixture.BackupId));
+        var exception = Assert.Throws<RpcException>(()
+            => createBackupSample.CreateBackup(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.BackupDatabaseId, _spannerFixture.BackupId, currentTimestamp));
         Assert.Equal(StatusCode.AlreadyExists, exception.StatusCode);
     }
 }

--- a/spanner/api/Spanner.Samples.Tests/SpannerFixture.cs
+++ b/spanner/api/Spanner.Samples.Tests/SpannerFixture.cs
@@ -141,10 +141,13 @@ public class SpannerFixture : IAsyncLifetime, ICollectionFixture<SpannerFixture>
             Console.WriteLine($"Database {BackupDatabaseId} already exists.");
         }
 
+        using var connection = new SpannerConnection(ConnectionString);
+        await connection.OpenAsync();
+        var currentTimestamp = (DateTime)connection.CreateSelectCommand("SELECT CURRENT_TIMESTAMP").ExecuteScalar();
         try
         {
             CreateBackupSample createBackupSample = new CreateBackupSample();
-            createBackupSample.CreateBackup(ProjectId, InstanceId, BackupDatabaseId, BackupId);
+            createBackupSample.CreateBackup(ProjectId, InstanceId, BackupDatabaseId, BackupId, currentTimestamp);
         }
         catch (RpcException e) when (e.StatusCode == StatusCode.AlreadyExists)
         {

--- a/spanner/api/Spanner.Samples/CreateBackup.cs
+++ b/spanner/api/Spanner.Samples/CreateBackup.cs
@@ -22,7 +22,7 @@ using System;
 
 public class CreateBackupSample
 {
-    public Backup CreateBackup(string projectId, string instanceId, string databaseId, string backupId)
+    public Backup CreateBackup(string projectId, string instanceId, string databaseId, string backupId, DateTime versionTime)
     {
         // Create the DatabaseAdminClient instance.
         DatabaseAdminClient databaseAdminClient = DatabaseAdminClient.Create();
@@ -32,7 +32,7 @@ public class CreateBackupSample
         {
             DatabaseAsDatabaseName = DatabaseName.FromProjectInstanceDatabase(projectId, instanceId, databaseId),
             ExpireTime = DateTime.UtcNow.AddDays(14).ToTimestamp(),
-            VersionTime = DateTime.UtcNow.ToTimestamp(),
+            VersionTime = versionTime.ToTimestamp(),
         };
         InstanceName instanceName = InstanceName.FromProjectInstance(projectId, instanceId);
 


### PR DESCRIPTION
Use the earliest version time of the test database instead of the local system time to ensure that the chosen version time is valid.

Fixes #1262 