### PR TITLE
Remove hardcoded image name in CloudDemo manifests

### DIFF
--- a/applications/clouddemo/net4/Dockerfile
+++ b/applications/clouddemo/net4/Dockerfile
@@ -19,7 +19,7 @@
 # under the License.
 #
 
-FROM microsoft/iis
+FROM mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2019
 EXPOSE 80
 SHELL ["powershell", "-command"]
 

--- a/applications/clouddemo/net4/README.md
+++ b/applications/clouddemo/net4/README.md
@@ -4,6 +4,9 @@
 [ASP.NET MVC 5](https://docs.microsoft.com/en-us/aspnet/mvc/overview/getting-started/introduction/getting-started)
 on .NET Framework 4.x. 
 
+For further details on how you can deploy the sample application, see
+[Creating a CI/CD pipeline with Azure Pipelines and Google Kubernetes Engine](https://cloud.google.com/solutions/creating-cicd-pipeline-vsts-kubernetes-engine).
+
 ## Prerequisites
 
 To build the application, you'll need

--- a/applications/clouddemo/net4/deployment.yaml
+++ b/applications/clouddemo/net4/deployment.yaml
@@ -66,7 +66,7 @@ spec:
         cloud.google.com/gke-os-distribution: windows_ltsc
       containers:
       - name: clouddemo-net4
-        image: gcr.io/ntdev-windows-containers/clouddemo-net4:latest
+        image: CLOUDDEMO_IMAGE
         ports:
           - containerPort: 80
         livenessProbe:      # Used by deployment controller

--- a/applications/clouddemo/netcore/README.md
+++ b/applications/clouddemo/netcore/README.md
@@ -4,6 +4,9 @@
 [ASP.NET MVC Core](https://docs.microsoft.com/en-us/aspnet/core/tutorials/first-mvc-app/start-mvc)
 on .NET Core. 
 
+For further details on how you can deploy the sample application, see
+[Creating a CI/CD pipeline with Azure Pipelines and Google Kubernetes Engine](https://cloud.google.com/solutions/creating-cicd-pipeline-vsts-kubernetes-engine).
+
 ## Prerequisites
 
 To build the application, you'll need

--- a/applications/clouddemo/netcore/deployment.yaml
+++ b/applications/clouddemo/netcore/deployment.yaml
@@ -60,7 +60,7 @@ spec:
     spec:
       containers:
       - name: clouddemo-netcore
-        image: gcr.io/ntdev-windows-containers/clouddemo-netcore:latest
+        image: CLOUDDEMO_IMAGE
         ports:
           - containerPort: 8080
         livenessProbe:      # Used by deployment controller


### PR DESCRIPTION
* Use placeholder as image name
* Use LTSC tag for Windows base image