### PR TITLE
ci(assets): Increase test timeout for exporting assets.

### DIFF
--- a/asset/quickstart/ExportAssetsTest/runTests.ps1
+++ b/asset/quickstart/ExportAssetsTest/runTests.ps1
@@ -14,6 +14,8 @@
 
 Import-Module -DisableNameChecking ..\..\..\BuildTools.psm1
 
+Set-TestTimeout 600
+
 $getBucketNameClause = 'Environment.GetEnvironmentVariable("AssetBucketName")'
 BackupAndEdit-TextFile @("..\ExportAssets\ExportAssets.cs") @{
     "YOUR-GOOGLE-PROJECT-ID" = $env:GOOGLE_PROJECT_ID;


### PR DESCRIPTION
Fixes #1273

Default timeout is 300 seconds, so this doubles it.