### PR TITLE
Update Eventarc sample to use latest libraries

### DIFF
--- a/eventarc/audit-storage/README.md
+++ b/eventarc/audit-storage/README.md
@@ -32,15 +32,26 @@ gsutil mb -p $(gcloud config get-value project) \
     gs://${MY_GCS_BUCKET}
 ```
 
+Grant the `eventarc.eventReceiver` role to the Compute Engine service account:
+
+```sh
+export PROJECT_NUMBER="$(gcloud projects describe $(gcloud config get-value project) --format='value(projectNumber)')"
+
+gcloud projects add-iam-policy-binding $(gcloud config get-value project) \
+    --member=serviceAccount:${PROJECT_NUMBER}-compute@developer.gserviceaccount.com \
+    --role='roles/eventarc.eventReceiver'
+```
+
 Create Cloud Storage trigger:
 
 ```sh
-gcloud beta events triggers create my-gcs-trigger \
+gcloud eventarc triggers create my-gcs-trigger \
   --destination-run-service ${MY_RUN_SERVICE} \
-  --matching-criteria type=google.cloud.audit.log.v1.written \
-  --matching-criteria methodName=storage.buckets.update \
-  --matching-criteria serviceName=storage.googleapis.com \
-  --matching-criteria resourceName=projects/_/buckets/"$MY_GCS_BUCKET"
+  --event-filters type=google.cloud.audit.log.v1.written \
+  --event-filters methodName=storage.buckets.update \
+  --event-filters serviceName=storage.googleapis.com \
+  --event-filters resourceName=projects/_/buckets/"$MY_GCS_BUCKET" \
+  --service-account=${PROJECT_NUMBER}-compute@developer.gserviceaccount.com
 ```
 
 ## Test

--- a/eventarc/pubsub/PubSub.csproj
+++ b/eventarc/pubsub/PubSub.csproj
@@ -6,9 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="CloudNative.CloudEvents" Version="1.3.80" />
-    <PackageReference Include="CloudNative.CloudEvents.AspNetCore" Version="1.3.80" />
-    <PackageReference Include="Google.Events" Version="1.0.0-alpha04" />
-    <PackageReference Include="Google.Events.Protobuf" Version="1.0.0-alpha04" />
+    <PackageReference Include="CloudNative.CloudEvents.AspNetCore" Version="2.0.0" />
+    <PackageReference Include="Google.Events.Protobuf" Version="1.0.0" />
   </ItemGroup>
 </Project>

--- a/eventarc/pubsub/README.md
+++ b/eventarc/pubsub/README.md
@@ -16,9 +16,9 @@ gcloud run deploy eventarc-pubsub \
 Create a Cloud Pub/Sub trigger:
 
 ```sh
-gcloud beta eventarc triggers create pubsub-trigger \
+gcloud eventarc triggers create pubsub-trigger \
   --destination-run-service eventarc-pubsub \
-  --matching-criteria "type=google.cloud.pubsub.topic.v1.messagePublished"
+  --event-filters "type=google.cloud.pubsub.topic.v1.messagePublished"
 ```
 
 ## Test

--- a/eventarc/pubsub/README.md
+++ b/eventarc/pubsub/README.md
@@ -16,7 +16,7 @@ gcloud run deploy eventarc-pubsub \
 Create a Cloud Pub/Sub trigger:
 
 ```sh
-gcloud beta events triggers create pubsub-trigger \
+gcloud beta eventarc triggers create pubsub-trigger \
   --destination-run-service eventarc-pubsub \
   --matching-criteria "type=google.cloud.pubsub.topic.v1.messagePublished"
 ```
@@ -26,7 +26,7 @@ gcloud beta events triggers create pubsub-trigger \
 Test your Cloud Run service by publishing a message to the topic:
 
 ```sh
-TOPIC=$(gcloud beta eventarc triggers describe pubsub-trigger \
+TOPIC=$(gcloud eventarc triggers describe pubsub-trigger \
 --format="value(transport.pubsub.topic)")
 
 echo "Listening to events on topic: $TOPIC"

--- a/eventarc/pubsub/Startup.cs
+++ b/eventarc/pubsub/Startup.cs
@@ -15,7 +15,7 @@
 // [START eventarc_pubsub_handler]
 
 using CloudNative.CloudEvents;
-using Google.Events;
+using CloudNative.CloudEvents.AspNetCore;
 using Google.Events.Protobuf.Cloud.PubSub.V1;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -45,10 +45,11 @@ public class Startup
         {
             endpoints.MapPost("/", async context =>
             {
-                var cloudEvent = await context.Request.ReadCloudEventAsync();
+                var formatter = CloudEventFormatterAttribute.CreateFormatter(typeof(MessagePublishedData));
+                var cloudEvent = await context.Request.ToCloudEventAsync(formatter);
                 logger.LogInformation("Received CloudEvent\n" + GetEventLog(cloudEvent));
 
-                var messagePublishedData = CloudEventConverters.ConvertCloudEventData<MessagePublishedData>(cloudEvent);
+                var messagePublishedData = (MessagePublishedData) cloudEvent.Data;
                 var pubSubMessage = messagePublishedData.Message;
                 if (pubSubMessage == null)
                 {
@@ -77,7 +78,7 @@ public class Startup
             + $"Subject: {cloudEvent.Subject}\n"
             + $"DataSchema: {cloudEvent.DataSchema}\n"
             + $"DataContentType: {cloudEvent.DataContentType}\n"
-            + $"Time: {cloudEvent.Time?.ToUniversalTime():yyyy-MM-dd'T'HH:mm:ss.fff'Z'}\n"
+            + $"Time: {cloudEvent.Time?.UtcDateTime:yyyy-MM-dd'T'HH:mm:ss.fff'Z'}\n"
             + $"SpecVersion: {cloudEvent.SpecVersion}\n"
             + $"Data: {cloudEvent.Data}";
     }


### PR DESCRIPTION
Both CloudNative.CloudEvents and Google.Events.Protobuf have
changed significantly since this sample was originally written.

The `gcloud eventarc` command is now GA, but creating a trigger with
a `matching-criteria` parameter still requires the `beta` component.