### PR TITLE
chore: Update API client library dependencies in Functions samples

### DIFF
--- a/functions/firebase/FirestoreReactive/FirestoreReactive.csproj
+++ b/functions/firebase/FirestoreReactive/FirestoreReactive.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Firestore" Version="2.1.0" />
+    <PackageReference Include="Google.Cloud.Firestore" Version="2.4.0" />
     <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.0.0" />
   </ItemGroup>

--- a/functions/imagemagick/ImageMagick/ImageMagick.csproj
+++ b/functions/imagemagick/ImageMagick/ImageMagick.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0" />
-    <PackageReference Include="Google.Cloud.Storage.V1" Version="3.2.0" />
-    <PackageReference Include="Google.Cloud.Vision.V1" Version="2.0.0" />
+    <PackageReference Include="Google.Cloud.Storage.V1" Version="3.5.0" />
+    <PackageReference Include="Google.Cloud.Vision.V1" Version="2.3.0" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.0.0" />
   </ItemGroup>
 </Project>

--- a/functions/slack/SlackKnowledgeGraphSearch/SlackKnowledgeGraphSearch.csproj
+++ b/functions/slack/SlackKnowledgeGraphSearch/SlackKnowledgeGraphSearch.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Apis.Kgsearch.v1" Version="1.49.0.2047" />
+    <PackageReference Include="Google.Apis.Kgsearch.v1" Version="1.52.0.2143" />
     <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This avoids using old (huge) versions of Grpc.Core.