### PR TITLE
refactor(Storage): Retries HMAC key cleanup.

### DIFF
--- a/storage/api/Storage.Samples.Tests/ActivateHmacKeyTest.cs
+++ b/storage/api/Storage.Samples.Tests/ActivateHmacKeyTest.cs
@@ -12,30 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using Xunit;
 
 [Collection(nameof(BucketFixture))]
-public class ActivateHmacKeyTest : IDisposable
+public class ActivateHmacKeyTest : HmacKeyManager
 {
-    private readonly BucketFixture _bucketFixture;
-
-    private string _accessId;
-    private bool _isActive = true;
-
-    public ActivateHmacKeyTest(BucketFixture bucketFixture)
-    {
-        _bucketFixture = bucketFixture;
-    }
-
-    public void Dispose()
-    {
-        if (_accessId is string)
-        {
-            _bucketFixture.DeleteHmacKey(_accessId, _isActive);
-            _accessId = null;
-        }
-    }
+    public ActivateHmacKeyTest(BucketFixture bucketFixture) : base(bucketFixture)
+    { }
 
     [Fact]
     public void TestActivateHmacKey()

--- a/storage/api/Storage.Samples.Tests/CreateHmacKeyTest.cs
+++ b/storage/api/Storage.Samples.Tests/CreateHmacKeyTest.cs
@@ -12,16 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using Xunit;
 
 [Collection(nameof(BucketFixture))]
-public class CreateHmacKeyTest
+public class CreateHmacKeyTest : IDisposable
 {
     private readonly BucketFixture _bucketFixture;
+
+    private string _accessId;
 
     public CreateHmacKeyTest(BucketFixture bucketFixture)
     {
         _bucketFixture = bucketFixture;
+    }
+
+    public void Dispose()
+    {
+        if (_accessId is string)
+        {
+            _bucketFixture.DeleteHmacKey(_accessId, true);
+            _accessId = null;
+        }
     }
 
     [Fact]
@@ -32,9 +44,7 @@ public class CreateHmacKeyTest
 
         // Create key.
         var key = createHmacKeySample.CreateHmacKey(_bucketFixture.ProjectId, serviceAccountEmail);
+        _accessId = key.Metadata.AccessId;
         Assert.Equal(key.Metadata.ServiceAccountEmail, serviceAccountEmail);
-
-        // Delete key.
-        _bucketFixture.DeleteHmacKey(key.Metadata.AccessId);
     }
 }

--- a/storage/api/Storage.Samples.Tests/CreateHmacKeyTest.cs
+++ b/storage/api/Storage.Samples.Tests/CreateHmacKeyTest.cs
@@ -12,29 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using Xunit;
 
 [Collection(nameof(BucketFixture))]
-public class CreateHmacKeyTest : IDisposable
+public class CreateHmacKeyTest : HmacKeyManager
 {
-    private readonly BucketFixture _bucketFixture;
-
-    private string _accessId;
-
-    public CreateHmacKeyTest(BucketFixture bucketFixture)
-    {
-        _bucketFixture = bucketFixture;
-    }
-
-    public void Dispose()
-    {
-        if (_accessId is string)
-        {
-            _bucketFixture.DeleteHmacKey(_accessId, true);
-            _accessId = null;
-        }
-    }
+    public CreateHmacKeyTest(BucketFixture bucketFixture) : base(bucketFixture)
+    { }
 
     [Fact]
     public void TestCreateHmacKey()

--- a/storage/api/Storage.Samples.Tests/DeactivateHmacKeyTest.cs
+++ b/storage/api/Storage.Samples.Tests/DeactivateHmacKeyTest.cs
@@ -12,30 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using Xunit;
 
 [Collection(nameof(BucketFixture))]
-public class DeactivateHmacKeyTest : IDisposable
+public class DeactivateHmacKeyTest : HmacKeyManager
 {
-    private readonly BucketFixture _bucketFixture;
-
-    private string _accessId;
-    private bool _isActive = true;
-
-    public DeactivateHmacKeyTest(BucketFixture bucketFixture)
-    {
-        _bucketFixture = bucketFixture;
-    }
-
-    public void Dispose()
-    {
-        if (_accessId is string)
-        {
-            _bucketFixture.DeleteHmacKey(_accessId, _isActive);
-            _accessId = null;
-        }
-    }
+    public DeactivateHmacKeyTest(BucketFixture bucketFixture) : base(bucketFixture)
+    { }
 
     [Fact]
     public void TestDeactivateHmacKey()

--- a/storage/api/Storage.Samples.Tests/DeleteHmacKeyTest.cs
+++ b/storage/api/Storage.Samples.Tests/DeleteHmacKeyTest.cs
@@ -12,30 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using Xunit;
 
 [Collection(nameof(BucketFixture))]
-public class DeleteHmacKeyTest : IDisposable
+public class DeleteHmacKeyTest : HmacKeyManager
 {
-    private readonly BucketFixture _bucketFixture;
-
-    private string _accessId;
-    private bool _isActive = true;
-
-    public DeleteHmacKeyTest(BucketFixture bucketFixture)
-    {
-        _bucketFixture = bucketFixture;
-    }
-
-    public void Dispose()
-    {
-        if (_accessId is string)
-        {
-            _bucketFixture.DeleteHmacKey(_accessId, _isActive);
-            _accessId = null;
-        }
-    }
+    public DeleteHmacKeyTest(BucketFixture bucketFixture) : base(bucketFixture)
+    { }
 
     [Fact]
     public void TestDeleteHmacKey()

--- a/storage/api/Storage.Samples.Tests/GetHmacKeyTest.cs
+++ b/storage/api/Storage.Samples.Tests/GetHmacKeyTest.cs
@@ -12,16 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using Xunit;
 
 [Collection(nameof(BucketFixture))]
-public class GetHmacKeyTest
+public class GetHmacKeyTest : IDisposable
 {
     private readonly BucketFixture _bucketFixture;
+    private string _accessId;
 
     public GetHmacKeyTest(BucketFixture bucketFixture)
     {
         _bucketFixture = bucketFixture;
+    }
+
+    public void Dispose()
+    {
+        if (_accessId is string)
+        {
+            _bucketFixture.DeleteHmacKey(_accessId, true);
+            _accessId = null;
+        }
     }
 
     [Fact]
@@ -34,12 +45,10 @@ public class GetHmacKeyTest
 
         // Create key.
         var key = createHmacKeySample.CreateHmacKey(_bucketFixture.ProjectId, serviceAccountEmail);
+        _accessId = key.Metadata.AccessId;
 
         // Get key.
-        var keyMetadata = getHmacKeySample.GetHmacKey(_bucketFixture.ProjectId, key.Metadata.AccessId);
+        var keyMetadata = getHmacKeySample.GetHmacKey(_bucketFixture.ProjectId, _accessId);
         Assert.Equal(keyMetadata.ServiceAccountEmail, serviceAccountEmail);
-
-        // Delete key.
-        _bucketFixture.DeleteHmacKey(key.Metadata.AccessId);
     }
 }

--- a/storage/api/Storage.Samples.Tests/GetHmacKeyTest.cs
+++ b/storage/api/Storage.Samples.Tests/GetHmacKeyTest.cs
@@ -12,28 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using Xunit;
 
 [Collection(nameof(BucketFixture))]
-public class GetHmacKeyTest : IDisposable
+public class GetHmacKeyTest : HmacKeyManager
 {
-    private readonly BucketFixture _bucketFixture;
-    private string _accessId;
-
-    public GetHmacKeyTest(BucketFixture bucketFixture)
-    {
-        _bucketFixture = bucketFixture;
-    }
-
-    public void Dispose()
-    {
-        if (_accessId is string)
-        {
-            _bucketFixture.DeleteHmacKey(_accessId, true);
-            _accessId = null;
-        }
-    }
+    public GetHmacKeyTest(BucketFixture bucketFixture) : base(bucketFixture)
+    { }
 
     [Fact]
     public void TestGetHmacKey()

--- a/storage/api/Storage.Samples.Tests/HmacKeyManager.cs
+++ b/storage/api/Storage.Samples.Tests/HmacKeyManager.cs
@@ -1,0 +1,34 @@
+﻿// Copyright 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+public class HmacKeyManager : IDisposable
+{
+    protected readonly BucketFixture _bucketFixture;
+
+    protected string _accessId;
+    protected bool _isActive = true;
+
+    public HmacKeyManager(BucketFixture bucketFixture) => _bucketFixture = bucketFixture;
+
+    public void Dispose()
+    {
+        if (_accessId is string)
+        {
+            _bucketFixture.DeleteHmacKey(_accessId, _isActive);
+            _accessId = null;
+        }
+    }
+}

--- a/storage/api/Storage.Samples.Tests/ListHmacKeysTest.cs
+++ b/storage/api/Storage.Samples.Tests/ListHmacKeysTest.cs
@@ -12,16 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using Xunit;
 
 [Collection(nameof(BucketFixture))]
-public class ListHmacKeysTest
+public class ListHmacKeysTest : IDisposable
 {
     private readonly BucketFixture _bucketFixture;
+    private string _accessId;
 
     public ListHmacKeysTest(BucketFixture bucketFixture)
     {
         _bucketFixture = bucketFixture;
+    }
+
+    public void Dispose()
+    {
+        if (_accessId is string)
+        {
+            _bucketFixture.DeleteHmacKey(_accessId, true);
+            _accessId = null;
+        }
     }
 
     [Fact]
@@ -34,12 +45,10 @@ public class ListHmacKeysTest
 
         // Create key.
         var key = createHmacKeySample.CreateHmacKey(_bucketFixture.ProjectId, serviceAccountEmail);
+        _accessId = key.Metadata.AccessId;
 
         // List keys.
         var keys = listHmacKeysSample.ListHmacKeys(_bucketFixture.ProjectId);
         Assert.Contains(keys, key => key.AccessId == key.AccessId);
-
-        // Delete key.
-        _bucketFixture.DeleteHmacKey(key.Metadata.AccessId);
     }
 }

--- a/storage/api/Storage.Samples.Tests/ListHmacKeysTest.cs
+++ b/storage/api/Storage.Samples.Tests/ListHmacKeysTest.cs
@@ -12,28 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using Xunit;
 
 [Collection(nameof(BucketFixture))]
-public class ListHmacKeysTest : IDisposable
+public class ListHmacKeysTest : HmacKeyManager
 {
-    private readonly BucketFixture _bucketFixture;
-    private string _accessId;
-
-    public ListHmacKeysTest(BucketFixture bucketFixture)
-    {
-        _bucketFixture = bucketFixture;
-    }
-
-    public void Dispose()
-    {
-        if (_accessId is string)
-        {
-            _bucketFixture.DeleteHmacKey(_accessId, true);
-            _accessId = null;
-        }
-    }
+    public ListHmacKeysTest(BucketFixture bucketFixture) : base(bucketFixture)
+    { }
 
     [Fact]
     public void TestListHmacKeys()


### PR DESCRIPTION
And moves the cleanup to individual Dispose methods so that tests themselves are not delayed.
Note: HMAC keys need to be deleted inmediately because only 5 are allowed per service account.
Fixes #1272