### PR TITLE
build: Ignore dependecy updates for apps that need modernization.

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,15 @@
 {
-  "extends": [
-    "config:base"
-  ],
-  "schedule": ["before 8am"],
-  "timezone": "Europe/London"
+    "extends": [
+        "config:base"
+    ],
+    "ignorePaths": [
+        "bigtable/api/**",
+        "appengine/flexible/**",
+        "endpoints/getting-started/**",
+        "applications/googlehome-meets-dotnetcontainers/**"
+    ],
+    "schedule": [
+        "before 8am"
+    ],
+    "timezone": "Europe/London"
 }


### PR DESCRIPTION
- #992 tracks Bigtable samples modernization.
- #1004 tracks AppEngine samples modernization.
- #1426 tracks Endpoints samples modernizaton.
- #1427 trackes Google Home samples modernization.

Closes #1434
Closes #1430