### PR TITLE
chore(storage): Undo dependecy update

### DIFF
--- a/storage/api/Storage/Storage.csproj
+++ b/storage/api/Storage/Storage.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Storage.V1" Version="3.5.0" />
+    <PackageReference Include="Google.Cloud.Storage.V1" Version="3.0.0-beta02" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This is just we can avoid conflicts in #1201 which deletes this file anyway. And we don't have access to that PR's branch anymore.