### PR TITLE
tests(Compute): Load tools from the correct path.

### DIFF
--- a/compute/api/runTests.ps1
+++ b/compute/api/runTests.ps1
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import-module -DisableNameChecking ..\..\..\BuildTools.psm1
+import-module -DisableNameChecking ..\..\BuildTools.psm1
 
 Set-TestTimeout 1200
 


### PR DESCRIPTION
This is why timeout was not having any effect.