### PR TITLE
tests(transcoder): Retry some more the job poller.

### DIFF
--- a/media/transcoder/api/Transcoder.Samples.Tests/TranscoderFixture.cs
+++ b/media/transcoder/api/Transcoder.Samples.Tests/TranscoderFixture.cs
@@ -48,7 +48,7 @@ public class TranscoderFixture : IDisposable, ICollectionFixture<TranscoderFixtu
     public RetryRobot JobPoller { get; } = new RetryRobot
     {
         FirstRetryDelayMs = 15000,
-        DelayMultiplier = 1.5f,
+        DelayMultiplier = 2,
         MaxTryCount = 20,
         ShouldRetry = ex => ex is XunitException ||
             (ex is GoogleApiException gex &&


### PR DESCRIPTION
Some of the jobs are still running when we stop retrying.
We might need to increase the overall timeout after this change.