### PR TITLE
feat(run/pubsub): add Cloud Run sample for Pub/Sub tutorial

### DIFF
--- a/run/pubsub/Run.Samples.Pubsub.MinimalApi.Tests/PostHandlerTests.cs
+++ b/run/pubsub/Run.Samples.Pubsub.MinimalApi.Tests/PostHandlerTests.cs
@@ -1,0 +1,66 @@
+// Copyright 2022 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+public class PostHandlerTests
+{
+    [Fact]
+    public async Task HandleRequet_ValidObject_ReturnsSuccessAccepted()
+    {
+        var app = new WebApplicationFactory<Program>();
+        var client = app.CreateClient();
+        var jsonPayload = @"{
+            ""message"": {
+                ""data"":""dGVzdA=="", 
+                ""attributes"": {},
+                ""messageId"": ""9101075178894"", 
+                ""publishTime"":""2017-09-25T23:16:42.302Z""
+                }
+            }";
+
+        var response = await client.PostAsync("/", new StringContent(jsonPayload, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task HandleRequet_EmptyObject_ReturnsBadRequest()
+    {
+        var app = new WebApplicationFactory<Program>();
+        var client = app.CreateClient();
+        var jsonPayload = "{}";
+
+        var response = await client.PostAsync("/", new StringContent(jsonPayload, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task HandleRequet_NoData_ReturnsBadRequest()
+    {
+        var app = new WebApplicationFactory<Program>();
+        var client = app.CreateClient();
+        var jsonPayload = string.Empty;
+
+        var response = await client.PostAsync("/", new StringContent(jsonPayload, Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+}

--- a/run/pubsub/Run.Samples.Pubsub.MinimalApi.Tests/Run.Samples.Pubsub.MinimalApi.Tests.csproj
+++ b/run/pubsub/Run.Samples.Pubsub.MinimalApi.Tests/Run.Samples.Pubsub.MinimalApi.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/run/pubsub/Run.Samples.Pubsub.MinimalApi.Tests/Run.Samples.Pubsub.MinimalApi.Tests.csproj
+++ b/run/pubsub/Run.Samples.Pubsub.MinimalApi.Tests/Run.Samples.Pubsub.MinimalApi.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Run.Samples.Pubsub.MinimalApi\Run.Samples.Pubsub.MinimalApi.csproj" />
+  </ItemGroup>
+</Project>

--- a/run/pubsub/Run.Samples.Pubsub.MinimalApi/.gcloudignore
+++ b/run/pubsub/Run.Samples.Pubsub.MinimalApi/.gcloudignore
@@ -1,0 +1,12 @@
+# The .gcloudignore file excludes file from upload to Cloud Build.
+# If this file is deleted, gcloud will default to .gitignore.
+#
+# https://cloud.google.com/cloud-build/docs/speeding-up-builds#gcloudignore
+# https://cloud.google.com/sdk/gcloud/reference/topic/gcloudignore
+
+**/obj/
+**/bin/
+
+# Exclude git history and configuration.
+.git/
+.gitignore

--- a/run/pubsub/Run.Samples.Pubsub.MinimalApi/Dockerfile
+++ b/run/pubsub/Run.Samples.Pubsub.MinimalApi/Dockerfile
@@ -1,0 +1,33 @@
+# Copyright 2022 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build in SDK base image
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
+WORKDIR /app
+
+COPY *.csproj ./
+RUN dotnet restore
+
+COPY . ./
+RUN dotnet publish -r linux-x64 --no-self-contained -p:PublishReadyToRun=true -c Release -o out
+
+# Copy to runtime image
+FROM mcr.microsoft.com/dotnet/aspnet:6.0
+WORKDIR /app
+COPY --from=build-env /app/out .
+
+# Port passed in by Cloud Run via environment variable PORT.  Default 8080.
+ENV PORT=8080
+
+ENTRYPOINT ["dotnet", "Run.Samples.Pubsub.MinimalApi.dll"]

--- a/run/pubsub/Run.Samples.Pubsub.MinimalApi/Dockerfile
+++ b/run/pubsub/Run.Samples.Pubsub.MinimalApi/Dockerfile
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START cloudrun_pubsub_dockerfile]
 # Build in SDK base image
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
 WORKDIR /app
@@ -31,3 +32,4 @@ COPY --from=build-env /app/out .
 ENV PORT=8080
 
 ENTRYPOINT ["dotnet", "Run.Samples.Pubsub.MinimalApi.dll"]
+# [END cloudrun_pubsub_dockerfile]

--- a/run/pubsub/Run.Samples.Pubsub.MinimalApi/Program.cs
+++ b/run/pubsub/Run.Samples.Pubsub.MinimalApi/Program.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// [START cloudrun_pubsub_server]
 var builder = WebApplication.CreateBuilder(args);
 var app = builder.Build();
 
@@ -20,7 +21,9 @@ if (port != null)
 {
     app.Urls.Add($"http://0.0.0.0:{port}");
 }
+// [END cloudrun_pubsub_server]
 
+// [START cloudrun_pubsub_handler]
 app.MapPost("/", (Envelope envelope) =>
 {
     if (envelope?.Message?.Data == null)
@@ -36,6 +39,7 @@ app.MapPost("/", (Envelope envelope) =>
 
     return Results.NoContent();
 });
+// [END cloudrun_pubsub_handler]
 
 app.Run();
 

--- a/run/pubsub/Run.Samples.Pubsub.MinimalApi/Program.cs
+++ b/run/pubsub/Run.Samples.Pubsub.MinimalApi/Program.cs
@@ -1,0 +1,47 @@
+// Copyright 2022 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+var port = Environment.GetEnvironmentVariable("PORT");
+if (port != null)
+{
+    app.Urls.Add($"http://0.0.0.0:{port}");
+}
+
+app.MapPost("/", (Envelope envelope) =>
+{
+    if (envelope?.Message?.Data == null)
+    {
+        app.Logger.LogWarning("Bad Request: Invalid Pub/Sub message format.");
+        return Results.BadRequest();
+    }
+
+    var data = Convert.FromBase64String(envelope.Message.Data);
+    var target = System.Text.Encoding.UTF8.GetString(data);
+
+    app.Logger.LogInformation($"Hello {target}!");
+
+    return Results.NoContent();
+});
+
+app.Run();
+
+record Message(string MessageId, string Data, DateTime PublishTime);
+
+record Envelope(Message Message);
+
+// Expose partial class for testing.
+public partial class Program { }

--- a/run/pubsub/Run.Samples.Pubsub.MinimalApi/Run.Samples.Pubsub.MinimalApi.csproj
+++ b/run/pubsub/Run.Samples.Pubsub.MinimalApi/Run.Samples.Pubsub.MinimalApi.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/run/pubsub/Run.Samples.Pubsub.sln
+++ b/run/pubsub/Run.Samples.Pubsub.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30114.105
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Run.Samples.Pubsub.MinimalApi", "Run.Samples.Pubsub.MinimalApi\Run.Samples.Pubsub.MinimalApi.csproj", "{687ACC00-3BA9-42BB-AECC-540DAE518502}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Run.Samples.Pubsub.MinimalApi.Tests", "Run.Samples.Pubsub.MinimalApi.Tests\Run.Samples.Pubsub.MinimalApi.Tests.csproj", "{8750C6AA-06A8-4F5A-AD29-06411B3BEDAC}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{687ACC00-3BA9-42BB-AECC-540DAE518502}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{687ACC00-3BA9-42BB-AECC-540DAE518502}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{687ACC00-3BA9-42BB-AECC-540DAE518502}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{687ACC00-3BA9-42BB-AECC-540DAE518502}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8750C6AA-06A8-4F5A-AD29-06411B3BEDAC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8750C6AA-06A8-4F5A-AD29-06411B3BEDAC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8750C6AA-06A8-4F5A-AD29-06411B3BEDAC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8750C6AA-06A8-4F5A-AD29-06411B3BEDAC}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/run/pubsub/runTests.ps1
+++ b/run/pubsub/runTests.ps1
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/run/pubsub/runTests.ps1
+++ b/run/pubsub/runTests.ps1
@@ -1,0 +1,16 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+dotnet restore --force
+dotnet test --no-restore --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }


### PR DESCRIPTION
Example that logs a simple Pub/Sub message consistent with examples from other frameworks.
Provides the code to implement the tutorial at https://cloud.google.com/run/docs/tutorials/pubsub

Implemented with .NET 6 and Minimal APIs.