### PR TITLE
docs: add Google Cloud Samples browser link to readme template

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The samples in this repo cover only _some_ of the total APIs that you can call f
 
 ## Google Cloud Samples
 
-To browse ready to use code samples check [Google Cloud Samples](https://cloud.google.com/docs/samples).
+You can also browse these samples, and more in [Google Cloud Samples](https://cloud.google.com/docs/samples).
 
 
 ### Build Status

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ lists all the _Cloud_ APIs you can call from .NET.
 
 The samples in this repo cover only _some_ of the total APIs that you can call from .NET.
 
+## Google Cloud Samples
+
+To browse ready to use code samples check [Google Cloud Samples](https://cloud.google.com/docs/samples).
+
+
 ### Build Status
 
 | Windows | Linux |


### PR DESCRIPTION
Adding a generic Google Code Sample link to the readme template.
 
This is for the benefit of the users, in navigating available Google Cloud code samples.