### PR TITLE
tests: Skip Bigtable samples tests as dependencies are now too old.

### DIFF
--- a/bigtable/api/BigtableTest/runTests.ps1
+++ b/bigtable/api/BigtableTest/runTests.ps1
@@ -12,6 +12,9 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
+# Skipping tests because of https://github.com/GoogleCloudPlatform/dotnet-docs-samples/issues/992
+return
+
 Import-Module ..\..\..\BuildTools.psm1 -DisableNameChecking
 
 Require-Platform Win*

--- a/bigtable/api/SnippetsTest/runTest.ps1
+++ b/bigtable/api/SnippetsTest/runTest.ps1
@@ -11,4 +11,6 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under
 # the License.
-dotnet test --test-adapter-path:. --logger:junit -v n
+
+dotnet restore --force
+dotnet test --no-restore --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }


### PR DESCRIPTION
See #992