### PR TITLE
Update some GAX V4 dependencies.

### DIFF
--- a/asset/api/Asset.Samples.Tests/Asset.Samples.Tests.csproj
+++ b/asset/api/Asset.Samples.Tests/Asset.Samples.Tests.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.BigQuery.V2" Version="2.4.0" />
+    <PackageReference Include="Google.Cloud.BigQuery.V2" Version="3.0.0" />
     <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/asset/api/Asset.Samples/Asset.Samples.csproj
+++ b/asset/api/Asset.Samples/Asset.Samples.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Asset.V1" Version="2.11.0" />
+    <PackageReference Include="Google.Cloud.Asset.V1" Version="3.0.0" />
   </ItemGroup>
 
 </Project>

--- a/bigquery/api/SimpleApp/SimpleApp.csproj
+++ b/bigquery/api/SimpleApp/SimpleApp.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.BigQuery.V2" Version="2.4.0" />
+    <PackageReference Include="Google.Cloud.BigQuery.V2" Version="3.0.0" />
     <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/bigquery/api/Snippets/Snippets.csproj
+++ b/bigquery/api/Snippets/Snippets.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.BigQuery.V2" Version="2.4.0" />
+    <PackageReference Include="Google.Cloud.BigQuery.V2" Version="3.0.0" />
     <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/bigquery/data-transfer/api/QuickStart/QuickStart.csproj
+++ b/bigquery/data-transfer/api/QuickStart/QuickStart.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.BigQuery.DataTransfer.V1" Version="3.4.0" />
+    <PackageReference Include="Google.Cloud.BigQuery.DataTransfer.V1" Version="4.0.0" />
   </ItemGroup>
 
 </Project>

--- a/bigquery/data-transfer/api/QuickStartTest/QuickStartTest.csproj
+++ b/bigquery/data-transfer/api/QuickStartTest/QuickStartTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/dlp/api/Snippets.Tests/Snippets.Tests.csproj
+++ b/dlp/api/Snippets.Tests/Snippets.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/dlp/api/Snippets/Snippets.csproj
+++ b/dlp/api/Snippets/Snippets.csproj
@@ -4,8 +4,8 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Dlp.V2" Version="3.5.0" />
-    <PackageReference Include="Google.Cloud.BigQuery.V2" Version="2.4.0" />
-    <PackageReference Include="Google.Cloud.PubSub.V1" Version="2.10.0" />
+    <PackageReference Include="Google.Cloud.Dlp.V2" Version="4.0.0" />
+    <PackageReference Include="Google.Cloud.BigQuery.V2" Version="3.0.0" />
+    <PackageReference Include="Google.Cloud.PubSub.V1" Version="3.0.0-beta01" />
   </ItemGroup>
 </Project>

--- a/testutil/testutil.csproj
+++ b/testutil/testutil.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Storage.V1" Version="3.7.0" />
+    <PackageReference Include="Google.Cloud.Storage.V1" Version="4.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Some of these need to be updated together, or the target framework updated. Renovate does not know to do that.