### PR TITLE
samples(storage): remove PrivatePreview field from sample

### DIFF
--- a/storage/api/Storage.Samples/EnableBucketLifecycleManagement.cs
+++ b/storage/api/Storage.Samples/EnableBucketLifecycleManagement.cs
@@ -52,7 +52,6 @@ public class EnableBucketLifecycleManagementSample
             Console.WriteLine($"Days Since Custom Time: \t{rule.Condition.DaysSinceCustomTime}");
             Console.WriteLine($"Days Since Non-current Time: \t{rule.Condition.DaysSinceNoncurrentTime}");
             Console.WriteLine($"IsLive: \t{rule.Condition.IsLive}");
-            Console.WriteLine($"Pattern: \t{rule.Condition.MatchesPattern}");
             Console.WriteLine($"Storage Class: \t{rule.Condition.MatchesStorageClass}");
             Console.WriteLine($"Noncurrent Time Before: \t{rule.Condition.NoncurrentTimeBefore}");
             Console.WriteLine($"Newer Versions: \t{rule.Condition.NumNewerVersions}");


### PR DESCRIPTION
`MatchesPrefix` and `MatchesSuffix` used to be `MatchesPattern`. `MatchesPattern` has been private preview and there are plans for it to be deprecated with `MatchesPrefix` and `MatchesSuffix` now released. It should be removed from this sample.