### PR TITLE
Use new Ingress resource for CloudDemo app

### DIFF
--- a/applications/clouddemo/net4/deployment.yaml
+++ b/applications/clouddemo/net4/deployment.yaml
@@ -37,14 +37,16 @@ spec:
   type: NodePort
 
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: clouddemo-net4
 spec:
-  backend:
-    serviceName: clouddemo-net4
-    servicePort: 80
+  defaultBackend:
+    service:
+      name: clouddemo-net4
+      port:
+        number: 80
 
 ---
 apiVersion: apps/v1

--- a/applications/clouddemo/netcore/deployment.yaml
+++ b/applications/clouddemo/netcore/deployment.yaml
@@ -34,14 +34,16 @@ spec:
   type: NodePort
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: clouddemo-netcore
 spec:
-  backend:
-    serviceName: clouddemo-netcore
-    servicePort: 80
+  defaultBackend:
+    service:
+      name: clouddemo-netcore
+      port:
+        number: 80
 
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
Use networking.k8s.io/v1 instead of extensions/v1beta1
as the latter is no longer supported in recent GKE/
Kubernetes versions.