### PR TITLE
feat: Exactly once delivery subscriber sample.

### DIFF
--- a/pubsub/api/Pubsub.Samples.Tests/CreateSubscriptionWithExactlyOnceDeliveryTest.cs
+++ b/pubsub/api/Pubsub.Samples.Tests/CreateSubscriptionWithExactlyOnceDeliveryTest.cs
@@ -1,0 +1,42 @@
+﻿// Copyright 2022 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+
+[Collection(nameof(PubsubFixture))]
+public class CreateSubscriptionWithExactlyOnceDeliveryTest
+{
+    private readonly PubsubFixture _pubsubFixture;
+    private readonly CreateSubscriptionWithExactlyOnceDeliverySample _createSubscriptionWithExactlyOnceDeliverySample;
+
+    public CreateSubscriptionWithExactlyOnceDeliveryTest(PubsubFixture pubsubFixture)
+    {
+        _pubsubFixture = pubsubFixture;
+        _createSubscriptionWithExactlyOnceDeliverySample = new CreateSubscriptionWithExactlyOnceDeliverySample();
+    }
+
+    [Fact]
+    public void CreateSubscriptionWithExactlyOnceDelivery()
+    {
+        string randomName = _pubsubFixture.RandomName();
+        string topicId = $"testTopicForExactlyOnceDeliverySubscriptionCreation{randomName}";
+        string subscriptionId = $"testSubscriptionForExactlyOnceDelivery{randomName}";
+
+        _pubsubFixture.CreateTopic(topicId);
+        _pubsubFixture.TempSubscriptionIds.Add(subscriptionId);
+        _createSubscriptionWithExactlyOnceDeliverySample.CreateSubscriptionWithExactlyOnceDelivery(_pubsubFixture.ProjectId, topicId, subscriptionId);
+        var subscription = _pubsubFixture.GetSubscription(subscriptionId);
+        Assert.True(subscription.EnableExactlyOnceDelivery);
+    }
+}

--- a/pubsub/api/Pubsub.Samples.Tests/ExactlyOnceDeliverySubscriberAsyncTest.cs
+++ b/pubsub/api/Pubsub.Samples.Tests/ExactlyOnceDeliverySubscriberAsyncTest.cs
@@ -1,0 +1,48 @@
+﻿// Copyright 2022 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Threading.Tasks;
+using Xunit;
+
+[Collection(nameof(PubsubFixture))]
+public class ExactlyOnceDeliverySubscriberAsyncTest
+{
+    private readonly PubsubFixture _pubsubFixture;
+    private readonly PublishMessagesAsyncSample _publishMessagesAsyncSample;
+    private readonly ExactlyOnceDeliverySubscriberAsyncSample _exactlyOnceDeliverySubscriberAsyncSample;
+
+    public ExactlyOnceDeliverySubscriberAsyncTest(PubsubFixture pubsubFixture)
+    {
+        _pubsubFixture = pubsubFixture;
+        _publishMessagesAsyncSample = new PublishMessagesAsyncSample();
+        _exactlyOnceDeliverySubscriberAsyncSample = new ExactlyOnceDeliverySubscriberAsyncSample();
+    }
+
+    [Fact]
+    public async Task ExactlyOnceDeliverySubscriberAsync()
+    {
+        string randomName = _pubsubFixture.RandomName();
+        string topicId = $"testTopicForExactlyOnceDelivery{randomName}";
+        string subscriptionId = $"testSubscriptionForExactlyOnceDelivery{randomName}";
+        var message = _pubsubFixture.RandomName();
+
+        _pubsubFixture.CreateTopic(topicId);
+        _pubsubFixture.CreateExactlyOnceDeliverySubscription(topicId, subscriptionId);
+
+        await _publishMessagesAsyncSample.PublishMessagesAsync(_pubsubFixture.ProjectId, topicId, new string[] { message });
+
+        var successfulIds = await _exactlyOnceDeliverySubscriberAsyncSample.ExactlyOnceDeliverySubscriberAsync(_pubsubFixture.ProjectId, subscriptionId);
+        Assert.Single(successfulIds);
+    }
+}

--- a/pubsub/api/Pubsub.Samples.Tests/PubsubFixture.cs
+++ b/pubsub/api/Pubsub.Samples.Tests/PubsubFixture.cs
@@ -94,9 +94,8 @@ public class PubsubFixture : IDisposable, ICollectionFixture<PubsubFixture>
     public Topic CreateTopic(string topicId)
     {
         var createTopicSampleObject = new CreateTopicSample();
-        var topic = createTopicSampleObject.CreateTopic(ProjectId, topicId);
         TempTopicIds.Add(topicId);
-        return topic;
+        return createTopicSampleObject.CreateTopic(ProjectId, topicId);
     }
 
     public Topic CreateTopicWithSchema(string topicId, string schemaId, Encoding encoding)
@@ -113,6 +112,13 @@ public class PubsubFixture : IDisposable, ICollectionFixture<PubsubFixture>
         var subscription = createSubscriptionSampleObject.CreateSubscription(ProjectId, topicId, subscriptionId);
         TempSubscriptionIds.Add(subscriptionId);
         return subscription;
+    }
+
+    public Subscription CreateExactlyOnceDeliverySubscription(string topicId, string subscriptionId)
+    {
+        var createSubscriptionWithExactlyOnceDeliverySample = new CreateSubscriptionWithExactlyOnceDeliverySample();
+        TempSubscriptionIds.Add(subscriptionId);
+        return createSubscriptionWithExactlyOnceDeliverySample.CreateSubscriptionWithExactlyOnceDelivery(ProjectId, topicId, subscriptionId);
     }
 
     public Schema CreateProtoSchema(string schemaId)

--- a/pubsub/api/Pubsub.Samples/CreateSubscriptionWithExactlyOnceDelivery.cs
+++ b/pubsub/api/Pubsub.Samples/CreateSubscriptionWithExactlyOnceDelivery.cs
@@ -1,0 +1,49 @@
+﻿// Copyright 2022 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START pubsub_create_subscription_with_exactly_once_delivery]
+
+using Google.Cloud.PubSub.V1;
+using Grpc.Core;
+
+public class CreateSubscriptionWithExactlyOnceDeliverySample
+{
+    public Subscription CreateSubscriptionWithExactlyOnceDelivery(string projectId, string topicId, string subscriptionId)
+    {
+        SubscriberServiceApiClient subscriber = SubscriberServiceApiClient.Create();
+        TopicName topicName = TopicName.FromProjectTopic(projectId, topicId);
+        SubscriptionName subscriptionName = SubscriptionName.FromProjectSubscription(projectId, subscriptionId);
+
+        var subscriptionRequest = new Subscription
+        {
+            SubscriptionName = subscriptionName,
+            TopicAsTopicName = topicName,
+            EnableExactlyOnceDelivery = true
+        };
+
+        Subscription subscription = null;
+
+        try
+        {
+            subscription = subscriber.CreateSubscription(subscriptionRequest);
+        }
+        catch (RpcException e) when (e.Status.StatusCode == StatusCode.AlreadyExists)
+        {
+            // Already exists.  That's fine.
+        }
+
+        return subscription;
+    }
+}
+// [END pubsub_create_subscription_with_exactly_once_delivery]

--- a/pubsub/api/Pubsub.Samples/ExactlyOnceDeliverySubscriberAsync.cs
+++ b/pubsub/api/Pubsub.Samples/ExactlyOnceDeliverySubscriberAsync.cs
@@ -1,0 +1,92 @@
+﻿// Copyright 2022 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START pubsub_subscriber_exactly_once]
+
+using Google.Cloud.PubSub.V1;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using static Google.Cloud.PubSub.V1.SubscriberClient;
+
+public class ExactlyOnceDeliverySubscriberAsyncSample
+{
+    public async Task<IEnumerable<string>> ExactlyOnceDeliverySubscriberAsync(string projectId, string subscriptionId)
+    {
+        // subscriptionId should be the ID of an exactly-once delivery subscription.
+        SubscriptionName subscriptionName = SubscriptionName.FromProjectSubscription(projectId, subscriptionId);
+        SubscriberClient subscriber = await SubscriberClient.CreateAsync(subscriptionName);
+        // To get the status of ACKnowledge (ACK) or Not ACKnowledge (NACK) request in exactly once delivery subscriptions,
+        // create a subscription handler that inherits from Google.Cloud.PubSub.V1.SubscriptionHandler. 
+        // For more information see Google.Cloud.PubSub.V1.SubscriptionHandler reference docs here:
+        // https://cloud.google.com/dotnet/docs/reference/Google.Cloud.PubSub.V1/latest/Google.Cloud.PubSub.V1.SubscriptionHandler?hl=en
+        var subscriptionHandler = new SampleSubscriptionHandler();
+        Task subscriptionTask = subscriber.StartAsync(subscriptionHandler);
+        // The subscriber will be running until it is stopped.
+        await Task.Delay(5000);
+        await subscriber.StopAsync(CancellationToken.None);
+        // Let's make sure that the start task finished successfully after the call to stop.
+        await subscriptionTask;
+        return subscriptionHandler.SuccessfulAckedIds;
+    }
+
+    // Sample handler to handle messages and ACK/NACK responses.
+    public class SampleSubscriptionHandler : SubscriptionHandler
+    {
+        public ConcurrentBag<string> SuccessfulAckedIds { get; } = new ConcurrentBag<string>();
+
+        /// <summary>
+        /// The function that processes received messages. It should be thread-safe.
+        /// Return <see cref="Reply.Ack"/> to ACKnowledge the message (meaning it won't be received again).
+        /// Return <see cref="Reply.Nack"/> to Not ACKnowledge the message (meaning it will be received again).
+        /// From the point of view of message acknowledgement, throwing an exception is equivalent to returning <see cref="Reply.Nack"/>.
+        /// </summary>
+        public override async Task<Reply> HandleMessage(PubsubMessage message, CancellationToken cancellationToken)
+        {
+            string text = System.Text.Encoding.UTF8.GetString(message.Data.ToArray());
+            Console.WriteLine($"Message {message.MessageId}: {text}");
+            return await Task.FromResult(Reply.Ack);
+        }
+
+        /// <summary>
+        /// This method will receive responses for all acknowledge requests.
+        /// </summary>
+        public override void HandleAckResponses(IReadOnlyList<AckNackResponse> responses)
+        {
+            foreach (var response in responses)
+            {
+                if (response.Status == AcknowledgementStatus.Success)
+                {
+                    SuccessfulAckedIds.Add(response.MessageId);
+                }
+
+                string result = response.Status switch
+                {
+                    AcknowledgementStatus.Success => $"MessageId {response.MessageId} successfully acknowledged.",
+                    AcknowledgementStatus.PermissionDenied => $"MessageId {response.MessageId} failed to acknowledge due to a permission denied error.",
+                    AcknowledgementStatus.FailedPrecondition => $"MessageId {response.MessageId} failed to acknowledge due to a failed precondition.",
+                    AcknowledgementStatus.InvalidAckId => $"MessageId {response.MessageId} failed to acknowledge due an invalid or expired AckId.",
+                    AcknowledgementStatus.Other => $"MessageId {response.MessageId} failed to acknowledge due to an unknown reason.",
+                    _ => $"Unknown acknowledgement status for messageId {response.MessageId}."
+                };
+
+                Console.WriteLine(result);
+            }
+        }
+    }
+}
+// [END pubsub_subscriber_exactly_once]

--- a/pubsub/api/Pubsub.Samples/Pubsub.Samples.csproj
+++ b/pubsub/api/Pubsub.Samples/Pubsub.Samples.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>


### PR DESCRIPTION
This draft PR demonstrates the exactly once subscriber sample using the new `SubscriptionHandler` . The library changes are yet not released so the code will not compile and hence tests would fail. Added the do not merge label. This is done so that the code can be reviewed and fixes can be made. Thanks.