### PR TITLE
feat(spanner): Add FGAC samples

### DIFF
--- a/spanner/api/Spanner.Samples.Tests/AddAndDropDatabaseRoleTests.cs
+++ b/spanner/api/Spanner.Samples.Tests/AddAndDropDatabaseRoleTests.cs
@@ -1,0 +1,48 @@
+﻿// Copyright 2022 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+[Collection(nameof(SpannerFixture))]
+public class AddAndDropDatabaseRoleTests
+{
+    private readonly SpannerFixture _spannerFixture;
+    private readonly TimeSpan delay = TimeSpan.FromSeconds(7);
+
+    public AddAndDropDatabaseRoleTests(SpannerFixture spannerFixture) =>
+        _spannerFixture = spannerFixture;
+
+    [Fact]
+    public async void TestAddAndDropDatabaseRole()
+    {
+        var addAndDropDatabaseRoleSample = new AddAndDropDatabaseRoleSample();
+        var listDatabaseRolesSample = new ListDatabaseRolesSample();
+        string testDbRole = "testRole";
+
+        var oldDbRoles = listDatabaseRolesSample.ListDatabaseRoles(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.DatabaseId);
+
+        addAndDropDatabaseRoleSample.AddDatabaseRole(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.DatabaseId, testDbRole);
+        await Task.Delay(delay);
+        var newDbRolesAfterAddition = listDatabaseRolesSample.ListDatabaseRoles(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.DatabaseId);
+
+        addAndDropDatabaseRoleSample.DropDatabaseRole(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.DatabaseId, testDbRole);
+        await Task.Delay(delay);
+        var newDbRolesAfterDeletion = listDatabaseRolesSample.ListDatabaseRoles(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.DatabaseId);
+
+        Assert.Equal(oldDbRoles.Count, newDbRolesAfterDeletion.Count);
+        Assert.Equal(oldDbRoles.Count + 1, newDbRolesAfterAddition.Count);
+    }
+}

--- a/spanner/api/Spanner.Samples.Tests/EnableFineGrainedAccessTest.cs
+++ b/spanner/api/Spanner.Samples.Tests/EnableFineGrainedAccessTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Google Inc.
+﻿// Copyright 2022 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,28 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Threading.Tasks;
 using Xunit;
 
 [Collection(nameof(SpannerFixture))]
-public class ReadStaleDataAsyncTest
+public class EnableFineGrainedAccessTest
 {
     private readonly SpannerFixture _spannerFixture;
-    private readonly TimeSpan delay = TimeSpan.FromSeconds(15);
 
-    public ReadStaleDataAsyncTest(SpannerFixture spannerFixture)
-    {
+    public EnableFineGrainedAccessTest(SpannerFixture spannerFixture) =>
         _spannerFixture = spannerFixture;
-    }
 
     [Fact]
-    public async Task TestReadStaleDataAsync()
+    public void TestEnableFineGrainedAccess()
     {
-        ReadStaleDataAsyncSample sample = new ReadStaleDataAsyncSample();
-        await _spannerFixture.RefillMarketingBudgetsAsync(300000, 300000);
-        await Task.Delay(delay);
-        var albums = await sample.ReadStaleDataAsync(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.DatabaseId);
-        Assert.Contains(albums, a => a.SingerId == 1 && a.AlbumId == 1 && a.MarketingBudget == 300000);
+        string databaseRole = "testrole";
+        var enableFineGrainedAccessSample = new EnableFineGrainedAccessSample();
+        var updatedPolicy = enableFineGrainedAccessSample.EnableFineGrainedAccess(_spannerFixture.ProjectId, _spannerFixture.InstanceId,
+            _spannerFixture.DatabaseId, databaseRole, $"serviceAccount:{_spannerFixture.SpannerServiceAccount.Email}");
+
+        Assert.Contains(updatedPolicy.Bindings, b => b.Role == "roles/spanner.fineGrainedAccessUser");
     }
 }

--- a/spanner/api/Spanner.Samples.Tests/ListDatabaseRolesTests.cs
+++ b/spanner/api/Spanner.Samples.Tests/ListDatabaseRolesTests.cs
@@ -1,0 +1,32 @@
+﻿// Copyright 2021 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+
+[Collection(nameof(SpannerFixture))]
+public class ListDatabasesRolesTests
+{
+    private readonly SpannerFixture _spannerFixture;
+
+    public ListDatabasesRolesTests(SpannerFixture spannerFixture) =>
+        _spannerFixture = spannerFixture;
+
+    [Fact]
+    public void TestListDatabaseRoles()
+    {
+        var listDatabaseRolesSample = new ListDatabaseRolesSample();
+        var dbroles = listDatabaseRolesSample.ListDatabaseRoles(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.DatabaseId);
+        Assert.NotEmpty(dbroles);
+    }
+}

--- a/spanner/api/Spanner.Samples.Tests/ReadDataWithDatabaseRoleTest.cs
+++ b/spanner/api/Spanner.Samples.Tests/ReadDataWithDatabaseRoleTest.cs
@@ -1,0 +1,45 @@
+﻿// Copyright 2022 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+[Collection(nameof(SpannerFixture))]
+public class ReadDataWithDatabaseRoleTest
+{
+    private readonly SpannerFixture _spannerFixture;
+    private readonly TimeSpan delay = TimeSpan.FromSeconds(7);
+
+    public ReadDataWithDatabaseRoleTest(SpannerFixture spannerFixture) =>
+        _spannerFixture = spannerFixture;
+
+    [Fact]
+    public async Task TestReadDataWithDatabaseRoleAsync()
+    {
+        var readDataWithDatabaseRoleSample = new ReadDataWithDatabaseRoleSample();
+        var addAndDropDatabaseRoleSample = new AddAndDropDatabaseRoleSample();
+        string dbRole = "readerRole";
+        addAndDropDatabaseRoleSample.AddDatabaseRole(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.DatabaseId, dbRole);
+        await Task.Delay(delay);
+
+        string grantAccessStatement = $"GRANT SELECT ON TABLE Venues TO ROLE {dbRole}";
+        using var updateCmd = _spannerFixture.SpannerConnection.CreateDdlCommand(grantAccessStatement);
+        await updateCmd.ExecuteNonQueryAsync();
+        await Task.Delay(delay);
+
+        var venues = await readDataWithDatabaseRoleSample.ReadDataWithDatabaseRoleAsync(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.DatabaseId, dbRole);
+        Assert.NotEmpty(venues);
+    }
+}

--- a/spanner/api/Spanner.Samples.Tests/Spanner.Samples.Tests.csproj
+++ b/spanner/api/Spanner.Samples.Tests/Spanner.Samples.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Cloud.Kms.V1" Version="3.1.0" />
+    <PackageReference Include="Google.Apis.Iam.v1" Version="1.57.0.2793" />
     <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/spanner/api/Spanner.Samples/AddAndDropDatabaseRole.cs
+++ b/spanner/api/Spanner.Samples/AddAndDropDatabaseRole.cs
@@ -1,0 +1,43 @@
+﻿// Copyright 2022 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START spanner_add_and_drop_database_role]
+
+using Google.Cloud.Spanner.Data;
+
+public class AddAndDropDatabaseRoleSample
+{
+    public async void AddDatabaseRole(string projectId, string instanceId, string databaseId, string databaseRole)
+    {
+        string connectionString = $"Data Source=projects/{projectId}/instances/{instanceId}/databases/{databaseId}";
+        string createRoleDDlStatement = $"CREATE ROLE {databaseRole}";
+
+        // Creates the given database role.
+        using var connection = new SpannerConnection(connectionString);
+        using var updateCmd = connection.CreateDdlCommand(createRoleDDlStatement);
+        await updateCmd.ExecuteNonQueryAsync();
+    }
+
+    public async void DropDatabaseRole(string projectId, string instanceId, string databaseId, string databaseRole)
+    {
+        string connectionString = $"Data Source=projects/{projectId}/instances/{instanceId}/databases/{databaseId}";
+        string dropDatabaseRoleStatement = $"DROP ROLE {databaseRole}";
+
+        // Drops the given database role.
+        using var connection = new SpannerConnection(connectionString);
+        using var updateCmd = connection.CreateDdlCommand(dropDatabaseRoleStatement);
+        await updateCmd.ExecuteNonQueryAsync();
+    }
+}
+// [END spanner_add_and_drop_database_role]

--- a/spanner/api/Spanner.Samples/EnableFineGrainedAccess.cs
+++ b/spanner/api/Spanner.Samples/EnableFineGrainedAccess.cs
@@ -1,0 +1,67 @@
+﻿// Copyright 2022 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START spanner_enable_fine_grained_access]
+
+using Google.Api.Gax;
+using Google.Cloud.Iam.V1;
+using Google.Cloud.Spanner.Admin.Database.V1;
+
+public class EnableFineGrainedAccessSample
+{
+    public Policy EnableFineGrainedAccess(string projectId, string instanceId, string databaseId, string databaseRole, string iamMember)
+    {
+        var resourceName = new UnparsedResourceName($"projects/{projectId}/instances/{instanceId}/databases/{databaseId}");
+
+        var client = new DatabaseAdminClientBuilder().Build();
+
+        // Requests policy version 3. As earlier versions does not support condition field in role binding.
+        // For more info see https://cloud.google.com/iam/docs/policies#versions.
+        GetIamPolicyRequest getIamPolicyRequest = new GetIamPolicyRequest
+        {
+            ResourceAsResourceName = resourceName,
+            Options = new GetPolicyOptions
+            {
+                RequestedPolicyVersion = 3
+            }
+        };
+
+        var policy = client.GetIamPolicy(getIamPolicyRequest);
+
+        Binding newBinding = new Binding
+        {
+            Role = "roles/spanner.fineGrainedAccessUser",
+            Members = { iamMember },
+            Condition = new Google.Type.Expr
+            {
+                Title = "DatabaseRoleBindingTitle",
+                Expression = $"resource.name.endsWith('/databaseRoles/{databaseRole}')"
+            }
+        };
+
+        policy.Bindings.Add(newBinding);
+        if (policy.Version < 3)
+        {
+            policy.Version = 3;
+        }
+        SetIamPolicyRequest setIamPolicyRequest = new SetIamPolicyRequest
+        {
+            Policy = policy,
+            ResourceAsResourceName = resourceName,
+        };
+        client.SetIamPolicy(setIamPolicyRequest);
+        return policy;
+    }
+}
+// [END spanner_enable_fine_grained_access]

--- a/spanner/api/Spanner.Samples/ListDatabaseRoles.cs
+++ b/spanner/api/Spanner.Samples/ListDatabaseRoles.cs
@@ -1,0 +1,52 @@
+﻿// Copyright 2022 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START spanner_list_database_roles]
+
+using Google.Cloud.Spanner.Admin.Database.V1;
+using System;
+using System.Collections.Generic;
+
+public class ListDatabaseRolesSample
+{
+    public List<string> ListDatabaseRoles(string projectId, string instanceId, string databaseId)
+    {
+        string parent = $"projects/{projectId}/instances/{instanceId}/databases/{databaseId}";
+        int pageSize = 5;
+        var client = new DatabaseAdminClientBuilder().Build();
+        string nextPageToken = null;
+        List<string> databaseRoles = new List<string>();
+        do
+        {
+            ListDatabaseRolesRequest req = new ListDatabaseRolesRequest
+            {
+                Parent = parent,
+                PageSize = pageSize,
+                PageToken = nextPageToken ?? ""
+            };
+            var ListDatabaseResponse = client.ListDatabaseRoles(req);
+            var page = ListDatabaseResponse.ReadPage(pageSize);
+            foreach (var dbRole in page)
+            {
+                Console.WriteLine($"Database Role: {dbRole.DatabaseRoleName}");
+                databaseRoles.Add(dbRole.DatabaseRoleName.ToString());
+            }
+            nextPageToken = page.NextPageToken;
+
+        }while (!string.IsNullOrEmpty(nextPageToken));
+
+        return databaseRoles;
+    }
+}
+// [END spanner_list_database_roles]

--- a/spanner/api/Spanner.Samples/ReadDataWithDatabaseRole.cs
+++ b/spanner/api/Spanner.Samples/ReadDataWithDatabaseRole.cs
@@ -1,0 +1,55 @@
+﻿// Copyright 2022 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START spanner_read_data_with_database_role]
+
+using Google.Cloud.Spanner.Data;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+public class ReadDataWithDatabaseRoleSample
+{
+    public class Venue
+    {
+        public int VenueId;
+
+        public string VenueName;
+    }
+
+    public async Task<List<Venue>> ReadDataWithDatabaseRoleAsync(string projectId, string instanceId, string databaseId, string databaseRole)
+    {
+        string connectionString = $"Data Source=projects/{projectId}/instances/{instanceId}/databases/{databaseId}";
+        string tableName = "Venues";
+
+        var spannerConnectionStringBuilder = new SpannerConnectionStringBuilder
+        {
+            ConnectionString = connectionString,
+            DatabaseRole = databaseRole
+        };
+        using var connection = new SpannerConnection(spannerConnectionStringBuilder);
+        var createSelectCmd = connection.CreateSelectCommand($"SELECT * FROM {tableName}");
+        using var reader = await createSelectCmd.ExecuteReaderAsync();
+        var venues = new List<Venue>();
+        while (reader.Read())
+        {
+            venues.Add(new Venue
+            {
+                VenueId = reader.GetFieldValue<int>("VenueId"),
+                VenueName = reader.GetFieldValue<string>("VenueName")
+            });
+        }
+        return venues;
+    }
+}
+// [END spanner_read_data_with_database_role]


### PR DESCRIPTION
Added samples which demonstrates, how users can use roles for fine grained access control and list these database roles.
