### PR TITLE
fix(Retail): Fix SearchWithQueryExpansionTest

### DIFF
--- a/retail/interactive-tutorial/RetailSearch.Samples.Tests/SearchWithQueryExpansionTest.cs
+++ b/retail/interactive-tutorial/RetailSearch.Samples.Tests/SearchWithQueryExpansionTest.cs
@@ -23,15 +23,11 @@ namespace RetailSearch.Samples.Tests
         public void TestSearchWithQueryExpansion()
         {
             const string ExpectedProductTitle = "Google Youth Hero Tee Grey";
-
-            var searchResultPages = SearchWithQueryExpansionTutorial.Search();
-
-            var topPages = searchResultPages.Take(2).ToList();
-            var firstPage = topPages[0];
-            var secondPage = topPages[1];
+            
+            var firstPage = SearchWithQueryExpansionTutorial.Search().First();
 
             Assert.Contains(firstPage, result => result.Product.Title.Contains(ExpectedProductTitle));
-            Assert.Contains(secondPage, result => !result.Product.Title.Contains(ExpectedProductTitle));
+            Assert.Contains(firstPage, result => !result.Product.Title.Contains(ExpectedProductTitle));
         }
     }
 }


### PR DESCRIPTION
With the test query and page size 10 our backend only returns 1 page of result currently. Fix the test case to only check the first page.