### PR TITLE
Remove obsolete node selector from deployment manifest

### DIFF
--- a/applications/clouddemo/net4/deployment.yaml
+++ b/applications/clouddemo/net4/deployment.yaml
@@ -65,7 +65,6 @@ spec:
     spec:
       nodeSelector:
         kubernetes.io/os: windows
-        cloud.google.com/gke-os-distribution: windows_ltsc
       containers:
       - name: clouddemo-net4
         image: CLOUDDEMO_IMAGE


### PR DESCRIPTION
The node selector is obsolete and no longer works on current GKE versions.