### PR TITLE
chore: Update all samples to Functions Framework v2

### DIFF
--- a/functions/concepts/Concepts.Tests/Concepts.Tests.csproj
+++ b/functions/concepts/Concepts.Tests/Concepts.Tests.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
-    <PackageReference Include="Google.Cloud.Functions.Testing" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Functions.Testing" Version="2.0.0" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/functions/concepts/Concepts.Tests/EnvironmentVariablesTest.cs
+++ b/functions/concepts/Concepts.Tests/EnvironmentVariablesTest.cs
@@ -17,27 +17,26 @@ using System;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Concepts.Tests
-{
-    // Note: these tests modify the "FOO" environment variable
-    // without any attempt to restore the original value. We assume
-    // no other tests will use that environment variable.
-    public class EnvironmentVariablesTest : FunctionTestBase<EnvironmentVariables.Function>
-    {
-        [Fact]
-        public async Task VariableSet()
-        {
-            Environment.SetEnvironmentVariable("FOO", "Test foo value");
-            var responseBody = await ExecuteHttpGetRequestAsync();
-            Assert.Equal("Test foo value", responseBody);
-        }
+namespace Concepts.Tests;
 
-        [Fact]
-        public async Task VariableNotSet()
-        {
-            Environment.SetEnvironmentVariable("FOO", null);
-            var responseBody = await ExecuteHttpGetRequestAsync();
-            Assert.Equal("Specified environment variable is not set.", responseBody);
-        }
+// Note: these tests modify the "FOO" environment variable
+// without any attempt to restore the original value. We assume
+// no other tests will use that environment variable.
+public class EnvironmentVariablesTest : FunctionTestBase<EnvironmentVariables.Function>
+{
+    [Fact]
+    public async Task VariableSet()
+    {
+        Environment.SetEnvironmentVariable("FOO", "Test foo value");
+        var responseBody = await ExecuteHttpGetRequestAsync();
+        Assert.Equal("Test foo value", responseBody);
+    }
+
+    [Fact]
+    public async Task VariableNotSet()
+    {
+        Environment.SetEnvironmentVariable("FOO", null);
+        var responseBody = await ExecuteHttpGetRequestAsync();
+        Assert.Equal("Specified environment variable is not set.", responseBody);
     }
 }

--- a/functions/concepts/Concepts.Tests/ExecutionCountTest.cs
+++ b/functions/concepts/Concepts.Tests/ExecutionCountTest.cs
@@ -16,20 +16,19 @@ using Google.Cloud.Functions.Testing;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Concepts.Tests
-{
-    public class ExecutionCountTest : FunctionTestBase<ExecutionCount.Function>
-    {
-        // This test relies on it being the *only* test to use ExecutionCount.Function.
-        // Without that, we might need some kind of reset capability.
-        [Fact]
-        public async Task TwoRequests()
-        {
-            string request1 = await ExecuteHttpGetRequestAsync();
-            string request2 = await ExecuteHttpGetRequestAsync();
+namespace Concepts.Tests;
 
-            Assert.Equal("Server execution count: 1", request1);
-            Assert.Equal("Server execution count: 2", request2);
-        }
+public class ExecutionCountTest : FunctionTestBase<ExecutionCount.Function>
+{
+    // This test relies on it being the *only* test to use ExecutionCount.Function.
+    // Without that, we might need some kind of reset capability.
+    [Fact]
+    public async Task TwoRequests()
+    {
+        string request1 = await ExecuteHttpGetRequestAsync();
+        string request2 = await ExecuteHttpGetRequestAsync();
+
+        Assert.Equal("Server execution count: 1", request1);
+        Assert.Equal("Server execution count: 2", request2);
     }
 }

--- a/functions/concepts/Concepts.Tests/FileSystemTest.cs
+++ b/functions/concepts/Concepts.Tests/FileSystemTest.cs
@@ -16,17 +16,16 @@ using Google.Cloud.Functions.Testing;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Concepts.Tests
+namespace Concepts.Tests;
+
+public class FileSystemTest : FunctionTestBase<FileSystem.Function>
 {
-    public class FileSystemTest : FunctionTestBase<FileSystem.Function>
+    [Fact]
+    public async Task FilesAreListed()
     {
-        [Fact]
-        public async Task FilesAreListed()
-        {
-            var responseBody = await ExecuteHttpGetRequestAsync();
-            Assert.Contains("Files:\n", responseBody);
-            // We expect the working directory to contain the test assembly.
-            Assert.Contains("Concepts.Tests.dll", responseBody);
-        }
+        var responseBody = await ExecuteHttpGetRequestAsync();
+        Assert.Contains("Files:\n", responseBody);
+        // We expect the working directory to contain the test assembly.
+        Assert.Contains("Concepts.Tests.dll", responseBody);
     }
 }

--- a/functions/concepts/Concepts.Tests/LazyFieldsTest.cs
+++ b/functions/concepts/Concepts.Tests/LazyFieldsTest.cs
@@ -16,15 +16,14 @@ using Google.Cloud.Functions.Testing;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Concepts.Tests
+namespace Concepts.Tests;
+
+public class LazyFieldsTest : FunctionTestBase<LazyFields.Function>
 {
-    public class LazyFieldsTest : FunctionTestBase<LazyFields.Function>
+    [Fact]
+    public async Task ResponseText()
     {
-        [Fact]
-        public async Task ResponseText()
-        {
-            var responseBody = await ExecuteHttpGetRequestAsync();
-            Assert.Equal("Lazy global: 45; non-lazy global: 362880", responseBody);
-        }
+        var responseBody = await ExecuteHttpGetRequestAsync();
+        Assert.Equal("Lazy global: 45; non-lazy global: 362880", responseBody);
     }
 }

--- a/functions/concepts/Concepts.Tests/ScopesTest.cs
+++ b/functions/concepts/Concepts.Tests/ScopesTest.cs
@@ -16,15 +16,14 @@ using Google.Cloud.Functions.Testing;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Concepts.Tests
+namespace Concepts.Tests;
+
+public class ScopesTest : FunctionTestBase<Scopes.Function>
 {
-    public class ScopesTest : FunctionTestBase<Scopes.Function>
+    [Fact]
+    public async Task ResponseText()
     {
-        [Fact]
-        public async Task ResponseText()
-        {
-            var responseBody = await ExecuteHttpGetRequestAsync();
-            Assert.Equal("Global: 362880; function: 45", responseBody);
-        }
+        var responseBody = await ExecuteHttpGetRequestAsync();
+        Assert.Equal("Global: 362880; function: 45", responseBody);
     }
 }

--- a/functions/concepts/EnvironmentVariables/EnvironmentVariables.csproj
+++ b/functions/concepts/EnvironmentVariables/EnvironmentVariables.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/functions/concepts/EnvironmentVariables/Function.cs
+++ b/functions/concepts/EnvironmentVariables/Function.cs
@@ -18,16 +18,15 @@ using Microsoft.AspNetCore.Http;
 using System;
 using System.Threading.Tasks;
 
-namespace EnvironmentVariables
+namespace EnvironmentVariables;
+
+public class Function : IHttpFunction
 {
-    public class Function : IHttpFunction
+    public async Task HandleAsync(HttpContext context)
     {
-        public async Task HandleAsync(HttpContext context)
-        {
-            string foo = Environment.GetEnvironmentVariable("FOO")
-                ?? "Specified environment variable is not set.";
-            await context.Response.WriteAsync(foo);
-        }
+        string foo = Environment.GetEnvironmentVariable("FOO")
+            ?? "Specified environment variable is not set.";
+        await context.Response.WriteAsync(foo);
     }
 }
 // [END functions_env_vars]

--- a/functions/concepts/ExecutionCount/ExecutionCount.csproj
+++ b/functions/concepts/ExecutionCount/ExecutionCount.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/functions/concepts/ExecutionCount/Function.cs
+++ b/functions/concepts/ExecutionCount/Function.cs
@@ -18,23 +18,22 @@ using Microsoft.AspNetCore.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace ExecutionCount
-{
-    public class Function : IHttpFunction
-    {
-        // Note that this variable must be static, because a new instance is
-        // created for each request. An alternative approach would be to use
-        // dependency injection with a singleton resource injected into the function
-        // constructor.
-        private static int _count;
+namespace ExecutionCount;
 
-        public async Task HandleAsync(HttpContext context)
-        {
-            // Note: the total function invocation count across
-            // all servers may not be equal to this value!
-            int currentCount = Interlocked.Increment(ref _count);
-            await context.Response.WriteAsync($"Server execution count: {currentCount}");
-        }
+public class Function : IHttpFunction
+{
+    // Note that this variable must be static, because a new instance is
+    // created for each request. An alternative approach would be to use
+    // dependency injection with a singleton resource injected into the function
+    // constructor.
+    private static int _count;
+
+    public async Task HandleAsync(HttpContext context)
+    {
+        // Note: the total function invocation count across
+        // all servers may not be equal to this value!
+        int currentCount = Interlocked.Increment(ref _count);
+        await context.Response.WriteAsync($"Server execution count: {currentCount}");
     }
 }
 // [END functions_concepts_stateless]

--- a/functions/concepts/FileSystem/FileSystem.csproj
+++ b/functions/concepts/FileSystem/FileSystem.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/functions/concepts/FileSystem/Function.cs
+++ b/functions/concepts/FileSystem/Function.cs
@@ -18,19 +18,18 @@ using Microsoft.AspNetCore.Http;
 using System.IO;
 using System.Threading.Tasks;
 
-namespace FileSystem
-{
-    public class Function : IHttpFunction
-    {
-        public async Task HandleAsync(HttpContext context)
-        {
-            string[] files = Directory.GetFiles(".");
+namespace FileSystem;
 
-            await context.Response.WriteAsync("Files:\n");
-            foreach (string file in files)
-            {
-                await context.Response.WriteAsync($"\t{file}\n");
-            }
+public class Function : IHttpFunction
+{
+    public async Task HandleAsync(HttpContext context)
+    {
+        string[] files = Directory.GetFiles(".");
+
+        await context.Response.WriteAsync("Files:\n");
+        foreach (string file in files)
+        {
+            await context.Response.WriteAsync($"\t{file}\n");
         }
     }
 }

--- a/functions/concepts/LazyFields/LazyFields.csproj
+++ b/functions/concepts/LazyFields/LazyFields.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/functions/concepts/Retry/Retry.csproj
+++ b/functions/concepts/Retry/Retry.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.0.0" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.2.0" />
   </ItemGroup>
 </Project>

--- a/functions/concepts/Scopes/Scopes.csproj
+++ b/functions/concepts/Scopes/Scopes.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/functions/concepts/TimeBoundedRetries/TimeBoundedRetries.csproj
+++ b/functions/concepts/TimeBoundedRetries/TimeBoundedRetries.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.0.0" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.2.0" />
   </ItemGroup>
 </Project>

--- a/functions/firebase/Firebase.Tests/Firebase.Tests.csproj
+++ b/functions/firebase/Firebase.Tests/Firebase.Tests.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
-    <PackageReference Include="Google.Cloud.Functions.Testing" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Functions.Testing" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/functions/firebase/Firebase.Tests/FirebaseAnalyticsTest.cs
+++ b/functions/firebase/Firebase.Tests/FirebaseAnalyticsTest.cs
@@ -19,43 +19,42 @@ using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Firebase.Tests
-{
-    public class FirebaseAnalyticsTest : FunctionTestBase<FirebaseAnalytics.Function>
-    {
-        [Fact]
-        public async Task LoggingForEvent()
-        {
-            var data = new AnalyticsLogData
-            {
-                EventDim =
-                {
-                    new EventDimensions
-                    {
-                        Name = "my-event",
-                        TimestampMicros = 1599818774000000L
-                    }
-                },
-                UserDim = new UserDimensions
-                {
-                    DeviceInfo = new DeviceInfo { DeviceModel = "Pixel" },
-                    GeoInfo = new GeoInfo { City = "London", Country = "UK" }
-                }
-            };
-            await ExecuteCloudEventRequestAsync(AnalyticsLogData.WrittenCloudEventType, data,
-                new Uri("//firebaseanalytics.googleapis.com/projects/my-project/apps/my-app", UriKind.RelativeOrAbsolute));
+namespace Firebase.Tests;
 
-            string[] expectedMessages =
+public class FirebaseAnalyticsTest : FunctionTestBase<FirebaseAnalytics.Function>
+{
+    [Fact]
+    public async Task LoggingForEvent()
+    {
+        var data = new AnalyticsLogData
+        {
+            EventDim =
             {
-                "Event source: //firebaseanalytics.googleapis.com/projects/my-project/apps/my-app",
-                "Event count: 1",
-                "First event name: my-event",
-                "First event timestamp: 2020-09-11 10:06:14Z",
-                "Device model: Pixel",
-                "Location: London, UK"
-            };
-            var actualMessages = GetFunctionLogEntries().Select(entry => entry.Message).ToArray();
-            Assert.Equal(expectedMessages, actualMessages);
-        }
+                new EventDimensions
+                {
+                    Name = "my-event",
+                    TimestampMicros = 1599818774000000L
+                }
+            },
+            UserDim = new UserDimensions
+            {
+                DeviceInfo = new DeviceInfo { DeviceModel = "Pixel" },
+                GeoInfo = new GeoInfo { City = "London", Country = "UK" }
+            }
+        };
+        await ExecuteCloudEventRequestAsync(AnalyticsLogData.WrittenCloudEventType, data,
+            new Uri("//firebaseanalytics.googleapis.com/projects/my-project/apps/my-app", UriKind.RelativeOrAbsolute));
+
+        string[] expectedMessages =
+        {
+            "Event source: //firebaseanalytics.googleapis.com/projects/my-project/apps/my-app",
+            "Event count: 1",
+            "First event name: my-event",
+            "First event timestamp: 2020-09-11 10:06:14Z",
+            "Device model: Pixel",
+            "Location: London, UK"
+        };
+        var actualMessages = GetFunctionLogEntries().Select(entry => entry.Message).ToArray();
+        Assert.Equal(expectedMessages, actualMessages);
     }
 }

--- a/functions/firebase/Firebase.Tests/FirebaseRemoteConfigTest.cs
+++ b/functions/firebase/Firebase.Tests/FirebaseRemoteConfigTest.cs
@@ -21,30 +21,29 @@ using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Firebase.Tests
+namespace Firebase.Tests;
+
+public class FirebaseRemoteConfigTest : FunctionTestBase<FirebaseRemoteConfig.Function>
 {
-    public class FirebaseRemoteConfigTest : FunctionTestBase<FirebaseRemoteConfig.Function>
+    [Fact]
+    public async Task DetailsAreLogged()
     {
-        [Fact]
-        public async Task DetailsAreLogged()
+        var data = new RemoteConfigEventData
         {
-            var data = new RemoteConfigEventData
-            {
-                UpdateType = RemoteConfigUpdateType.IncrementalUpdate,
-                UpdateOrigin = RemoteConfigUpdateOrigin.Console,
-                VersionNumber = 12345L
-            };
+            UpdateType = RemoteConfigUpdateType.IncrementalUpdate,
+            UpdateOrigin = RemoteConfigUpdateOrigin.Console,
+            VersionNumber = 12345L
+        };
 
-            await ExecuteCloudEventRequestAsync(RemoteConfigEventData.UpdatedCloudEventType, data);
+        await ExecuteCloudEventRequestAsync(RemoteConfigEventData.UpdatedCloudEventType, data);
 
-            var expectedMessages = new[]
-            {
-                "Update type: IncrementalUpdate",
-                "Update origin: Console",
-                "Version number: 12345"
-            };
-            var actualMessages = GetFunctionLogEntries().Select(entry => entry.Message).ToArray();
-            Assert.Equal(expectedMessages, actualMessages);
-        }
+        var expectedMessages = new[]
+        {
+            "Update type: IncrementalUpdate",
+            "Update origin: Console",
+            "Version number: 12345"
+        };
+        var actualMessages = GetFunctionLogEntries().Select(entry => entry.Message).ToArray();
+        Assert.Equal(expectedMessages, actualMessages);
     }
 }

--- a/functions/firebase/Firebase.Tests/FirebaseRtdbTest.cs
+++ b/functions/firebase/Firebase.Tests/FirebaseRtdbTest.cs
@@ -18,23 +18,22 @@ using Google.Protobuf.WellKnownTypes;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Firebase.Tests
-{
-    public class FirebaseRtdbTest : FunctionTestBase<FirebaseRtdb.Function>
-    {
-        [Fact]
-        public async Task SubjectAndDeltaAreLogged()
-        {
-            var data = new ReferenceEventData
-            {
-                Data = Value.ForNumber(5),
-                Delta = Value.ForNumber(10)
-            };
-            await ExecuteCloudEventRequestAsync(ReferenceEventData.UpdatedCloudEventType, data, subject: "refs/sample_ref/score");
+namespace Firebase.Tests;
 
-            var logEntries = GetFunctionLogEntries();
-            Assert.Contains(logEntries, entry => entry.Message == "Function triggered by change to refs/sample_ref/score");
-            Assert.Contains(logEntries, entry => entry.Message == "Delta: 10");
-        }
+public class FirebaseRtdbTest : FunctionTestBase<FirebaseRtdb.Function>
+{
+    [Fact]
+    public async Task SubjectAndDeltaAreLogged()
+    {
+        var data = new ReferenceEventData
+        {
+            Data = Value.ForNumber(5),
+            Delta = Value.ForNumber(10)
+        };
+        await ExecuteCloudEventRequestAsync(ReferenceEventData.UpdatedCloudEventType, data, subject: "refs/sample_ref/score");
+
+        var logEntries = GetFunctionLogEntries();
+        Assert.Contains(logEntries, entry => entry.Message == "Function triggered by change to refs/sample_ref/score");
+        Assert.Contains(logEntries, entry => entry.Message == "Delta: 10");
     }
 }

--- a/functions/firebase/FirebaseAnalytics/FirebaseAnalytics.csproj
+++ b/functions/firebase/FirebaseAnalytics/FirebaseAnalytics.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.0.0" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.2.0" />
   </ItemGroup>
 </Project>

--- a/functions/firebase/FirebaseAnalytics/Function.cs
+++ b/functions/firebase/FirebaseAnalytics/Function.cs
@@ -22,38 +22,37 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace FirebaseAnalytics
+namespace FirebaseAnalytics;
+
+public class Function : ICloudEventFunction<AnalyticsLogData>
 {
-    public class Function : ICloudEventFunction<AnalyticsLogData>
+    private readonly ILogger _logger;
+
+    public Function(ILogger<Function> logger) =>
+        _logger = logger;
+
+    public Task HandleAsync(CloudEvent cloudEvent, AnalyticsLogData data, CancellationToken cancellationToken)
     {
-        private readonly ILogger _logger;
+        _logger.LogInformation("Event source: {source}", cloudEvent.Source);
+        _logger.LogInformation("Event count: {count}", data.EventDim.Count);
 
-        public Function(ILogger<Function> logger) =>
-            _logger = logger;
-
-        public Task HandleAsync(CloudEvent cloudEvent, AnalyticsLogData data, CancellationToken cancellationToken)
+        var firstEvent = data.EventDim.FirstOrDefault();
+        if (firstEvent is object)
         {
-            _logger.LogInformation("Event source: {source}", cloudEvent.Source);
-            _logger.LogInformation("Event count: {count}", data.EventDim.Count);
-
-            var firstEvent = data.EventDim.FirstOrDefault();
-            if (firstEvent is object)
-            {
-                _logger.LogInformation("First event name: {name}", firstEvent.Name);
-                DateTimeOffset timestamp = DateTimeOffset.FromUnixTimeMilliseconds(firstEvent.TimestampMicros / 1000);
-                _logger.LogInformation("First event timestamp: {timestamp:u}", timestamp);
-            }
-
-            var userObject = data.UserDim;
-            if (userObject is object)
-            {
-                _logger.LogInformation("Device model: {device}", userObject.DeviceInfo?.DeviceModel);
-                _logger.LogInformation("Location: {city}, {country}", userObject.GeoInfo?.City, userObject.GeoInfo.Country);
-            }
-            // In this example, we don't need to perform any asynchronous operations, so the
-            // method doesn't need to be declared async.
-            return Task.CompletedTask;
+            _logger.LogInformation("First event name: {name}", firstEvent.Name);
+            DateTimeOffset timestamp = DateTimeOffset.FromUnixTimeMilliseconds(firstEvent.TimestampMicros / 1000);
+            _logger.LogInformation("First event timestamp: {timestamp:u}", timestamp);
         }
+
+        var userObject = data.UserDim;
+        if (userObject is object)
+        {
+            _logger.LogInformation("Device model: {device}", userObject.DeviceInfo?.DeviceModel);
+            _logger.LogInformation("Location: {city}, {country}", userObject.GeoInfo?.City, userObject.GeoInfo.Country);
+        }
+        // In this example, we don't need to perform any asynchronous operations, so the
+        // method doesn't need to be declared async.
+        return Task.CompletedTask;
     }
 }
 // [END functions_firebase_analytics]

--- a/functions/firebase/FirebaseAuth/FirebaseAuth.csproj
+++ b/functions/firebase/FirebaseAuth/FirebaseAuth.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.0.0" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.2.0" />
   </ItemGroup>
 </Project>

--- a/functions/firebase/FirebaseAuth/Function.cs
+++ b/functions/firebase/FirebaseAuth/Function.cs
@@ -20,31 +20,30 @@ using Microsoft.Extensions.Logging;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace FirebaseAuth
+namespace FirebaseAuth;
+
+public class Function : ICloudEventFunction<AuthEventData>
 {
-    public class Function : ICloudEventFunction<AuthEventData>
+    private readonly ILogger _logger;
+
+    public Function(ILogger<Function> logger) =>
+        _logger = logger;
+
+    public Task HandleAsync(CloudEvent cloudEvent, AuthEventData data, CancellationToken cancellationToken)
     {
-        private readonly ILogger _logger;
-
-        public Function(ILogger<Function> logger) =>
-            _logger = logger;
-
-        public Task HandleAsync(CloudEvent cloudEvent, AuthEventData data, CancellationToken cancellationToken)
+        _logger.LogInformation("Function triggered by change to user: {uid}", data.Uid);
+        if (data.Metadata is UserMetadata metadata)
         {
-            _logger.LogInformation("Function triggered by change to user: {uid}", data.Uid);
-            if (data.Metadata is UserMetadata metadata)
-            {
-                _logger.LogInformation("User created at: {created:s}", metadata.CreateTime.ToDateTimeOffset());
-            }
-            if (!string.IsNullOrEmpty(data.Email))
-            {
-                _logger.LogInformation("Email: {email}", data.Email);
-            }
-
-            // In this example, we don't need to perform any asynchronous operations, so the
-            // method doesn't need to be declared async.
-            return Task.CompletedTask;
+            _logger.LogInformation("User created at: {created:s}", metadata.CreateTime.ToDateTimeOffset());
         }
+        if (!string.IsNullOrEmpty(data.Email))
+        {
+            _logger.LogInformation("Email: {email}", data.Email);
+        }
+
+        // In this example, we don't need to perform any asynchronous operations, so the
+        // method doesn't need to be declared async.
+        return Task.CompletedTask;
     }
 }
 // [END functions_firebase_auth]

--- a/functions/firebase/FirebaseFirestore/FirebaseFirestore.csproj
+++ b/functions/firebase/FirebaseFirestore/FirebaseFirestore.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.0.0" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.2.0" />
   </ItemGroup>
 </Project>

--- a/functions/firebase/FirebaseRemoteConfig/FirebaseRemoteConfig.csproj
+++ b/functions/firebase/FirebaseRemoteConfig/FirebaseRemoteConfig.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.0.0" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.2.0" />
   </ItemGroup>
 </Project>

--- a/functions/firebase/FirebaseRemoteConfig/Function.cs
+++ b/functions/firebase/FirebaseRemoteConfig/Function.cs
@@ -20,25 +20,24 @@ using Microsoft.Extensions.Logging;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace FirebaseRemoteConfig
+namespace FirebaseRemoteConfig;
+
+public class Function : ICloudEventFunction<RemoteConfigEventData>
 {
-    public class Function : ICloudEventFunction<RemoteConfigEventData>
+    private readonly ILogger _logger;
+
+    public Function(ILogger<Function> logger) =>
+        _logger = logger;
+
+    public Task HandleAsync(CloudEvent cloudEvent, RemoteConfigEventData data, CancellationToken cancellationToken)
     {
-        private readonly ILogger _logger;
+        _logger.LogInformation("Update type: {origin}", data.UpdateType);
+        _logger.LogInformation("Update origin: {origin}", data.UpdateOrigin);
+        _logger.LogInformation("Version number: {version}", data.VersionNumber);
 
-        public Function(ILogger<Function> logger) =>
-            _logger = logger;
-
-        public Task HandleAsync(CloudEvent cloudEvent, RemoteConfigEventData data, CancellationToken cancellationToken)
-        {
-            _logger.LogInformation("Update type: {origin}", data.UpdateType);
-            _logger.LogInformation("Update origin: {origin}", data.UpdateOrigin);
-            _logger.LogInformation("Version number: {version}", data.VersionNumber);
-
-            // In this example, we don't need to perform any asynchronous operations, so the
-            // method doesn't need to be declared async.
-            return Task.CompletedTask;
-        }
+        // In this example, we don't need to perform any asynchronous operations, so the
+        // method doesn't need to be declared async.
+        return Task.CompletedTask;
     }
 }
 // [END functions_firebase_remote_config]

--- a/functions/firebase/FirebaseRtdb/FirebaseRtdb.csproj
+++ b/functions/firebase/FirebaseRtdb/FirebaseRtdb.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.0.0" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.2.0" />
   </ItemGroup>
 </Project>

--- a/functions/firebase/FirebaseRtdb/Function.cs
+++ b/functions/firebase/FirebaseRtdb/Function.cs
@@ -20,24 +20,23 @@ using Microsoft.Extensions.Logging;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace FirebaseRtdb
+namespace FirebaseRtdb;
+
+public class Function : ICloudEventFunction<ReferenceEventData>
 {
-    public class Function : ICloudEventFunction<ReferenceEventData>
+    private readonly ILogger _logger;
+
+    public Function(ILogger<Function> logger) =>
+        _logger = logger;
+
+    public Task HandleAsync(CloudEvent cloudEvent, ReferenceEventData data, CancellationToken cancellationToken)
     {
-        private readonly ILogger _logger;
+        _logger.LogInformation("Function triggered by change to {subject}", cloudEvent.Subject);
+        _logger.LogInformation("Delta: {delta}", data.Delta);
 
-        public Function(ILogger<Function> logger) =>
-            _logger = logger;
-
-        public Task HandleAsync(CloudEvent cloudEvent, ReferenceEventData data, CancellationToken cancellationToken)
-        {
-            _logger.LogInformation("Function triggered by change to {subject}", cloudEvent.Subject);
-            _logger.LogInformation("Delta: {delta}", data.Delta);
-
-            // In this example, we don't need to perform any asynchronous operations, so the
-            // method doesn't need to be declared async.
-            return Task.CompletedTask;
-        }
+        // In this example, we don't need to perform any asynchronous operations, so the
+        // method doesn't need to be declared async.
+        return Task.CompletedTask;
     }
 }
 // [END functions_firebase_rtdb]

--- a/functions/firebase/FirestoreReactive/FirestoreReactive.csproj
+++ b/functions/firebase/FirestoreReactive/FirestoreReactive.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Google.Cloud.Firestore" Version="3.0.0" />
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.0.0" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.2.0" />
   </ItemGroup>
 </Project>

--- a/functions/helloworld/HelloGcs/Function.cs
+++ b/functions/helloworld/HelloGcs/Function.cs
@@ -21,30 +21,29 @@ using Microsoft.Extensions.Logging;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace HelloGcs
+namespace HelloGcs;
+
+ /// <summary>
+ /// Example Cloud Storage-triggered function.
+ /// This function can process any event from Cloud Storage.
+ /// </summary>
+public class Function : ICloudEventFunction<StorageObjectData>
 {
-     /// <summary>
-     /// Example Cloud Storage-triggered function.
-     /// This function can process any event from Cloud Storage.
-     /// </summary>
-    public class Function : ICloudEventFunction<StorageObjectData>
+    private readonly ILogger _logger;
+
+    public Function(ILogger<Function> logger) =>
+        _logger = logger;
+
+    public Task HandleAsync(CloudEvent cloudEvent, StorageObjectData data, CancellationToken cancellationToken)
     {
-        private readonly ILogger _logger;
-
-        public Function(ILogger<Function> logger) =>
-            _logger = logger;
-
-        public Task HandleAsync(CloudEvent cloudEvent, StorageObjectData data, CancellationToken cancellationToken)
-        {
-            _logger.LogInformation("Event: {event}", cloudEvent.Id);
-            _logger.LogInformation("Event Type: {type}", cloudEvent.Type);
-            _logger.LogInformation("Bucket: {bucket}", data.Bucket);
-            _logger.LogInformation("File: {file}", data.Name);
-            _logger.LogInformation("Metageneration: {metageneration}", data.Metageneration);
-            _logger.LogInformation("Created: {created:s}", data.TimeCreated?.ToDateTimeOffset());
-            _logger.LogInformation("Updated: {updated:s}", data.Updated?.ToDateTimeOffset());
-            return Task.CompletedTask;
-        }
+        _logger.LogInformation("Event: {event}", cloudEvent.Id);
+        _logger.LogInformation("Event Type: {type}", cloudEvent.Type);
+        _logger.LogInformation("Bucket: {bucket}", data.Bucket);
+        _logger.LogInformation("File: {file}", data.Name);
+        _logger.LogInformation("Metageneration: {metageneration}", data.Metageneration);
+        _logger.LogInformation("Created: {created:s}", data.TimeCreated?.ToDateTimeOffset());
+        _logger.LogInformation("Updated: {updated:s}", data.Updated?.ToDateTimeOffset());
+        return Task.CompletedTask;
     }
 }
 // [END functions_cloudevent_storage]

--- a/functions/helloworld/HelloGcs/HelloGcs.csproj
+++ b/functions/helloworld/HelloGcs/HelloGcs.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.0.0" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.2.0" />
   </ItemGroup>
 </Project>

--- a/functions/helloworld/HelloHttp/Function.cs
+++ b/functions/helloworld/HelloHttp/Function.cs
@@ -23,44 +23,43 @@ using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
 
-namespace HelloHttp
+namespace HelloHttp;
+
+public class Function : IHttpFunction
 {
-    public class Function : IHttpFunction
+    private readonly ILogger _logger;
+
+    public Function(ILogger<Function> logger) =>
+        _logger = logger;
+
+    public async Task HandleAsync(HttpContext context)
     {
-        private readonly ILogger _logger;
+        HttpRequest request = context.Request;
+        // Check URL parameters for "name" field
+        // "world" is the default value
+        string name = ((string) request.Query["name"]) ?? "world";
 
-        public Function(ILogger<Function> logger) =>
-            _logger = logger;
-
-        public async Task HandleAsync(HttpContext context)
+        // If there's a body, parse it as JSON and check for "name" field.
+        using TextReader reader = new StreamReader(request.Body);
+        string text = await reader.ReadToEndAsync();
+        if (text.Length > 0)
         {
-            HttpRequest request = context.Request;
-            // Check URL parameters for "name" field
-            // "world" is the default value
-            string name = ((string) request.Query["name"]) ?? "world";
-
-            // If there's a body, parse it as JSON and check for "name" field.
-            using TextReader reader = new StreamReader(request.Body);
-            string text = await reader.ReadToEndAsync();
-            if (text.Length > 0)
+            try
             {
-                try
+                JsonElement json = JsonSerializer.Deserialize<JsonElement>(text);
+                if (json.TryGetProperty("name", out JsonElement nameElement) &&
+                    nameElement.ValueKind == JsonValueKind.String)
                 {
-                    JsonElement json = JsonSerializer.Deserialize<JsonElement>(text);
-                    if (json.TryGetProperty("name", out JsonElement nameElement) &&
-                        nameElement.ValueKind == JsonValueKind.String)
-                    {
-                        name = nameElement.GetString();
-                    }
-                }
-                catch (JsonException parseException)
-                {
-                    _logger.LogError(parseException, "Error parsing JSON request");
+                    name = nameElement.GetString();
                 }
             }
-
-            await context.Response.WriteAsync($"Hello {name}!");
+            catch (JsonException parseException)
+            {
+                _logger.LogError(parseException, "Error parsing JSON request");
+            }
         }
+
+        await context.Response.WriteAsync($"Hello {name}!");
     }
 }
 // [END functions_helloworld_http]

--- a/functions/helloworld/HelloHttp/HelloHttp.csproj
+++ b/functions/helloworld/HelloHttp/HelloHttp.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/functions/helloworld/HelloPubSub/Function.cs
+++ b/functions/helloworld/HelloPubSub/Function.cs
@@ -21,22 +21,21 @@ using Microsoft.Extensions.Logging;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace HelloPubSub
+namespace HelloPubSub;
+
+public class Function : ICloudEventFunction<MessagePublishedData>
 {
-    public class Function : ICloudEventFunction<MessagePublishedData>
+    private readonly ILogger _logger;
+
+    public Function(ILogger<Function> logger) =>
+        _logger = logger;
+
+    public Task HandleAsync(CloudEvent cloudEvent, MessagePublishedData data, CancellationToken cancellationToken)
     {
-        private readonly ILogger _logger;
-
-        public Function(ILogger<Function> logger) =>
-            _logger = logger;
-
-        public Task HandleAsync(CloudEvent cloudEvent, MessagePublishedData data, CancellationToken cancellationToken)
-        {
-            string nameFromMessage = data.Message?.TextData;
-            string name = string.IsNullOrEmpty(nameFromMessage) ? "world" : nameFromMessage;
-            _logger.LogInformation("Hello {name}", name);
-            return Task.CompletedTask;
-        }
+        string nameFromMessage = data.Message?.TextData;
+        string name = string.IsNullOrEmpty(nameFromMessage) ? "world" : nameFromMessage;
+        _logger.LogInformation("Hello {name}", name);
+        return Task.CompletedTask;
     }
 }
 // [END functions_helloworld_pubsub]

--- a/functions/helloworld/HelloPubSub/HelloPubSub.csproj
+++ b/functions/helloworld/HelloPubSub/HelloPubSub.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.0.0" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.2.0" />
   </ItemGroup>
 </Project>

--- a/functions/helloworld/HelloPubSubFSharp/HelloPubSubFSharp.fsproj
+++ b/functions/helloworld/HelloPubSubFSharp/HelloPubSubFSharp.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,7 +9,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.0.0" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.2.0" />
   </ItemGroup>
 </Project>

--- a/functions/helloworld/HelloPubSubVb/HelloPubSubVb.vbproj
+++ b/functions/helloworld/HelloPubSubVb/HelloPubSubVb.vbproj
@@ -2,11 +2,11 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>HelloPubSubVb</RootNamespace>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.0.0" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.2.0" />
   </ItemGroup>
 </Project>

--- a/functions/helloworld/HelloWorld.Tests/FunctionIntegrationTest.cs
+++ b/functions/helloworld/HelloWorld.Tests/FunctionIntegrationTest.cs
@@ -19,54 +19,53 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace HelloHttp.Tests
+namespace HelloHttp.Tests;
+
+public class FunctionIntegrationTest
 {
-    public class FunctionIntegrationTest
+    [Fact]
+    public async Task GetRequest_NoParameters()
     {
-        [Fact]
-        public async Task GetRequest_NoParameters()
-        {
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "uri");
-            string text = await ExecuteRequest(request);
-            Assert.Equal("Hello world!", text);
-        }
+        HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "uri");
+        string text = await ExecuteRequest(request);
+        Assert.Equal("Hello world!", text);
+    }
 
-        [Fact]
-        public async Task GetRequest_UrlParameters()
-        {
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "uri?name=Cho");
-            string text = await ExecuteRequest(request);
-            Assert.Equal("Hello Cho!", text);
-        }
+    [Fact]
+    public async Task GetRequest_UrlParameters()
+    {
+        HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "uri?name=Cho");
+        string text = await ExecuteRequest(request);
+        Assert.Equal("Hello Cho!", text);
+    }
 
-        [Fact]
-        public async Task PostRequest_BodyParameters()
+    [Fact]
+    public async Task PostRequest_BodyParameters()
+    {
+        string json = "{\"name\":\"Julie\"}";
+        HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "uri")
         {
-            string json = "{\"name\":\"Julie\"}";
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "uri")
+            Content = new StringContent(json)
+        };
+        string text = await ExecuteRequest(request);
+        Assert.Equal("Hello Julie!", text);
+    }
+
+    /// <summary>
+    /// Executes the given request in the function in an in-memory test server,
+    /// validates that the response status code is 200, and returns the text of the
+    /// response body. FunctionTestServer{T} is provided by the
+    /// Google.Cloud.Functions.Testing package.
+    /// </summary>
+    private static async Task<string> ExecuteRequest(HttpRequestMessage request)
+    {
+        using (var server = new FunctionTestServer<Function>())
+        {
+            using (HttpClient client = server.CreateClient())
             {
-                Content = new StringContent(json)
-            };
-            string text = await ExecuteRequest(request);
-            Assert.Equal("Hello Julie!", text);
-        }
-
-        /// <summary>
-        /// Executes the given request in the function in an in-memory test server,
-        /// validates that the response status code is 200, and returns the text of the
-        /// response body. FunctionTestServer{T} is provided by the
-        /// Google.Cloud.Functions.Testing package.
-        /// </summary>
-        private static async Task<string> ExecuteRequest(HttpRequestMessage request)
-        {
-            using (var server = new FunctionTestServer<Function>())
-            {
-                using (HttpClient client = server.CreateClient())
-                {
-                    HttpResponseMessage response = await client.SendAsync(request);
-                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-                    return await response.Content.ReadAsStringAsync();
-                }
+                HttpResponseMessage response = await client.SendAsync(request);
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                return await response.Content.ReadAsStringAsync();
             }
         }
     }

--- a/functions/helloworld/HelloWorld.Tests/FunctionUnitTest.cs
+++ b/functions/helloworld/HelloWorld.Tests/FunctionUnitTest.cs
@@ -20,63 +20,62 @@ using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace HelloHttp.Tests
+namespace HelloHttp.Tests;
+
+public class FunctionUnitTest
 {
-    public class FunctionUnitTest
+    [Fact]
+    public async Task GetRequest_NoParameters()
     {
-        [Fact]
-        public async Task GetRequest_NoParameters()
-        {
-            DefaultHttpContext context = new DefaultHttpContext();
-            string text = await ExecuteRequest(context);
-            Assert.Equal("Hello world!", text);
-        }
+        DefaultHttpContext context = new DefaultHttpContext();
+        string text = await ExecuteRequest(context);
+        Assert.Equal("Hello world!", text);
+    }
 
-        [Fact]
-        public async Task GetRequest_UrlParameters()
+    [Fact]
+    public async Task GetRequest_UrlParameters()
+    {
+        DefaultHttpContext context = new DefaultHttpContext
         {
-            DefaultHttpContext context = new DefaultHttpContext
+            Request = { QueryString = new QueryString("?name=Cho") }
+        };
+        string text = await ExecuteRequest(context);
+        Assert.Equal("Hello Cho!", text);
+    }
+
+    [Fact]
+    public async Task PostRequest_BodyParameters()
+    {
+        string json = "{\"name\":\"Julie\"}";
+        DefaultHttpContext context = new DefaultHttpContext
+        {
+            Request =
             {
-                Request = { QueryString = new QueryString("?name=Cho") }
-            };
-            string text = await ExecuteRequest(context);
-            Assert.Equal("Hello Cho!", text);
-        }
+                Method = HttpMethods.Post,
+                Body = new MemoryStream(Encoding.UTF8.GetBytes(json))
+            }
+        };
+        string text = await ExecuteRequest(context);
+        Assert.Equal("Hello Julie!", text);
+    }
 
-        [Fact]
-        public async Task PostRequest_BodyParameters()
-        {
-            string json = "{\"name\":\"Julie\"}";
-            DefaultHttpContext context = new DefaultHttpContext
-            {
-                Request =
-                {
-                    Method = HttpMethods.Post,
-                    Body = new MemoryStream(Encoding.UTF8.GetBytes(json))
-                }
-            };
-            string text = await ExecuteRequest(context);
-            Assert.Equal("Hello Julie!", text);
-        }
+    /// <summary>
+    /// Executes the given request in the function, validates that the response
+    /// status code is 200, and returns the text of the response body.
+    /// </summary>
+    private static async Task<string> ExecuteRequest(HttpContext context)
+    {
+        MemoryStream responseStream = new MemoryStream();
+        context.Response.Body = responseStream;
 
-        /// <summary>
-        /// Executes the given request in the function, validates that the response
-        /// status code is 200, and returns the text of the response body.
-        /// </summary>
-        private static async Task<string> ExecuteRequest(HttpContext context)
-        {
-            MemoryStream responseStream = new MemoryStream();
-            context.Response.Body = responseStream;
+        Function function = new Function(new NullLogger<Function>());
+        await function.HandleAsync(context);
+        Assert.Equal(200, context.Response.StatusCode);
+        context.Response.BodyWriter.Complete();
+        context.Response.Body.Position = 0;
 
-            Function function = new Function(new NullLogger<Function>());
-            await function.HandleAsync(context);
-            Assert.Equal(200, context.Response.StatusCode);
-            context.Response.BodyWriter.Complete();
-            context.Response.Body.Position = 0;
-
-            TextReader reader = new StreamReader(responseStream);
-            return reader.ReadToEnd();
-        }
+        TextReader reader = new StreamReader(responseStream);
+        return reader.ReadToEnd();
     }
 }
 // [END functions_http_unit_test]

--- a/functions/helloworld/HelloWorld.Tests/HelloGcsUnitTest.cs
+++ b/functions/helloworld/HelloWorld.Tests/HelloGcsUnitTest.cs
@@ -24,33 +24,32 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace HelloWorld.Tests
+namespace HelloWorld.Tests;
+
+public class HelloGcsUnitTest
 {
-    public class HelloGcsUnitTest
+    [Fact]
+    public async Task FileNameIsLogged()
     {
-        [Fact]
-        public async Task FileNameIsLogged()
+        // Prepare the inputs
+        var data = new StorageObjectData { Name = "new-file.txt" };
+        var cloudEvent = new CloudEvent
         {
-            // Prepare the inputs
-            var data = new StorageObjectData { Name = "new-file.txt" };
-            var cloudEvent = new CloudEvent
-            {
-                Type = StorageObjectData.FinalizedCloudEventType,
-                Source = new Uri("//storage.googleapis.com", UriKind.RelativeOrAbsolute),
-                Id = "1234",
-                Data = data
-            };
-            var logger = new MemoryLogger<HelloGcs.Function>();
+            Type = StorageObjectData.FinalizedCloudEventType,
+            Source = new Uri("//storage.googleapis.com", UriKind.RelativeOrAbsolute),
+            Id = "1234",
+            Data = data
+        };
+        var logger = new MemoryLogger<HelloGcs.Function>();
 
-            // Execute the function
-            var function = new HelloGcs.Function(logger);
-            await function.HandleAsync(cloudEvent, data, CancellationToken.None);
+        // Execute the function
+        var function = new HelloGcs.Function(logger);
+        await function.HandleAsync(cloudEvent, data, CancellationToken.None);
 
-            // Check the log results - just the entry starting with "File:".
-            var logEntry = Assert.Single(logger.ListLogEntries(), entry => entry.Message.StartsWith("File:"));
-            Assert.Equal("File: new-file.txt", logEntry.Message);
-            Assert.Equal(LogLevel.Information, logEntry.Level);
-        }
+        // Check the log results - just the entry starting with "File:".
+        var logEntry = Assert.Single(logger.ListLogEntries(), entry => entry.Message.StartsWith("File:"));
+        Assert.Equal("File: new-file.txt", logEntry.Message);
+        Assert.Equal(LogLevel.Information, logEntry.Level);
     }
 }
 // [END functions_storage_unit_test]

--- a/functions/helloworld/HelloWorld.Tests/HelloHttpTest.cs
+++ b/functions/helloworld/HelloWorld.Tests/HelloHttpTest.cs
@@ -19,70 +19,69 @@ using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace HelloWorld.Tests
+namespace HelloWorld.Tests;
+
+public class HelloHttpTest : FunctionTestBase<HelloHttp.Function>
 {
-    public class HelloHttpTest : FunctionTestBase<HelloHttp.Function>
+    [Fact]
+    public async Task EmptyRequest()
     {
-        [Fact]
-        public async Task EmptyRequest()
-        {
-            using var client = Server.CreateClient();
-            using var response = await client.GetAsync("uri");
-            response.EnsureSuccessStatusCode();
-            var responseBody = await response.Content.ReadAsStringAsync();
-            Assert.Equal("Hello world!", responseBody);
-            Assert.Empty(Server.GetFunctionLogEntries());
-        }
+        using var client = Server.CreateClient();
+        using var response = await client.GetAsync("uri");
+        response.EnsureSuccessStatusCode();
+        var responseBody = await response.Content.ReadAsStringAsync();
+        Assert.Equal("Hello world!", responseBody);
+        Assert.Empty(Server.GetFunctionLogEntries());
+    }
 
-        [Fact]
-        public async Task NameInQuery()
-        {
-            using var client = Server.CreateClient();
-            using var response = await client.GetAsync("uri?name=test");
-            response.EnsureSuccessStatusCode();
-            var responseBody = await response.Content.ReadAsStringAsync();
-            Assert.Equal("Hello test!", responseBody);
-            Assert.Empty(Server.GetFunctionLogEntries());
-        }
+    [Fact]
+    public async Task NameInQuery()
+    {
+        using var client = Server.CreateClient();
+        using var response = await client.GetAsync("uri?name=test");
+        response.EnsureSuccessStatusCode();
+        var responseBody = await response.Content.ReadAsStringAsync();
+        Assert.Equal("Hello test!", responseBody);
+        Assert.Empty(Server.GetFunctionLogEntries());
+    }
 
-        [Fact]
-        public async Task JsonWithNameInBody()
-        {
-            using var client = Server.CreateClient();
-            using var content = new StringContent("{\"name\":\"test\"}", Encoding.UTF8, "application/json");
-            var response = await client.PostAsync("uri", content);
-            response.EnsureSuccessStatusCode();
-            var responseBody = await response.Content.ReadAsStringAsync();
-            Assert.Equal("Hello test!", responseBody);
-            Assert.Empty(Server.GetFunctionLogEntries());
-        }
+    [Fact]
+    public async Task JsonWithNameInBody()
+    {
+        using var client = Server.CreateClient();
+        using var content = new StringContent("{\"name\":\"test\"}", Encoding.UTF8, "application/json");
+        var response = await client.PostAsync("uri", content);
+        response.EnsureSuccessStatusCode();
+        var responseBody = await response.Content.ReadAsStringAsync();
+        Assert.Equal("Hello test!", responseBody);
+        Assert.Empty(Server.GetFunctionLogEntries());
+    }
 
-        [Fact]
-        public async Task JsonWithoutNameInBody()
-        {
-            using var client = Server.CreateClient();
-            using var content = new StringContent("{\"foo\":\"test\"}", Encoding.UTF8, "application/json");
-            var response = await client.PostAsync("uri", content);
-            response.EnsureSuccessStatusCode();
-            var responseBody = await response.Content.ReadAsStringAsync();
-            Assert.Equal("Hello world!", responseBody);
-            Assert.Empty(Server.GetFunctionLogEntries());
-        }
+    [Fact]
+    public async Task JsonWithoutNameInBody()
+    {
+        using var client = Server.CreateClient();
+        using var content = new StringContent("{\"foo\":\"test\"}", Encoding.UTF8, "application/json");
+        var response = await client.PostAsync("uri", content);
+        response.EnsureSuccessStatusCode();
+        var responseBody = await response.Content.ReadAsStringAsync();
+        Assert.Equal("Hello world!", responseBody);
+        Assert.Empty(Server.GetFunctionLogEntries());
+    }
 
-        [Fact]
-        public async Task InvalidJson()
-        {
-            // If the JSON is invalid, we log an error but don't fail.
-            // TODO: Check that the error is logged. (Maybe this is something we should do in the FunctionTestServer...)
-            using var client = Server.CreateClient();
-            using var content = new StringContent("{\"name\":\"test\",invalid}", Encoding.UTF8, "application/json");
-            var response = await client.PostAsync("uri", content);
-            response.EnsureSuccessStatusCode();
-            var responseBody = await response.Content.ReadAsStringAsync();
-            Assert.Equal("Hello world!", responseBody);
-            var error = Assert.Single(Server.GetFunctionLogEntries());
-            Assert.Equal("Error parsing JSON request", error.Message);
-            Assert.Equal(LogLevel.Error, error.Level);
-        }
+    [Fact]
+    public async Task InvalidJson()
+    {
+        // If the JSON is invalid, we log an error but don't fail.
+        // TODO: Check that the error is logged. (Maybe this is something we should do in the FunctionTestServer...)
+        using var client = Server.CreateClient();
+        using var content = new StringContent("{\"name\":\"test\",invalid}", Encoding.UTF8, "application/json");
+        var response = await client.PostAsync("uri", content);
+        response.EnsureSuccessStatusCode();
+        var responseBody = await response.Content.ReadAsStringAsync();
+        Assert.Equal("Hello world!", responseBody);
+        var error = Assert.Single(Server.GetFunctionLogEntries());
+        Assert.Equal("Error parsing JSON request", error.Message);
+        Assert.Equal(LogLevel.Error, error.Level);
     }
 }

--- a/functions/helloworld/HelloWorld.Tests/HelloPubSubTest.cs
+++ b/functions/helloworld/HelloWorld.Tests/HelloPubSubTest.cs
@@ -21,48 +21,47 @@ using System;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace HelloWorld.Tests
+namespace HelloWorld.Tests;
+
+public abstract class HelloPubSubTestBase<TFunction> : FunctionTestBase<TFunction>
 {
-    public abstract class HelloPubSubTestBase<TFunction> : FunctionTestBase<TFunction>
+    [Fact]
+    public async Task MessageWithTextData()
     {
-        [Fact]
-        public async Task MessageWithTextData()
+        var data = new MessagePublishedData { Message = new PubsubMessage { TextData = "PubSub user" } };
+        await ExecuteCloudEventRequestAsync(MessagePublishedData.MessagePublishedCloudEventType, data);
+
+        var logEntry = Assert.Single(GetFunctionLogEntries());
+        Assert.Equal("Hello PubSub user", logEntry.Message);
+        Assert.Equal(LogLevel.Information, logEntry.Level);
+    }
+
+    [Fact]
+    public async Task MessageWithoutTextData()
+    {
+        var data = new MessagePublishedData
         {
-            var data = new MessagePublishedData { Message = new PubsubMessage { TextData = "PubSub user" } };
-            await ExecuteCloudEventRequestAsync(MessagePublishedData.MessagePublishedCloudEventType, data);
+            Message = new PubsubMessage { Attributes = { { "key", "value" } } }
+        };
+        await ExecuteCloudEventRequestAsync(MessagePublishedData.MessagePublishedCloudEventType, data);
 
-            var logEntry = Assert.Single(GetFunctionLogEntries());
-            Assert.Equal("Hello PubSub user", logEntry.Message);
-            Assert.Equal(LogLevel.Information, logEntry.Level);
-        }
-
-        [Fact]
-        public async Task MessageWithoutTextData()
-        {
-            var data = new MessagePublishedData
-            {
-                Message = new PubsubMessage { Attributes = { { "key", "value" } } }
-            };
-            await ExecuteCloudEventRequestAsync(MessagePublishedData.MessagePublishedCloudEventType, data);
-
-            var logEntry = Assert.Single(GetFunctionLogEntries());
-            Assert.Equal("Hello world", logEntry.Message);
-            Assert.Equal(LogLevel.Information, logEntry.Level);
-        }
+        var logEntry = Assert.Single(GetFunctionLogEntries());
+        Assert.Equal("Hello world", logEntry.Message);
+        Assert.Equal(LogLevel.Information, logEntry.Level);
     }
+}
 
-    // C# test
-    public class HelloPubSubTest : HelloPubSubTestBase<HelloPubSub.Function>
-    {
-    }
+// C# test
+public class HelloPubSubTest : HelloPubSubTestBase<HelloPubSub.Function>
+{
+}
 
-    // VB test
-    public class HelloPubSubVbTest : HelloPubSubTestBase<HelloPubSubVb.CloudFunction>
-    {
-    }
+// VB test
+public class HelloPubSubVbTest : HelloPubSubTestBase<HelloPubSubVb.CloudFunction>
+{
+}
 
-    // F# test
-    public class HelloPubSubFSharpTest : HelloPubSubTestBase<HelloPubSubFSharp.Function>
-    {
-    }
+// F# test
+public class HelloPubSubFSharpTest : HelloPubSubTestBase<HelloPubSubFSharp.Function>
+{
 }

--- a/functions/helloworld/HelloWorld.Tests/HelloPubSubUnitTest.cs
+++ b/functions/helloworld/HelloWorld.Tests/HelloPubSubUnitTest.cs
@@ -23,55 +23,54 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace HelloWorld.Tests
+namespace HelloWorld.Tests;
+
+public class HelloPubSubUnitTest
 {
-    public class HelloPubSubUnitTest
+    [Fact]
+    public async Task MessageWithTextData()
     {
-        [Fact]
-        public async Task MessageWithTextData()
+        var data = new MessagePublishedData { Message = new PubsubMessage { TextData = "PubSub user" } };
+        var cloudEvent = new CloudEvent
         {
-            var data = new MessagePublishedData { Message = new PubsubMessage { TextData = "PubSub user" } };
-            var cloudEvent = new CloudEvent
-            {
-                Type = MessagePublishedData.MessagePublishedCloudEventType,
-                Source = new Uri("//pubsub.googleapis.com", UriKind.RelativeOrAbsolute),
-                Id = Guid.NewGuid().ToString(),
-                Time = DateTimeOffset.UtcNow,
-                Data = data
-            };
+            Type = MessagePublishedData.MessagePublishedCloudEventType,
+            Source = new Uri("//pubsub.googleapis.com", UriKind.RelativeOrAbsolute),
+            Id = Guid.NewGuid().ToString(),
+            Time = DateTimeOffset.UtcNow,
+            Data = data
+        };
 
-            var logger = new MemoryLogger<HelloPubSub.Function>();
-            var function = new HelloPubSub.Function(logger);
-            await function.HandleAsync(cloudEvent, data, CancellationToken.None);
+        var logger = new MemoryLogger<HelloPubSub.Function>();
+        var function = new HelloPubSub.Function(logger);
+        await function.HandleAsync(cloudEvent, data, CancellationToken.None);
 
-            var logEntry = Assert.Single(logger.ListLogEntries());
-            Assert.Equal("Hello PubSub user", logEntry.Message);
-            Assert.Equal(LogLevel.Information, logEntry.Level);
-        }
+        var logEntry = Assert.Single(logger.ListLogEntries());
+        Assert.Equal("Hello PubSub user", logEntry.Message);
+        Assert.Equal(LogLevel.Information, logEntry.Level);
+    }
 
-        [Fact]
-        public async Task MessageWithoutTextData()
+    [Fact]
+    public async Task MessageWithoutTextData()
+    {
+        var data = new MessagePublishedData
         {
-            var data = new MessagePublishedData
-            {
-                Message = new PubsubMessage { Attributes = { { "key", "value" } } }
-            };
-            var cloudEvent = new CloudEvent
-            {
-                Type = MessagePublishedData.MessagePublishedCloudEventType,
-                Source = new Uri("//pubsub.googleapis.com", UriKind.RelativeOrAbsolute),
-                Id = Guid.NewGuid().ToString(),
-                Time = DateTimeOffset.UtcNow
-            };
+            Message = new PubsubMessage { Attributes = { { "key", "value" } } }
+        };
+        var cloudEvent = new CloudEvent
+        {
+            Type = MessagePublishedData.MessagePublishedCloudEventType,
+            Source = new Uri("//pubsub.googleapis.com", UriKind.RelativeOrAbsolute),
+            Id = Guid.NewGuid().ToString(),
+            Time = DateTimeOffset.UtcNow
+        };
 
-            var logger = new MemoryLogger<HelloPubSub.Function>();
-            var function = new HelloPubSub.Function(logger);
-            await function.HandleAsync(cloudEvent, data, CancellationToken.None);
+        var logger = new MemoryLogger<HelloPubSub.Function>();
+        var function = new HelloPubSub.Function(logger);
+        await function.HandleAsync(cloudEvent, data, CancellationToken.None);
 
-            var logEntry = Assert.Single(logger.ListLogEntries());
-            Assert.Equal("Hello world", logEntry.Message);
-            Assert.Equal(LogLevel.Information, logEntry.Level);
-        }
+        var logEntry = Assert.Single(logger.ListLogEntries());
+        Assert.Equal("Hello world", logEntry.Message);
+        Assert.Equal(LogLevel.Information, logEntry.Level);
     }
 }
 // [END functions_pubsub_unit_test]

--- a/functions/helloworld/HelloWorld.Tests/HelloWorld.Tests.csproj
+++ b/functions/helloworld/HelloWorld.Tests/HelloWorld.Tests.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
-    <PackageReference Include="Google.Cloud.Functions.Testing" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Functions.Testing" Version="2.0.0" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/functions/helloworld/HelloWorld.Tests/HelloWorldTest.cs
+++ b/functions/helloworld/HelloWorld.Tests/HelloWorldTest.cs
@@ -16,30 +16,29 @@ using Google.Cloud.Functions.Testing;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace HelloWorld.Tests
+namespace HelloWorld.Tests;
+
+public abstract class HelloWorldTestBase<TFunction> : FunctionTestBase<TFunction>
 {
-    public abstract class HelloWorldTestBase<TFunction> : FunctionTestBase<TFunction>
+    [Fact]
+    public async Task EmptyRequest()
     {
-        [Fact]
-        public async Task EmptyRequest()
-        {
-            var responseBody = await ExecuteHttpGetRequestAsync("uri");
-            Assert.Equal("Hello World!", responseBody);
-        }
+        var responseBody = await ExecuteHttpGetRequestAsync("uri");
+        Assert.Equal("Hello World!", responseBody);
     }
+}
 
-    // C# test
-    public class HelloWorldTest : HelloWorldTestBase<HelloWorld.Function>
-    {
-    }
+// C# test
+public class HelloWorldTest : HelloWorldTestBase<HelloWorld.Function>
+{
+}
 
-    // VB test
-    public class HelloWorldVbTest : HelloWorldTestBase<HelloWorldVb.CloudFunction>
-    {
-    }
+// VB test
+public class HelloWorldVbTest : HelloWorldTestBase<HelloWorldVb.CloudFunction>
+{
+}
 
-    // F# test
-    public class HelloWorldFSharpTest : HelloWorldTestBase<HelloWorldFSharp.Function>
-    {
-    }
+// F# test
+public class HelloWorldFSharpTest : HelloWorldTestBase<HelloWorldFSharp.Function>
+{
 }

--- a/functions/helloworld/HelloWorld/Function.cs
+++ b/functions/helloworld/HelloWorld/Function.cs
@@ -17,14 +17,13 @@ using Google.Cloud.Functions.Framework;
 using Microsoft.AspNetCore.Http;
 using System.Threading.Tasks;
 
-namespace HelloWorld
+namespace HelloWorld;
+
+public class Function : IHttpFunction
 {
-    public class Function : IHttpFunction
+    public async Task HandleAsync(HttpContext context)
     {
-        public async Task HandleAsync(HttpContext context)
-        {
-            await context.Response.WriteAsync("Hello World!");
-        }
+        await context.Response.WriteAsync("Hello World!");
     }
 }
 // [END functions_helloworld_get]

--- a/functions/helloworld/HelloWorld/HelloWorld.csproj
+++ b/functions/helloworld/HelloWorld/HelloWorld.csproj
@@ -2,11 +2,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.0.0" />
   </ItemGroup>
 </Project>
 <!-- [END functions_csharp_project] -->

--- a/functions/helloworld/HelloWorldFSharp/HelloWorldFSharp.fsproj
+++ b/functions/helloworld/HelloWorldFSharp/HelloWorldFSharp.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.0.0" />
   </ItemGroup>
 </Project>
 <!-- [END functions_fsharp_project] -->

--- a/functions/helloworld/HelloWorldVb/HelloWorldVb.vbproj
+++ b/functions/helloworld/HelloWorldVb/HelloWorldVb.vbproj
@@ -3,11 +3,11 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>HelloWorldVb</RootNamespace>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.0.0" />
   </ItemGroup>
 </Project>
 <!-- [END functions_vb_project] -->

--- a/functions/http/Cors/Cors.csproj
+++ b/functions/http/Cors/Cors.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/functions/http/Cors/Function.cs
+++ b/functions/http/Cors/Function.cs
@@ -18,33 +18,32 @@ using Microsoft.AspNetCore.Http;
 using System.Net;
 using System.Threading.Tasks;
 
-namespace Cors
+namespace Cors;
+
+// For more information about CORS and CORS preflight requests, see
+// https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request.
+public class Function : IHttpFunction
 {
-    // For more information about CORS and CORS preflight requests, see
-    // https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request.
-    public class Function : IHttpFunction
+    public async Task HandleAsync(HttpContext context)
     {
-        public async Task HandleAsync(HttpContext context)
+        HttpRequest request = context.Request;
+        HttpResponse response = context.Response;
+
+        // Set CORS headers
+        //   Allows GETs from any origin with the Content-Type
+        //   header and caches preflight response for 3600s
+
+        response.Headers.Append("Access-Control-Allow-Origin", "*");
+        if (HttpMethods.IsOptions(request.Method))
         {
-            HttpRequest request = context.Request;
-            HttpResponse response = context.Response;
-
-            // Set CORS headers
-            //   Allows GETs from any origin with the Content-Type
-            //   header and caches preflight response for 3600s
-
-            response.Headers.Append("Access-Control-Allow-Origin", "*");
-            if (HttpMethods.IsOptions(request.Method))
-            {
-                response.Headers.Append("Access-Control-Allow-Methods", "GET");
-                response.Headers.Append("Access-Control-Allow-Headers", "Content-Type");
-                response.Headers.Append("Access-Control-Max-Age", "3600");
-                response.StatusCode = (int) HttpStatusCode.NoContent;
-                return;
-            }
-
-            await response.WriteAsync("CORS headers set successfully!");
+            response.Headers.Append("Access-Control-Allow-Methods", "GET");
+            response.Headers.Append("Access-Control-Allow-Headers", "Content-Type");
+            response.Headers.Append("Access-Control-Max-Age", "3600");
+            response.StatusCode = (int) HttpStatusCode.NoContent;
+            return;
         }
+
+        await response.WriteAsync("CORS headers set successfully!");
     }
 }
 // [END functions_http_cors]

--- a/functions/http/Http.Tests/CorsTest.cs
+++ b/functions/http/Http.Tests/CorsTest.cs
@@ -19,44 +19,43 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Http.Tests
+namespace Http.Tests;
+
+public class CorsTest : FunctionTestBase<Cors.Function>
 {
-    public class CorsTest : FunctionTestBase<Cors.Function>
+    [Fact]
+    public async Task GetRequest()
     {
-        [Fact]
-        public async Task GetRequest()
+        var request = new HttpRequestMessage(HttpMethod.Get, "uri");
+
+        await ExecuteHttpRequestAsync(request, async response =>
         {
-            var request = new HttpRequestMessage(HttpMethod.Get, "uri");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Single(response.Headers.GetValues("Access-Control-Allow-Origin"), "*");
+            var actualContent = await response.Content.ReadAsStringAsync();
+            var expectedContent = "CORS headers set successfully!";
+            Assert.Equal(expectedContent, actualContent);
+        });
+    }
 
-            await ExecuteHttpRequestAsync(request, async response =>
-            {
-                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-                Assert.Single(response.Headers.GetValues("Access-Control-Allow-Origin"), "*");
-                var actualContent = await response.Content.ReadAsStringAsync();
-                var expectedContent = "CORS headers set successfully!";
-                Assert.Equal(expectedContent, actualContent);
-            });
-        }
-
-        [Fact]
-        public async Task OptionsRequest()
+    [Fact]
+    public async Task OptionsRequest()
+    {
+        var request = new HttpRequestMessage
         {
-            var request = new HttpRequestMessage
-            {
-                Method = HttpMethod.Options,
-                RequestUri = new Uri("uri", UriKind.Relative)
-            };
-            await ExecuteHttpRequestAsync(request, async response =>
-            {
-                Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
-                Assert.Single(response.Headers.GetValues("Access-Control-Allow-Origin"), "*");
-                Assert.Single(response.Headers.GetValues("Access-Control-Allow-Methods"), "GET");
-                Assert.Single(response.Headers.GetValues("Access-Control-Allow-Headers"), "Content-Type");
-                Assert.Single(response.Headers.GetValues("Access-Control-Max-Age"), "3600");
+            Method = HttpMethod.Options,
+            RequestUri = new Uri("uri", UriKind.Relative)
+        };
+        await ExecuteHttpRequestAsync(request, async response =>
+        {
+            Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+            Assert.Single(response.Headers.GetValues("Access-Control-Allow-Origin"), "*");
+            Assert.Single(response.Headers.GetValues("Access-Control-Allow-Methods"), "GET");
+            Assert.Single(response.Headers.GetValues("Access-Control-Allow-Headers"), "Content-Type");
+            Assert.Single(response.Headers.GetValues("Access-Control-Max-Age"), "3600");
 
-                var actualContent = await response.Content.ReadAsStringAsync();
-                Assert.Empty(actualContent);
-            });
-        }
+            var actualContent = await response.Content.ReadAsStringAsync();
+            Assert.Empty(actualContent);
+        });
     }
 }

--- a/functions/http/Http.Tests/Http.Tests.csproj
+++ b/functions/http/Http.Tests/Http.Tests.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
-    <PackageReference Include="Google.Cloud.Functions.Testing" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Functions.Testing" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/functions/http/Http.Tests/HttpRequestMethodTest.cs
+++ b/functions/http/Http.Tests/HttpRequestMethodTest.cs
@@ -18,28 +18,27 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Http.Tests
-{
-    public class HttpRequestMethodTest : FunctionTestBase<HttpRequestMethod.Function>
-    {
-        [Theory]
-        [InlineData("GET", HttpStatusCode.OK, "Hello world!")]
-        [InlineData("PUT", HttpStatusCode.Forbidden, "Forbidden!")]
-        [InlineData("DELETE", HttpStatusCode.MethodNotAllowed, "Something blew up!")]
-        public async Task ExecuteFunction(string method, HttpStatusCode expectedStatus, string expectedContent)
-        {
-            var request = new HttpRequestMessage
-            {
-                Method = new HttpMethod(method),
-                RequestUri = new Uri("uri", UriKind.Relative)
-            };
+namespace Http.Tests;
 
-            await ExecuteHttpRequestAsync(request, async response =>
-            {
-                Assert.Equal(expectedStatus, response.StatusCode);
-                var actualContent = await response.Content.ReadAsStringAsync();
-                Assert.Equal(expectedContent, actualContent);
-            });
-        }
+public class HttpRequestMethodTest : FunctionTestBase<HttpRequestMethod.Function>
+{
+    [Theory]
+    [InlineData("GET", HttpStatusCode.OK, "Hello world!")]
+    [InlineData("PUT", HttpStatusCode.Forbidden, "Forbidden!")]
+    [InlineData("DELETE", HttpStatusCode.MethodNotAllowed, "Something blew up!")]
+    public async Task ExecuteFunction(string method, HttpStatusCode expectedStatus, string expectedContent)
+    {
+        var request = new HttpRequestMessage
+        {
+            Method = new HttpMethod(method),
+            RequestUri = new Uri("uri", UriKind.Relative)
+        };
+
+        await ExecuteHttpRequestAsync(request, async response =>
+        {
+            Assert.Equal(expectedStatus, response.StatusCode);
+            var actualContent = await response.Content.ReadAsStringAsync();
+            Assert.Equal(expectedContent, actualContent);
+        });
     }
 }

--- a/functions/http/Http.Tests/ParseContentTypeTest.cs
+++ b/functions/http/Http.Tests/ParseContentTypeTest.cs
@@ -21,42 +21,41 @@ using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Http.Tests
+namespace Http.Tests;
+
+public class ParseContentTypeTest : FunctionTestBase<ParseContentType.Function>
 {
-    public class ParseContentTypeTest : FunctionTestBase<ParseContentType.Function>
-    {
-        public static TheoryData<HttpContent, string> TestData =
-            new TheoryData<HttpContent, string>
-            {
-                { new StringContent("{\"name\":\"John\"}", Encoding.UTF8, "application/json"), "John" },
-                { new StringContent("{\"not-name\":\"foo\"}", Encoding.UTF8, "application/json"), null },
-                { new StringContent(Convert.ToBase64String(Encoding.UTF8.GetBytes("Fred")), Encoding.UTF8, "application/octet-stream"), "Fred" },
-                { new StringContent("Jane\nBill", Encoding.UTF8, "text/plain"), "Jane" },
-                { new FormUrlEncodedContent(new[] { KeyValuePair.Create("name", "Ginger") }), "Ginger" },
-                { new FormUrlEncodedContent(new[] { KeyValuePair.Create("not-name", "foo") }), null} ,
-                { new StringContent("other-text", Encoding.UTF8, "application/other-content"), null },
-            };
-
-        [Theory]
-        [MemberData(nameof(TestData))]
-        public async Task Process(HttpContent content, string expectedName)
+    public static TheoryData<HttpContent, string> TestData =
+        new TheoryData<HttpContent, string>
         {
-            var request = new HttpRequestMessage
-            {
-                Method = HttpMethod.Post,
-                RequestUri = new Uri("uri", UriKind.Relative),
-                Content = content
-            };
+            { new StringContent("{\"name\":\"John\"}", Encoding.UTF8, "application/json"), "John" },
+            { new StringContent("{\"not-name\":\"foo\"}", Encoding.UTF8, "application/json"), null },
+            { new StringContent(Convert.ToBase64String(Encoding.UTF8.GetBytes("Fred")), Encoding.UTF8, "application/octet-stream"), "Fred" },
+            { new StringContent("Jane\nBill", Encoding.UTF8, "text/plain"), "Jane" },
+            { new FormUrlEncodedContent(new[] { KeyValuePair.Create("name", "Ginger") }), "Ginger" },
+            { new FormUrlEncodedContent(new[] { KeyValuePair.Create("not-name", "foo") }), null} ,
+            { new StringContent("other-text", Encoding.UTF8, "application/other-content"), null },
+        };
 
-            var expectedStatusCode = expectedName is null ? HttpStatusCode.BadRequest : HttpStatusCode.OK;
-            var expectedContent = expectedName is null ? "" : $"Hello {expectedName}!";
+    [Theory]
+    [MemberData(nameof(TestData))]
+    public async Task Process(HttpContent content, string expectedName)
+    {
+        var request = new HttpRequestMessage
+        {
+            Method = HttpMethod.Post,
+            RequestUri = new Uri("uri", UriKind.Relative),
+            Content = content
+        };
 
-            await ExecuteHttpRequestAsync(request, async response =>
-            {
-                Assert.Equal(expectedStatusCode, response.StatusCode);
-                var actualContent = await response.Content.ReadAsStringAsync();
-                Assert.Equal(expectedContent, actualContent);
-            });
-        }
+        var expectedStatusCode = expectedName is null ? HttpStatusCode.BadRequest : HttpStatusCode.OK;
+        var expectedContent = expectedName is null ? "" : $"Hello {expectedName}!";
+
+        await ExecuteHttpRequestAsync(request, async response =>
+        {
+            Assert.Equal(expectedStatusCode, response.StatusCode);
+            var actualContent = await response.Content.ReadAsStringAsync();
+            Assert.Equal(expectedContent, actualContent);
+        });
     }
 }

--- a/functions/http/Http.Tests/SendHttpRequestTest.cs
+++ b/functions/http/Http.Tests/SendHttpRequestTest.cs
@@ -12,20 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 using Google.Cloud.Functions.Testing;
-using System.Net;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Http.Tests
+namespace Http.Tests;
+
+public class SendHttpRequestTest : FunctionTestBase<SendHttpRequest.Function>
 {
-    public class SendHttpRequestTest : FunctionTestBase<SendHttpRequest.Function>
+    [Fact]
+    public async Task SuccessfulRequest()
     {
-        [Fact]
-        public async Task SuccessfulRequest()
-        {
-            var actualContent = await ExecuteHttpGetRequestAsync("uri");
-            var expectedContent = "Received code '200' from URL 'http://example.com'.";
-            Assert.Equal(expectedContent, actualContent);
-        }
+        var actualContent = await ExecuteHttpGetRequestAsync("uri");
+        var expectedContent = "Received code '200' from URL 'http://example.com'.";
+        Assert.Equal(expectedContent, actualContent);
     }
 }

--- a/functions/http/HttpFormData/HttpFormData.csproj
+++ b/functions/http/HttpFormData/HttpFormData.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/functions/http/HttpRequestMethod/Function.cs
+++ b/functions/http/HttpRequestMethod/Function.cs
@@ -18,28 +18,27 @@ using Microsoft.AspNetCore.Http;
 using System.Net;
 using System.Threading.Tasks;
 
-namespace HttpRequestMethod
+namespace HttpRequestMethod;
+
+public class Function : IHttpFunction
 {
-    public class Function : IHttpFunction
+    public async Task HandleAsync(HttpContext context)
     {
-        public async Task HandleAsync(HttpContext context)
+        HttpResponse response = context.Response;
+        switch (context.Request.Method)
         {
-            HttpResponse response = context.Response;
-            switch (context.Request.Method)
-            {
-                case "GET":
-                    response.StatusCode = (int) HttpStatusCode.OK;
-                    await response.WriteAsync("Hello world!");
-                    break;
-                case "PUT":
-                    response.StatusCode = (int) HttpStatusCode.Forbidden;
-                    await response.WriteAsync("Forbidden!");
-                    break;
-                default:
-                    response.StatusCode = (int) HttpStatusCode.MethodNotAllowed;
-                    await response.WriteAsync("Something blew up!");
-                    break;
-            }
+            case "GET":
+                response.StatusCode = (int) HttpStatusCode.OK;
+                await response.WriteAsync("Hello world!");
+                break;
+            case "PUT":
+                response.StatusCode = (int) HttpStatusCode.Forbidden;
+                await response.WriteAsync("Forbidden!");
+                break;
+            default:
+                response.StatusCode = (int) HttpStatusCode.MethodNotAllowed;
+                await response.WriteAsync("Something blew up!");
+                break;
         }
     }
 }

--- a/functions/http/HttpRequestMethod/HttpRequestMethod.csproj
+++ b/functions/http/HttpRequestMethod/HttpRequestMethod.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/functions/http/ParseContentType/ParseContentType.csproj
+++ b/functions/http/ParseContentType/ParseContentType.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/functions/http/SendHttpRequest/Function.cs
+++ b/functions/http/SendHttpRequest/Function.cs
@@ -21,38 +21,37 @@ using Microsoft.Extensions.DependencyInjection;
 using System.Net.Http;
 using System.Threading.Tasks;
 
-namespace SendHttpRequest
+namespace SendHttpRequest;
+
+// Dependency injection configuration, executed during server startup.
+public class Startup : FunctionsStartup
 {
-    // Dependency injection configuration, executed during server startup.
-    public class Startup : FunctionsStartup
+    public override void ConfigureServices(WebHostBuilderContext context, IServiceCollection services)
     {
-        public override void ConfigureServices(WebHostBuilderContext context, IServiceCollection services)
-        {
-            // Make an HttpClient available to our function via dependency injection.
-            // There are many options here; see
-            // https://docs.microsoft.com/en-us/aspnet/core/fundamentals/http-requests
-            // for more details.
-            services.AddHttpClient<IHttpFunction, Function>();
-        }
+        // Make an HttpClient available to our function via dependency injection.
+        // There are many options here; see
+        // https://docs.microsoft.com/en-us/aspnet/core/fundamentals/http-requests
+        // for more details.
+        services.AddHttpClient<IHttpFunction, Function>();
     }
+}
 
-    // Function, decorated with the FunctionsStartup attribute to specify the startup class
-    // for dependency injection.
-    [FunctionsStartup(typeof(Startup))]
-    public class Function : IHttpFunction
+// Function, decorated with the FunctionsStartup attribute to specify the startup class
+// for dependency injection.
+[FunctionsStartup(typeof(Startup))]
+public class Function : IHttpFunction
+{
+    private readonly HttpClient _httpClient;
+
+    public Function(HttpClient httpClient) =>
+        _httpClient = httpClient;
+
+    public async Task HandleAsync(HttpContext context)
     {
-        private readonly HttpClient _httpClient;
-
-        public Function(HttpClient httpClient) =>
-            _httpClient = httpClient;
-
-        public async Task HandleAsync(HttpContext context)
+        string url = "http://example.com";
+        using (HttpResponseMessage clientResponse = await _httpClient.GetAsync(url))
         {
-            string url = "http://example.com";
-            using (HttpResponseMessage clientResponse = await _httpClient.GetAsync(url))
-            {
-                await context.Response.WriteAsync($"Received code '{(int) clientResponse.StatusCode}' from URL '{url}'.");
-            }
+            await context.Response.WriteAsync($"Received code '{(int) clientResponse.StatusCode}' from URL '{url}'.");
         }
     }
 }

--- a/functions/http/SendHttpRequest/SendHttpRequest.csproj
+++ b/functions/http/SendHttpRequest/SendHttpRequest.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/functions/imagemagick/ImageMagick/Function.cs
+++ b/functions/imagemagick/ImageMagick/Function.cs
@@ -29,133 +29,132 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace ImageMagick
+namespace ImageMagick;
+
+// Dependency injection configuration, executed during server startup.
+public class Startup : FunctionsStartup
 {
-    // Dependency injection configuration, executed during server startup.
-    public class Startup : FunctionsStartup
+    public override void ConfigureServices(WebHostBuilderContext context, IServiceCollection services) =>
+        services
+            .AddSingleton(ImageAnnotatorClient.Create())
+            .AddSingleton(StorageClient.Create());
+}
+
+[FunctionsStartup(typeof(Startup))]
+public class Function : ICloudEventFunction<StorageObjectData>
+{
+    /// <summary>
+    /// The bucket to store blurred images in. An alternative to using environment variables here would be to
+    /// fetch it from IConfiguration.
+    /// </summary>
+    private static readonly string s_blurredBucketName = Environment.GetEnvironmentVariable("BLURRED_BUCKET_NAME");
+
+    private readonly ImageAnnotatorClient _visionClient;
+    private readonly StorageClient _storageClient;
+    private readonly ILogger _logger;
+
+    public Function(ImageAnnotatorClient visionClient, StorageClient storageClient, ILogger<Function> logger) =>
+        (_visionClient, _storageClient, _logger) = (visionClient, storageClient, logger);
+
+    // [END functions_imagemagick_setup]
+
+    // [START functions_imagemagick_analyze]
+    public async Task HandleAsync(CloudEvent cloudEvent, StorageObjectData data, CancellationToken cancellationToken)
     {
-        public override void ConfigureServices(WebHostBuilderContext context, IServiceCollection services) =>
-            services
-                .AddSingleton(ImageAnnotatorClient.Create())
-                .AddSingleton(StorageClient.Create());
-    }
+        // Validate parameters
+        if (data.Bucket is null || data.Name is null)
+        {
+            _logger.LogError("Malformed GCS event.");
+            return;
+        }
 
-    [FunctionsStartup(typeof(Startup))]
-    public class Function : ICloudEventFunction<StorageObjectData>
+        // Construct URI to GCS bucket and file.
+        string gcsUri = $"gs://{data.Bucket}/{data.Name}";
+        _logger.LogInformation("Analyzing {uri}", gcsUri);
+
+        // Perform safe search detection using the Vision API.
+        Image image = Image.FromUri(gcsUri);
+        SafeSearchAnnotation annotation;
+        try
+        {
+            annotation = await _visionClient.DetectSafeSearchAsync(image);
+        }
+        // If the call to the Vision API fails, log the error but let the function complete normally.
+        // If the exceptions weren't caught (and just propagated) the event would be retried.
+        // See the "Best Practices" section in the documentation for more details about retry.
+        catch (AnnotateImageException e)
+        {
+            _logger.LogError(e, "Vision API reported an error while performing safe search detection");
+            return;
+        }
+        catch (RpcException e)
+        {
+            _logger.LogError(e, "Error communicating with the Vision API");
+            return;
+        }
+
+        if (annotation.Adult == Likelihood.VeryLikely || annotation.Violence == Likelihood.VeryLikely)
+        {
+            _logger.LogInformation("Detected {uri} as inappropriate.", gcsUri);
+            await BlurImageAsync(data, cancellationToken);
+        }
+        else
+        {
+            _logger.LogInformation("Detected {uri} as OK.", gcsUri);
+        }
+    }
+    // [END functions_imagemagick_analyze]
+
+    // [START functions_imagemagick_blur]
+    /// <summary>
+    /// Downloads the Storage object specified by <paramref name="data"/>,
+    /// blurs it using ImageMagick, and uploads it to the "blurred" bucket.
+    /// </summary>
+    private async Task BlurImageAsync(StorageObjectData data, CancellationToken cancellationToken)
     {
-        /// <summary>
-        /// The bucket to store blurred images in. An alternative to using environment variables here would be to
-        /// fetch it from IConfiguration.
-        /// </summary>
-        private static readonly string s_blurredBucketName = Environment.GetEnvironmentVariable("BLURRED_BUCKET_NAME");
-
-        private readonly ImageAnnotatorClient _visionClient;
-        private readonly StorageClient _storageClient;
-        private readonly ILogger _logger;
-
-        public Function(ImageAnnotatorClient visionClient, StorageClient storageClient, ILogger<Function> logger) =>
-            (_visionClient, _storageClient, _logger) = (visionClient, storageClient, logger);
-
-        // [END functions_imagemagick_setup]
-
-        // [START functions_imagemagick_analyze]
-        public async Task HandleAsync(CloudEvent cloudEvent, StorageObjectData data, CancellationToken cancellationToken)
+        // Download image
+        string originalImageFile = Path.GetTempFileName();
+        using (Stream output = File.Create(originalImageFile))
         {
-            // Validate parameters
-            if (data.Bucket is null || data.Name is null)
-            {
-                _logger.LogError("Malformed GCS event.");
-                return;
-            }
-
-            // Construct URI to GCS bucket and file.
-            string gcsUri = $"gs://{data.Bucket}/{data.Name}";
-            _logger.LogInformation("Analyzing {uri}", gcsUri);
-
-            // Perform safe search detection using the Vision API.
-            Image image = Image.FromUri(gcsUri);
-            SafeSearchAnnotation annotation;
-            try
-            {
-                annotation = await _visionClient.DetectSafeSearchAsync(image);
-            }
-            // If the call to the Vision API fails, log the error but let the function complete normally.
-            // If the exceptions weren't caught (and just propagated) the event would be retried.
-            // See the "Best Practices" section in the documentation for more details about retry.
-            catch (AnnotateImageException e)
-            {
-                _logger.LogError(e, "Vision API reported an error while performing safe search detection");
-                return;
-            }
-            catch (RpcException e)
-            {
-                _logger.LogError(e, "Error communicating with the Vision API");
-                return;
-            }
-
-            if (annotation.Adult == Likelihood.VeryLikely || annotation.Violence == Likelihood.VeryLikely)
-            {
-                _logger.LogInformation("Detected {uri} as inappropriate.", gcsUri);
-                await BlurImageAsync(data, cancellationToken);
-            }
-            else
-            {
-                _logger.LogInformation("Detected {uri} as OK.", gcsUri);
-            }
+            await _storageClient.DownloadObjectAsync(data.Bucket, data.Name, output, cancellationToken: cancellationToken);
         }
-        // [END functions_imagemagick_analyze]
 
-        // [START functions_imagemagick_blur]
-        /// <summary>
-        /// Downloads the Storage object specified by <paramref name="data"/>,
-        /// blurs it using ImageMagick, and uploads it to the "blurred" bucket.
-        /// </summary>
-        private async Task BlurImageAsync(StorageObjectData data, CancellationToken cancellationToken)
+        // Construct the ImageMagick command
+        string blurredImageFile = Path.GetTempFileName();
+        // Command-line arguments for ImageMagick.
+        // Paths are wrapped in quotes in case they contain spaces.
+        string arguments = $"\"{originalImageFile}\" -blur 0x8, \"{blurredImageFile}\"";
+
+        // Run the ImageMagick command line tool ("convert").
+        Process process = Process.Start("convert", arguments);
+        // Process doesn't expose a way of asynchronously waiting for completion.
+        // See https://stackoverflow.com/questions/470256 for examples of how
+        // this can be achieved using events, but for the sake of brevity,
+        // this sample just waits synchronously.
+        process.WaitForExit();
+
+        // If ImageMagick failed, log the error but complete normally to avoid retrying.
+        if (process.ExitCode != 0)
         {
-            // Download image
-            string originalImageFile = Path.GetTempFileName();
-            using (Stream output = File.Create(originalImageFile))
-            {
-                await _storageClient.DownloadObjectAsync(data.Bucket, data.Name, output, cancellationToken: cancellationToken);
-            }
-
-            // Construct the ImageMagick command
-            string blurredImageFile = Path.GetTempFileName();
-            // Command-line arguments for ImageMagick.
-            // Paths are wrapped in quotes in case they contain spaces.
-            string arguments = $"\"{originalImageFile}\" -blur 0x8, \"{blurredImageFile}\"";
-
-            // Run the ImageMagick command line tool ("convert").
-            Process process = Process.Start("convert", arguments);
-            // Process doesn't expose a way of asynchronously waiting for completion.
-            // See https://stackoverflow.com/questions/470256 for examples of how
-            // this can be achieved using events, but for the sake of brevity,
-            // this sample just waits synchronously.
-            process.WaitForExit();
-
-            // If ImageMagick failed, log the error but complete normally to avoid retrying.
-            if (process.ExitCode != 0)
-            {
-                _logger.LogError("ImageMagick exited with code {exitCode}", process.ExitCode);
-                return;
-            }
-
-            // Upload image to blurred bucket.
-            using (Stream input = File.OpenRead(blurredImageFile))
-            {
-                await _storageClient.UploadObjectAsync(
-                    s_blurredBucketName, data.Name, data.ContentType, input, cancellationToken: cancellationToken);
-            }
-
-            string uri = $"gs://{s_blurredBucketName}/{data.Name}";
-            _logger.LogInformation("Blurred image uploaded to: {uri}", uri);
-
-            // Remove images from the file system.
-            File.Delete(originalImageFile);
-            File.Delete(blurredImageFile);
+            _logger.LogError("ImageMagick exited with code {exitCode}", process.ExitCode);
+            return;
         }
-        // [END functions_imagemagick_blur]
-        // [START functions_imagemagick_setup]
+
+        // Upload image to blurred bucket.
+        using (Stream input = File.OpenRead(blurredImageFile))
+        {
+            await _storageClient.UploadObjectAsync(
+                s_blurredBucketName, data.Name, data.ContentType, input, cancellationToken: cancellationToken);
+        }
+
+        string uri = $"gs://{s_blurredBucketName}/{data.Name}";
+        _logger.LogInformation("Blurred image uploaded to: {uri}", uri);
+
+        // Remove images from the file system.
+        File.Delete(originalImageFile);
+        File.Delete(blurredImageFile);
     }
+    // [END functions_imagemagick_blur]
+    // [START functions_imagemagick_setup]
 }
 // [END functions_imagemagick_setup]

--- a/functions/imagemagick/ImageMagick/ImageMagick.csproj
+++ b/functions/imagemagick/ImageMagick/ImageMagick.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.0.0" />
     <PackageReference Include="Google.Cloud.Storage.V1" Version="4.2.0" />
     <PackageReference Include="Google.Cloud.Vision.V1" Version="3.3.0" />
     <PackageReference Include="Google.Events.Protobuf" Version="1.2.0" />

--- a/functions/logging/LogHelloWorld/Function.cs
+++ b/functions/logging/LogHelloWorld/Function.cs
@@ -19,25 +19,24 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Threading.Tasks;
 
-namespace LogHelloWorld
+namespace LogHelloWorld;
+
+public class Function : IHttpFunction
 {
-    public class Function : IHttpFunction
+    private readonly ILogger _logger;
+
+    public Function(ILogger<Function> logger) =>
+        _logger = logger;
+
+    public async Task HandleAsync(HttpContext context)
     {
-        private readonly ILogger _logger;
+        Console.WriteLine("I am a log to stdout!");
+        Console.Error.WriteLine("I am a log to stderr!");
 
-        public Function(ILogger<Function> logger) =>
-            _logger = logger;
+        _logger.LogInformation("I am an info log!");
+        _logger.LogWarning("I am a warning log!");
 
-        public async Task HandleAsync(HttpContext context)
-        {
-            Console.WriteLine("I am a log to stdout!");
-            Console.Error.WriteLine("I am a log to stderr!");
-
-            _logger.LogInformation("I am an info log!");
-            _logger.LogWarning("I am a warning log!");
-
-            await context.Response.WriteAsync("Messages successfully logged!");
-        }
+        await context.Response.WriteAsync("Messages successfully logged!");
     }
 }
 // [END functions_log_helloworld]

--- a/functions/logging/LogHelloWorld/LogHelloWorld.csproj
+++ b/functions/logging/LogHelloWorld/LogHelloWorld.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/functions/logging/Logging.Tests/LogHelloWorldTest.cs
+++ b/functions/logging/Logging.Tests/LogHelloWorldTest.cs
@@ -19,52 +19,51 @@ using System.IO;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Logging.Tests
+namespace Logging.Tests;
+
+public class LogHelloWorldTest : FunctionTestBase<LogHelloWorld.Function>
 {
-    public class LogHelloWorldTest : FunctionTestBase<LogHelloWorld.Function>
+    [Fact]
+    public async Task LogEntriesWritten()
     {
-        [Fact]
-        public async Task LogEntriesWritten()
+        var (stdout, stderr) = await RunWithConsoleRedirection(async () =>
         {
-            var (stdout, stderr) = await RunWithConsoleRedirection(async () =>
-            {
-                var responseBody = await ExecuteHttpGetRequestAsync("uri");
-                Assert.Equal("Messages successfully logged!", responseBody);
-            });
+            var responseBody = await ExecuteHttpGetRequestAsync("uri");
+            Assert.Equal("Messages successfully logged!", responseBody);
+        });
 
-            // The console output will include ASP.NET Core logs (including the info and warning
-            // logs written in the function) because our test logger doesn't disable the console
-            // logger, but we should at least have the expected message as well.
-            Assert.Contains("I am a log to stdout!\n", stdout);
-            Assert.Contains("I am a log to stderr!\n", stderr);
-            
-            var logEntries = GetFunctionLogEntries();
-            var info = Assert.Single(logEntries, entry => entry.Level == LogLevel.Information);
-            Assert.Equal("I am an info log!", info.Message);
+        // The console output will include ASP.NET Core logs (including the info and warning
+        // logs written in the function) because our test logger doesn't disable the console
+        // logger, but we should at least have the expected message as well.
+        Assert.Contains("I am a log to stdout!\n", stdout);
+        Assert.Contains("I am a log to stderr!\n", stderr);
+        
+        var logEntries = GetFunctionLogEntries();
+        var info = Assert.Single(logEntries, entry => entry.Level == LogLevel.Information);
+        Assert.Equal("I am an info log!", info.Message);
 
-            var warning  = Assert.Single(logEntries, entry => entry.Level == LogLevel.Warning);
-            Assert.Equal("I am a warning log!", warning.Message);
+        var warning  = Assert.Single(logEntries, entry => entry.Level == LogLevel.Warning);
+        Assert.Equal("I am a warning log!", warning.Message);
+    }
+
+    public async Task<(string stdout, string stderr)> RunWithConsoleRedirection(Func<Task> func)
+    {
+        var originalOut = Console.Out;
+        var originalError = Console.Error;
+        try
+        {
+            var outWriter = new StringWriter { NewLine = "\n" };
+            var errorWriter = new StringWriter { NewLine = "\n" };
+            Console.SetOut(outWriter);
+            Console.SetError(errorWriter);
+
+            await func().ConfigureAwait(false);
+            return (outWriter.ToString(), errorWriter.ToString());
         }
-
-        public async Task<(string stdout, string stderr)> RunWithConsoleRedirection(Func<Task> func)
+        finally
         {
-            var originalOut = Console.Out;
-            var originalError = Console.Error;
-            try
-            {
-                var outWriter = new StringWriter { NewLine = "\n" };
-                var errorWriter = new StringWriter { NewLine = "\n" };
-                Console.SetOut(outWriter);
-                Console.SetError(errorWriter);
-
-                await func().ConfigureAwait(false);
-                return (outWriter.ToString(), errorWriter.ToString());
-            }
-            finally
-            {
-                Console.SetOut(originalOut);
-                Console.SetError(originalError);
-            }
+            Console.SetOut(originalOut);
+            Console.SetError(originalError);
         }
     }
 }

--- a/functions/logging/Logging.Tests/Logging.Tests.csproj
+++ b/functions/logging/Logging.Tests/Logging.Tests.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
-    <PackageReference Include="Google.Cloud.Functions.Testing" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Functions.Testing" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/functions/slack/SlackKnowledgeGraphSearch/Function.cs
+++ b/functions/slack/SlackKnowledgeGraphSearch/Function.cs
@@ -23,125 +23,124 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 
-namespace SlackKnowledgeGraphSearch
+namespace SlackKnowledgeGraphSearch;
+
+public class Function : IHttpFunction
 {
-    public class Function : IHttpFunction
+    // [START functions_slack_search]
+    private readonly ILogger _logger;
+    private readonly KgsearchService _kgService;
+    private readonly SlackRequestVerifier _verifier;
+
+    public Function(ILogger<Function> logger, KgsearchService kgService, SlackRequestVerifier verifier) =>
+        (_logger, _kgService, _verifier) = (logger, kgService, verifier);
+
+    public async Task HandleAsync(HttpContext context)
     {
-        // [START functions_slack_search]
-        private readonly ILogger _logger;
-        private readonly KgsearchService _kgService;
-        private readonly SlackRequestVerifier _verifier;
+        var request = context.Request;
+        var response = context.Response;
 
-        public Function(ILogger<Function> logger, KgsearchService kgService, SlackRequestVerifier verifier) =>
-            (_logger, _kgService, _verifier) = (logger, kgService, verifier);
-
-        public async Task HandleAsync(HttpContext context)
+        // Validate request
+        if (request.Method != "POST")
         {
-            var request = context.Request;
-            var response = context.Response;
-
-            // Validate request
-            if (request.Method != "POST")
-            {
-                _logger.LogWarning("Unexpected request method '{method}'", request.Method);
-                response.StatusCode = (int) HttpStatusCode.MethodNotAllowed;
-                return;
-            }
-
-            if (!request.HasFormContentType)
-            {
-                _logger.LogWarning("Unexpected content type '{contentType}'", request.ContentType);
-                response.StatusCode = (int) HttpStatusCode.BadRequest;
-                return;
-            }
-
-            // We need to read the request body twice: once to validate the signature,
-            // and once to read the form content. We copy it into a memory stream,
-            // so that we can rewind it after reading.
-            var bodyCopy = new MemoryStream();
-            await request.Body.CopyToAsync(bodyCopy);
-            request.Body = bodyCopy;
-            bodyCopy.Position = 0;
-
-            if (!_verifier.VerifyRequest(request, bodyCopy.ToArray()))
-            {
-                _logger.LogWarning("Slack request verification failed");
-                response.StatusCode = (int) HttpStatusCode.Unauthorized;
-                return;
-            }
-
-            var form = await request.ReadFormAsync();
-            if (!form.TryGetValue("text", out var query))
-            {
-                _logger.LogWarning("Slack request form did not contain a text element");
-                response.StatusCode = (int) HttpStatusCode.BadRequest;
-                return;
-            }
-
-            var kgResponse = await SearchKnowledgeGraphAsync(query);
-            string formattedResponse = FormatSlackMessage(kgResponse, query);
-            response.ContentType = "application/json";
-            await response.WriteAsync(formattedResponse);
+            _logger.LogWarning("Unexpected request method '{method}'", request.Method);
+            response.StatusCode = (int) HttpStatusCode.MethodNotAllowed;
+            return;
         }
-        // [END functions_slack_search]
 
-        // [START functions_slack_request]
-        private async Task<SearchResponse> SearchKnowledgeGraphAsync(string query)
+        if (!request.HasFormContentType)
         {
-            _logger.LogInformation("Performing Knowledge Graph search for '{query}'", query);
-            var request = _kgService.Entities.Search();
-            request.Limit = 1;
-            request.Query = query;
-            return await request.ExecuteAsync();
+            _logger.LogWarning("Unexpected content type '{contentType}'", request.ContentType);
+            response.StatusCode = (int) HttpStatusCode.BadRequest;
+            return;
         }
-        // [END functions_slack_request]
 
-        // [START functions_slack_format]
-        private string FormatSlackMessage(SearchResponse kgResponse, string query)
+        // We need to read the request body twice: once to validate the signature,
+        // and once to read the form content. We copy it into a memory stream,
+        // so that we can rewind it after reading.
+        var bodyCopy = new MemoryStream();
+        await request.Body.CopyToAsync(bodyCopy);
+        request.Body = bodyCopy;
+        bodyCopy.Position = 0;
+
+        if (!_verifier.VerifyRequest(request, bodyCopy.ToArray()))
         {
-            JObject attachment = new JObject();
-            JObject response = new JObject();
-
-            response["response_type"] = "in_channel";
-            response["text"] = $"Query: {query}";
-
-            var element = kgResponse.ItemListElement?.FirstOrDefault() as JObject;
-            if (element is object && element.TryGetValue("result", out var entityToken) &&
-                entityToken is JObject entity)
-            {
-                string title = (string) entity["name"];
-                if (entity.TryGetValue("description", out var description))
-                {
-                    title = $"{title}: {description}";
-                }
-                attachment["title"] = title;
-                if (entity.TryGetValue("detailedDescription", out var detailedDescriptionToken) &&
-                    detailedDescriptionToken is JObject detailedDescription)
-                {
-                    AddPropertyIfPresent(detailedDescription, "url", "title_link");
-                    AddPropertyIfPresent(detailedDescription, "articleBody", "text");
-                }
-                if (entity.TryGetValue("image", out var imageToken) &&
-                    imageToken is JObject image)
-                {
-                    AddPropertyIfPresent(image, "contentUrl", "image_url");
-                }
-            }
-            else
-            {
-                attachment["text"] = "No results match your query...";
-            }
-            response["attachments"] = new JArray { attachment };
-            return response.ToString();
-
-            void AddPropertyIfPresent(JObject parent, string sourceProperty, string targetProperty)
-            {
-                if (parent.TryGetValue(sourceProperty, out var propertyValue))
-                {
-                    attachment[targetProperty] = propertyValue;
-                }
-            }
+            _logger.LogWarning("Slack request verification failed");
+            response.StatusCode = (int) HttpStatusCode.Unauthorized;
+            return;
         }
-        // [END functions_slack_format]
+
+        var form = await request.ReadFormAsync();
+        if (!form.TryGetValue("text", out var query))
+        {
+            _logger.LogWarning("Slack request form did not contain a text element");
+            response.StatusCode = (int) HttpStatusCode.BadRequest;
+            return;
+        }
+
+        var kgResponse = await SearchKnowledgeGraphAsync(query);
+        string formattedResponse = FormatSlackMessage(kgResponse, query);
+        response.ContentType = "application/json";
+        await response.WriteAsync(formattedResponse);
     }
+    // [END functions_slack_search]
+
+    // [START functions_slack_request]
+    private async Task<SearchResponse> SearchKnowledgeGraphAsync(string query)
+    {
+        _logger.LogInformation("Performing Knowledge Graph search for '{query}'", query);
+        var request = _kgService.Entities.Search();
+        request.Limit = 1;
+        request.Query = query;
+        return await request.ExecuteAsync();
+    }
+    // [END functions_slack_request]
+
+    // [START functions_slack_format]
+    private string FormatSlackMessage(SearchResponse kgResponse, string query)
+    {
+        JObject attachment = new JObject();
+        JObject response = new JObject();
+
+        response["response_type"] = "in_channel";
+        response["text"] = $"Query: {query}";
+
+        var element = kgResponse.ItemListElement?.FirstOrDefault() as JObject;
+        if (element is object && element.TryGetValue("result", out var entityToken) &&
+            entityToken is JObject entity)
+        {
+            string title = (string) entity["name"];
+            if (entity.TryGetValue("description", out var description))
+            {
+                title = $"{title}: {description}";
+            }
+            attachment["title"] = title;
+            if (entity.TryGetValue("detailedDescription", out var detailedDescriptionToken) &&
+                detailedDescriptionToken is JObject detailedDescription)
+            {
+                AddPropertyIfPresent(detailedDescription, "url", "title_link");
+                AddPropertyIfPresent(detailedDescription, "articleBody", "text");
+            }
+            if (entity.TryGetValue("image", out var imageToken) &&
+                imageToken is JObject image)
+            {
+                AddPropertyIfPresent(image, "contentUrl", "image_url");
+            }
+        }
+        else
+        {
+            attachment["text"] = "No results match your query...";
+        }
+        response["attachments"] = new JArray { attachment };
+        return response.ToString();
+
+        void AddPropertyIfPresent(JObject parent, string sourceProperty, string targetProperty)
+        {
+            if (parent.TryGetValue(sourceProperty, out var propertyValue))
+            {
+                attachment[targetProperty] = propertyValue;
+            }
+        }
+    }
+    // [END functions_slack_format]
 }

--- a/functions/slack/SlackKnowledgeGraphSearch/SlackKnowledgeGraphSearch.csproj
+++ b/functions/slack/SlackKnowledgeGraphSearch/SlackKnowledgeGraphSearch.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Google.Apis.Kgsearch.v1" Version="1.59.0.2143" />
-    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="1.1.0" />
+    <PackageReference Include="Google.Cloud.Functions.Hosting" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/functions/slack/SlackKnowledgeGraphSearch/SlackRequestVerifier.cs
+++ b/functions/slack/SlackKnowledgeGraphSearch/SlackRequestVerifier.cs
@@ -18,69 +18,68 @@ using System;
 using System.Security.Cryptography;
 using System.Text;
 
-namespace SlackKnowledgeGraphSearch
+namespace SlackKnowledgeGraphSearch;
+
+public class SlackRequestVerifier
 {
-    public class SlackRequestVerifier
+    private const string Version = "v0";
+    private const string SignaturePrefix = Version + "=";
+    private static readonly byte[] VersionBytes = Encoding.UTF8.GetBytes(Version);
+    private static readonly byte[] ColonBytes = Encoding.UTF8.GetBytes(":");
+
+    private readonly byte[] _signingKeyBytes;
+    private readonly TimeSpan _timestampTolerance;
+
+    public SlackRequestVerifier(string signingKey, TimeSpan timestampTolerance) =>
+        (_signingKeyBytes, _timestampTolerance) =
+        (Encoding.UTF8.GetBytes(signingKey), timestampTolerance);
+
+    /// <summary>
+    /// Verifies a request signature with the given content, which would
+    /// normally have been read from the request beforehand.
+    /// </summary>
+    public bool VerifyRequest(HttpRequest request, byte[] content)
     {
-        private const string Version = "v0";
-        private const string SignaturePrefix = Version + "=";
-        private static readonly byte[] VersionBytes = Encoding.UTF8.GetBytes(Version);
-        private static readonly byte[] ColonBytes = Encoding.UTF8.GetBytes(":");
-
-        private readonly byte[] _signingKeyBytes;
-        private readonly TimeSpan _timestampTolerance;
-
-        public SlackRequestVerifier(string signingKey, TimeSpan timestampTolerance) =>
-            (_signingKeyBytes, _timestampTolerance) =
-            (Encoding.UTF8.GetBytes(signingKey), timestampTolerance);
-
-        /// <summary>
-        /// Verifies a request signature with the given content, which would
-        /// normally have been read from the request beforehand.
-        /// </summary>
-        public bool VerifyRequest(HttpRequest request, byte[] content)
+        if (!request.Headers.TryGetValue("X-Slack-Request-Timestamp", out var timestampHeader) ||
+            !request.Headers.TryGetValue("X-Slack-Signature", out var signatureHeader))
         {
-            if (!request.Headers.TryGetValue("X-Slack-Request-Timestamp", out var timestampHeader) ||
-                !request.Headers.TryGetValue("X-Slack-Signature", out var signatureHeader))
-            {
-                return false;
-            }
-
-            // Validate that the request isn't too old.
-            if (!int.TryParse(timestampHeader, out var unixSeconds))
-            {
-                return false;
-            }
-            var timestamp = DateTimeOffset.FromUnixTimeSeconds(unixSeconds);
-            if (timestamp + _timestampTolerance < DateTimeOffset.UtcNow)
-            {
-                return false;
-            }
-
-            // Hash the version:timestamp:content
-            using var hmac = new HMACSHA256(_signingKeyBytes);
-            AddToHash(VersionBytes);
-            AddToHash(ColonBytes);
-            AddToHash(Encoding.UTF8.GetBytes(timestampHeader));
-            AddToHash(ColonBytes);
-            byte[] hash = hmac.ComputeHash(content);
-            void AddToHash(byte[] bytes) => hmac.TransformBlock(bytes, 0, bytes.Length, null, 0);
-
-            // Compare the resulting signature with the signature in the request.
-            return CreateSignature(hash) == (string) signatureHeader;
+            return false;
         }
 
-        private const string Hex = "0123456789abcdef";
-        private static string CreateSignature(byte[] hash)
+        // Validate that the request isn't too old.
+        if (!int.TryParse(timestampHeader, out var unixSeconds))
         {
-            var builder = new StringBuilder(SignaturePrefix, SignaturePrefix.Length + hash.Length * 2);
-            foreach (var b in hash)
-            {
-                builder.Append(Hex[b >> 4]);
-                builder.Append(Hex[b & 0xf]);
-            }
-            return builder.ToString();
+            return false;
         }
+        var timestamp = DateTimeOffset.FromUnixTimeSeconds(unixSeconds);
+        if (timestamp + _timestampTolerance < DateTimeOffset.UtcNow)
+        {
+            return false;
+        }
+
+        // Hash the version:timestamp:content
+        using var hmac = new HMACSHA256(_signingKeyBytes);
+        AddToHash(VersionBytes);
+        AddToHash(ColonBytes);
+        AddToHash(Encoding.UTF8.GetBytes(timestampHeader));
+        AddToHash(ColonBytes);
+        byte[] hash = hmac.ComputeHash(content);
+        void AddToHash(byte[] bytes) => hmac.TransformBlock(bytes, 0, bytes.Length, null, 0);
+
+        // Compare the resulting signature with the signature in the request.
+        return CreateSignature(hash) == (string) signatureHeader;
+    }
+
+    private const string Hex = "0123456789abcdef";
+    private static string CreateSignature(byte[] hash)
+    {
+        var builder = new StringBuilder(SignaturePrefix, SignaturePrefix.Length + hash.Length * 2);
+        foreach (var b in hash)
+        {
+            builder.Append(Hex[b >> 4]);
+            builder.Append(Hex[b & 0xf]);
+        }
+        return builder.ToString();
     }
 }
 // [END functions_verify_webhook]

--- a/functions/slack/SlackKnowledgeGraphSearch/Startup.cs
+++ b/functions/slack/SlackKnowledgeGraphSearch/Startup.cs
@@ -24,25 +24,24 @@ using System;
 // This can also be specified on the function type.
 [assembly: FunctionsStartup(typeof(SlackKnowledgeGraphSearch.Startup))]
 
-namespace SlackKnowledgeGraphSearch
+namespace SlackKnowledgeGraphSearch;
+
+public class Startup : FunctionsStartup
 {
-    public class Startup : FunctionsStartup
+    private static readonly TimeSpan SlackTimestampTolerance = TimeSpan.FromMinutes(5);
+
+    public override void ConfigureServices(WebHostBuilderContext context, IServiceCollection services)
     {
-        private static readonly TimeSpan SlackTimestampTolerance = TimeSpan.FromMinutes(5);
+        // These can come from an environment variable or a configuration file.
+        string kgApiKey = context.Configuration["KG_API_KEY"];
+        string slackSigningSecret = context.Configuration["SLACK_SECRET"];
 
-        public override void ConfigureServices(WebHostBuilderContext context, IServiceCollection services)
+        services.AddSingleton(new KgsearchService(new BaseClientService.Initializer
         {
-            // These can come from an environment variable or a configuration file.
-            string kgApiKey = context.Configuration["KG_API_KEY"];
-            string slackSigningSecret = context.Configuration["SLACK_SECRET"];
-
-            services.AddSingleton(new KgsearchService(new BaseClientService.Initializer
-            {
-                ApiKey = kgApiKey
-            }));
-            services.AddSingleton(new SlackRequestVerifier(slackSigningSecret, SlackTimestampTolerance));
-            base.ConfigureServices(context, services);
-        }
+            ApiKey = kgApiKey
+        }));
+        services.AddSingleton(new SlackRequestVerifier(slackSigningSecret, SlackTimestampTolerance));
+        base.ConfigureServices(context, services);
     }
 }
 // [END functions_slack_setup]


### PR DESCRIPTION
(Initially to FF v2.0.0-beta01, but we can get it ready that way, then quickly swap out the dependencies after FF v2 has gone GA.)

Note that the C# code changes are basically just using file-scoped namespaces, which reduce the indent level (particularly handy for samples).