### PR TITLE
chore(samples): fix retail query expansion tests

### DIFF
--- a/retail/interactive-tutorial/RetailSearch.Samples.Tests/SearchWithQueryExpansionTest.cs
+++ b/retail/interactive-tutorial/RetailSearch.Samples.Tests/SearchWithQueryExpansionTest.cs
@@ -26,8 +26,7 @@ namespace RetailSearch.Samples.Tests
             
             var firstPage = SearchWithQueryExpansionTutorial.Search().First();
 
-            Assert.Contains(firstPage, result => result.Product.Title.Contains(ExpectedProductTitle));
-            Assert.Contains(firstPage, result => !result.Product.Title.Contains(ExpectedProductTitle));
+            Assert.True(firstPage.queryExpansionInfo.expandedQuery);
         }
     }
 }

--- a/retail/interactive-tutorial/RetailSearch.Samples.Tests/SearchWithQueryExpansionTest.cs
+++ b/retail/interactive-tutorial/RetailSearch.Samples.Tests/SearchWithQueryExpansionTest.cs
@@ -26,7 +26,7 @@ namespace RetailSearch.Samples.Tests
             
             var firstPage = SearchWithQueryExpansionTutorial.Search().First();
 
-            Assert.True(firstPage.queryExpansionInfo.expandedQuery);
+            Assert.True(firstPage.QueryExpansionInfo.ExpandedQuery);
         }
     }
 }


### PR DESCRIPTION
The query expansion search result on the backend is not stable and the returned results may change over time. Tried to remove the strong result checks, and only check if query expansion is enabled in the search response, if the users request to enable query expansion.

Fixes #2047