### PR TITLE
ci: Explicitly specify .NET Core 3.1 on setup

### DIFF
--- a/.kokoro-windows/New-BuildEnv.ps1
+++ b/.kokoro-windows/New-BuildEnv.ps1
@@ -27,7 +27,7 @@ if (-not $chocoPackages.Contains('Microsoft .NET Core SDK - 2.2.')) {
 }
 
 if (-not $chocoPackages.Contains('.NET Core SDK 3.1.')) {
-    choco install -y --sxs --no-progress dotnetcore-sdk
+    choco install -y --sxs --no-progress dotnetcore-3.1-sdk
 }
 
 if (-not $chocoPackages.Contains('Microsoft .NET SDK 6.')) {


### PR DESCRIPTION
Specifying just `dotnetcore-sdk` is failing to install .NET Core 3.1 even though that's what Chocolatey shows as an example. Let's be explicit instead.