### PR TITLE
chore(storage): remove nested region tag

### DIFF
--- a/storage/api/Storage.Samples/MakePublic.cs
+++ b/storage/api/Storage.Samples/MakePublic.cs
@@ -12,10 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//TODO: remove the storage_set_bucket_public_iam tag later as it is already declared in MakeBucketPublic.cs
-
 // [START storage_make_public]
-// [START storage_set_bucket_public_iam]
 
 using Google.Apis.Storage.v1.Data;
 using Google.Cloud.Storage.V1;
@@ -38,5 +35,4 @@ public class MakePublicSample
     }
 }
 
-// [END storage_set_bucket_public_iam]
 // [END storage_make_public]


### PR DESCRIPTION
Addressing this TODO: remove the storage_set_bucket_public_iam tag later as it is already declared in MakeBucketPublic.cs