### PR TITLE
fix: Add missing product region tags for Cloud CDN snippets

### DIFF
--- a/cdn/signUrl/SignUrlSample/Program.cs
+++ b/cdn/signUrl/SignUrlSample/Program.cs
@@ -66,6 +66,7 @@ namespace SignUrlSample
         }
 
         // [START CreateSignedUrl]
+        // [START cloudcdn_sign_url]
         /// <summary>
         /// Creates signed URL for Google Cloud SDN
         /// More details about order of operations is here: 
@@ -134,6 +135,7 @@ namespace SignUrlSample
             }
         }
 
+        // [END cloudcdn_sign_url] 
         // [END CreateSignedUrl]
     }
 }


### PR DESCRIPTION
Cloud CDN Snippets are missing product's specific region tags. In this PR, we are only adding region tags. No code changes. For more details, refer to [b/264905390](b/264905390).