### PR TITLE
Validate that the IAP JWT was actually issued by IAP

### DIFF
--- a/identity-aware-proxy/IAPClient/IAPTokenVerification.cs
+++ b/identity-aware-proxy/IAPClient/IAPTokenVerification.cs
@@ -15,6 +15,7 @@
 // [START iap_validate_jwt]
 
 using Google.Apis.Auth;
+using Google.Apis.Auth.OAuth2;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -40,7 +41,9 @@ public class IAPTokenVerification
             // between the issuer and the verifier.
             IssuedAtClockTolerance = TimeSpan.FromMinutes(1),
             ExpiryClockTolerance = TimeSpan.FromMinutes(1),
-            TrustedAudiences = { expectedAudience }
+            TrustedAudiences = { expectedAudience },
+            TrustedIssuers = { "https://cloud.google.com/iap" },
+            CertificatesUrl = GoogleAuthConsts.IapKeySetUrl,
         };
         
         return await JsonWebSignature.VerifySignedTokenAsync(signedJwt, options, cancellationToken: cancellationToken);


### PR DESCRIPTION
Also explicitly specify that the IAP keys should be used to verify the signature.

### Why this matters

Basically by not explicitly specifying these properties, it is hypothetically possible for an attacker to use a non-IAP token to talk to a IAP-protected application. If an attacker were able to get a token signed by Google for a user of the IAP-protected application, the attacker could impersonate the user. This would only be possible if the application exposed its non-IAP-protected endpoint, so hopefully its unlikely.

### Exploit example

Here is an example of how the sample token authentication code will incorrectly accept a non IAP token. In this example a GCP service account token is used. Its subject will not match an IAP token, so it probably will not fool a relying party.

https://gist.github.com/AustinWise/2e9d16c11cf846d4c1e9eabd973df0e5

### Changes in this PR

The [`SignedTokenVerification` class](https://github.com/googleapis/google-api-dotnet-client/blob/main/Src/Support/Google.Apis.Auth/SignedTokenVerification.cs) by default allows the author of the token to specify which keys are used to validate a token. For ES256 tokens, it uses the IAP list of keys. Other token types use other keys. So by this PR changes the token validation code to only allow IAP keys to be used to validate IAP tokens.

Also, this PR requires that the token has an `iss` (issuer) claim that says the token was created by IAP.
