### PR TITLE
DLP: Added sample for deidentify data with replace infotypes

### DIFF
--- a/dlp/api/Snippets.Tests/DeidentifyWithReplaceInfotypesTests.cs
+++ b/dlp/api/Snippets.Tests/DeidentifyWithReplaceInfotypesTests.cs
@@ -1,0 +1,36 @@
+﻿// Copyright 2023 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.Dlp.V2;
+using Xunit;
+
+namespace GoogleCloudSamples
+{
+    public class DeidentifyWithReplaceInfotypesTests : IClassFixture<DlpTestFixture>
+    {
+        private DlpTestFixture _fixture;
+
+        public DeidentifyWithReplaceInfotypesTests(DlpTestFixture fixture) => _fixture = fixture;
+
+        [Fact]
+        public void TestDeidentifyWithReplaceInfotypes()
+        {
+            var testData = "My numbers are (415) 555-0890 and (415) 555-0990 and email is test@example.com.";
+            var infoTypes = new InfoType[] { new InfoType { Name = "PHONE_NUMBER" }, new InfoType { Name = "EMAIL_ADDRESS" } };
+            var expected = "My numbers are [PHONE_NUMBER] and [PHONE_NUMBER] and email is [EMAIL_ADDRESS].";
+            var result = DeidentifyWithReplaceInfotypes.DeidentifyInfo(_fixture.ProjectId, testData, infoTypes);
+            Assert.Equal(expected, result.Item.Value);
+        }
+    }
+}

--- a/dlp/api/Snippets.Tests/runTest.ps1
+++ b/dlp/api/Snippets.Tests/runTest.ps1
@@ -11,7 +11,7 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under
 # the License.
-import-module -DisableNameChecking ..\..\BuildTools.psm1
+import-module -DisableNameChecking ..\..\..\BuildTools.psm1
 
 Set-TestTimeout 1200
 

--- a/dlp/api/Snippets/DeidentifyWithReplaceInfotypes.cs
+++ b/dlp/api/Snippets/DeidentifyWithReplaceInfotypes.cs
@@ -1,0 +1,80 @@
+﻿// Copyright 2023 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+// [START dlp_deidentify_replace_infotype]
+
+using System;
+using System.Collections.Generic;
+using Google.Api.Gax.ResourceNames;
+using Google.Cloud.Dlp.V2;
+
+public class DeidentifyWithReplaceInfotypes
+{
+    public static DeidentifyContentResponse DeidentifyInfo(
+        string projectId,
+        string text,
+        IEnumerable<InfoType> infoTypes = null)
+    {
+        // Instantiate the client.
+        var dlp = DlpServiceClient.Create();
+
+        // Construct the inspect config by specifying the type of info to be inspected.
+        var inspectConfig = new InspectConfig
+        {
+            InfoTypes =
+            {
+                infoTypes ?? new InfoType[] { new InfoType { Name = "EMAIL_ADDRESS" } }
+            }
+        };
+
+        // Construct the replace info types config.
+        var replaceInfoTypesConfig = new ReplaceWithInfoTypeConfig();
+
+        // Construct the deidentify config using replace config.
+        var deidentifyConfig = new DeidentifyConfig
+        {
+            InfoTypeTransformations = new InfoTypeTransformations
+            {
+                Transformations =
+                {
+                    new InfoTypeTransformations.Types.InfoTypeTransformation
+                    {
+                        PrimitiveTransformation = new PrimitiveTransformation
+                        {
+                            ReplaceWithInfoTypeConfig = replaceInfoTypesConfig
+                        }
+                    }
+                }
+            }
+        };
+
+        // Construct the request.
+        var request = new DeidentifyContentRequest
+        {
+            ParentAsLocationName = new LocationName(projectId, "global"),
+            DeidentifyConfig = deidentifyConfig,
+            InspectConfig = inspectConfig,
+            Item = new ContentItem { Value = text }
+        };
+
+        // Call the API.
+        var response = dlp.DeidentifyContent(request);
+
+        // Check the de-identified content.
+        Console.WriteLine($"De-identified content: {response.Item.Value}");
+        return response;
+    }
+}
+
+// [END dlp_deidentify_replace_infotype]


### PR DESCRIPTION
- Added sample for [Deidentify Data With Replace Infotypes](https://cloud.google.com/dlp/docs/redacting-sensitive-data.md#dlp-replace-infotype-java) and test cases