### PR TITLE
chore: Improve renovate bot configuration.

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,6 @@
     ],
     "ignorePaths": [
         "bigtable/api/**",
-        "appengine/flexible/**",
         "endpoints/getting-started/**",
         "applications/googlehome-meets-dotnetcontainers/**"
     ],
@@ -13,4 +12,7 @@
         "before 8am"
     ],
     "timezone": "Europe/London"
+    "labels": [
+        "automerge: exact"
+    ]
 }


### PR DESCRIPTION
- Configure renovate bot PRs to have the `automerge: exact` label.
- Stop ignoring the App Engine Flex samples for dependency renovation as they are being updated.