### PR TITLE
DLP: Fixed the region tag of redact image with listed infoTypes

### DIFF
--- a/dlp/api/Snippets.Tests/RedactImageWithListedInfotypesTests.cs
+++ b/dlp/api/Snippets.Tests/RedactImageWithListedInfotypesTests.cs
@@ -17,19 +17,16 @@ using Xunit;
 
 namespace GoogleCloudSamples
 {
-    public class RedactImageTests : IClassFixture<DlpTestFixture>
+    public class RedactImageWithListedInfotypesTests : IClassFixture<DlpTestFixture>
     {
-        private DlpTestFixture Fixture { get; }
-        public RedactImageTests(DlpTestFixture fixture)
-        {
-            Fixture = fixture;
-        }
+        private DlpTestFixture _fixture;
+        public RedactImageWithListedInfotypesTests(DlpTestFixture fixture) => _fixture = fixture;
         [Fact]
         public void TestRedactImage()
         {
-            var input = Path.Combine(Fixture.ResourcePath, "test_redact_image.png");
-            var output = Path.Combine(Fixture.ResourcePath, "redacted.png");
-            var redacted = RedactImage.Redact(Fixture.ProjectId, input, output);
+            var input = Path.Combine(_fixture.ResourcePath, "test_redact_image.png");
+            var output = Path.Combine(_fixture.ResourcePath, "redacted.png");
+            var redacted = RedactImageWithListedInfotypes.Redact(_fixture.ProjectId, input, output);
             Assert.True(File.Exists(output));
             Assert.Contains("223-456-7890", redacted.ExtractedText);
         }

--- a/dlp/api/Snippets/RedactImageWithListedInfotypes.cs
+++ b/dlp/api/Snippets/RedactImageWithListedInfotypes.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// [START redact_image]
+// [START dlp_redact_image_listed_infotypes]
 
 using Google.Api.Gax.ResourceNames;
 using Google.Cloud.Dlp.V2;
@@ -20,7 +20,7 @@ using Google.Protobuf;
 using System;
 using System.IO;
 
-public class RedactImage
+public class RedactImageWithListedInfotypes
 {
     public static RedactImageResponse Redact(string projectId, string originalImagePath, string redactedImagePath)
     {
@@ -57,4 +57,4 @@ public class RedactImage
     }
 }
 
-// [END redact_image]
+// [END dlp_redact_image_listed_infotypes]


### PR DESCRIPTION
- Updated the region tag to `dlp_redact_image_listed_infotypes` from `redact_image` and renamed the files.