### PR TITLE
fix: firestore flaky test issue#1162

### DIFF
--- a/firestore/api/FirestoreTest/FirestoreTest.cs
+++ b/firestore/api/FirestoreTest/FirestoreTest.cs
@@ -473,7 +473,7 @@ namespace GoogleCloudSamples
         }
 
         // LISTEN DATA TESTS
-        [Fact(Skip = "https://github.com/GoogleCloudPlatform/dotnet-docs-samples/issues/1162")]
+        [Fact]
         public void ListenDocumentTest()
         {
             RunDeleteData("delete-collection", Environment.GetEnvironmentVariable("FIRESTORE_PROJECT_ID"));
@@ -489,7 +489,7 @@ namespace GoogleCloudSamples
             Assert.Contains("Stopping the listener", listenDocumentOutput.Stdout);
         }
 
-        [Fact(Skip = "https://github.com/GoogleCloudPlatform/dotnet-docs-samples/issues/1162")]
+        [Fact]
         public void ListenMultipleTest()
         {
             RunDeleteData("delete-collection", Environment.GetEnvironmentVariable("FIRESTORE_PROJECT_ID"));
@@ -501,7 +501,7 @@ namespace GoogleCloudSamples
             Assert.Contains("Stopping the listener", listenMultipleOutput.Stdout);
         }
 
-        [Fact(Skip = "https://github.com/GoogleCloudPlatform/dotnet-docs-samples/issues/1162")]
+        [Fact]
         public void ListenForChangesTest()
         {
             RunDeleteData("delete-collection", Environment.GetEnvironmentVariable("FIRESTORE_PROJECT_ID"));

--- a/firestore/api/ListenData/Program.cs
+++ b/firestore/api/ListenData/Program.cs
@@ -65,7 +65,7 @@ Where command is one of
                 { "Population", 860000 }
             };
             await docRef.CreateAsync(cityObject);
-            await Task.Delay(1000);
+            await Task.Delay(3000);
 
             // Stop the listener when you no longer want to receive updates.
             Console.WriteLine("Stopping the listener");
@@ -104,7 +104,7 @@ Where command is one of
                 { "Population", 3900000 }
             };
             await docRef.CreateAsync(cityObject);
-            await Task.Delay(1000);
+            await Task.Delay(3000);
 
             // Stop the listener when you no longer want to receive updates.
             Console.WriteLine("Stopping the listener");
@@ -150,7 +150,7 @@ Where command is one of
                 { "Population", 80000 }
             };
             await docRef.CreateAsync(cityObject);
-            await Task.Delay(1000);
+            await Task.Delay(3000);
 
             // Modify the cities/MTV document to demonstrate detection of the 'Modified change
             Console.WriteLine("Modifying document");
@@ -163,12 +163,12 @@ Where command is one of
                 { "Population", 90000 }
             };
             await docRef.SetAsync(city);
-            await Task.Delay(1000);
+            await Task.Delay(3000);
 
             // Modify the cities/MTV document to demonstrate detection of the 'Modified change
             Console.WriteLine("Deleting document");
             await docRef.DeleteAsync();
-            await Task.Delay(1000);
+            await Task.Delay(3000);
 
             // Stop the listener when you no longer want to receive updates.
             Console.WriteLine("Stopping the listener");


### PR DESCRIPTION
Increase delay in listener tests from 1sec to 3 sec and un-skip flaky listeners tests.