### PR TITLE
chore: Using temporary databases for all sample tests that modify the database.

### DIFF
--- a/spanner/api/Spanner.Samples.Tests/AddColumnAsyncPostgresTest.cs
+++ b/spanner/api/Spanner.Samples.Tests/AddColumnAsyncPostgresTest.cs
@@ -32,6 +32,9 @@ public class AddColumnAsyncPostgresTest
     public async Task TestAddColumnAsyncPostgres()
     {
         //Act.
-        await _sample.AddColumnAsyncPostgres(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.PostgreSqlDatabaseId);
+        await _spannerFixture.RunWithTemporaryPostgresDatabaseAsync(async databaseId =>
+       {
+           await _sample.AddColumnAsyncPostgres(_spannerFixture.ProjectId, _spannerFixture.InstanceId, databaseId);
+       });
     }
 }

--- a/spanner/api/Spanner.Samples.Tests/AddStoringIndexAsyncPostgresTest.cs
+++ b/spanner/api/Spanner.Samples.Tests/AddStoringIndexAsyncPostgresTest.cs
@@ -31,7 +31,10 @@ public class AddStoringIndexAsyncPostgresTest
     [Fact]
     public async Task TestAddStoringIndexAsyncPostgres()
     {
-        //Act.
-        await _sample.AddStoringIndexAsyncPostgres(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.PostgreSqlDatabaseId);
+        await _spannerFixture.RunWithTemporaryPostgresDatabaseAsync(async databaseId =>
+        {
+            //Act.
+            await _sample.AddStoringIndexAsyncPostgres(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.PostgreSqlDatabaseId);
+        });
     }
 }

--- a/spanner/api/Spanner.Samples.Tests/DeleteUsingDmlCoreAsyncTest.cs
+++ b/spanner/api/Spanner.Samples.Tests/DeleteUsingDmlCoreAsyncTest.cs
@@ -28,8 +28,12 @@ public class DeleteUsingDmlCoreAsyncTest
     [Fact]
     public async Task TestDeleteUsingDmlCoreAsync()
     {
-        DeleteUsingDmlCoreAsyncSample sample = new DeleteUsingDmlCoreAsyncSample();
-        var rowCount = await sample.DeleteUsingDmlCoreAsync(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.DatabaseId);
-        Assert.Equal(1, rowCount);
+        await _spannerFixture.RunWithTemporaryDatabaseAsync(async databaseId =>
+        {
+            await _spannerFixture.InitializeTempDatabaseAsync(databaseId, insertData: true, addColumn: false);
+            DeleteUsingDmlCoreAsyncSample sample = new DeleteUsingDmlCoreAsyncSample();
+            var rowCount = await sample.DeleteUsingDmlCoreAsync(_spannerFixture.ProjectId, _spannerFixture.InstanceId, databaseId);
+            Assert.Equal(1, rowCount);
+        }, SpannerFixture.CreateSingersTableStatement, SpannerFixture.CreateAlbumsTableStatement);
     }
 }

--- a/spanner/api/Spanner.Samples.Tests/DeleteUsingDmlReturningAsyncTest.cs
+++ b/spanner/api/Spanner.Samples.Tests/DeleteUsingDmlReturningAsyncTest.cs
@@ -30,19 +30,12 @@ public class DeleteDmlReturningAsyncTest
     {
         await _spannerFixture.RunWithTemporaryDatabaseAsync(async databaseId =>
         {
-            await CreateTableAndInsertDataAsync(databaseId);
+            await _spannerFixture.InitializeTempDatabaseAsync(databaseId, insertData: true, addColumn: false);
             var sample = new DeleteUsingDmlReturningAsyncSample();
             var deletedSingerNames = await sample.DeleteUsingDmlReturningAsync(_spannerFixture.ProjectId, _spannerFixture.InstanceId, databaseId);
 
             Assert.Single(deletedSingerNames);
             Assert.Equal("Alice Trentor", deletedSingerNames[0]);
-        });
-    }
-
-    private async Task CreateTableAndInsertDataAsync(string databaseId)
-    {
-        await _spannerFixture.CreateSingersAndAlbumsTableAsync(_spannerFixture.ProjectId, _spannerFixture.InstanceId, databaseId);
-        var insertDataAsyncSample = new InsertDataAsyncSample();
-        await insertDataAsyncSample.InsertDataAsync(_spannerFixture.ProjectId, _spannerFixture.InstanceId, databaseId);
+        }, SpannerFixture.CreateSingersTableStatement, SpannerFixture.CreateAlbumsTableStatement);
     }
 }

--- a/spanner/api/Spanner.Samples.Tests/DeleteUsingPartitionedDmlCoreAsyncTest.cs
+++ b/spanner/api/Spanner.Samples.Tests/DeleteUsingPartitionedDmlCoreAsyncTest.cs
@@ -28,8 +28,13 @@ public class DeleteUsingPartitionedDmlCoreAsyncTest
     [Fact]
     public async Task TestDeleteUsingPartitionedDmlCoreAsync()
     {
-        DeleteUsingPartitionedDmlCoreAsyncSample sample = new DeleteUsingPartitionedDmlCoreAsyncSample();
-        var rowCount = await sample.DeleteUsingPartitionedDmlCoreAsync(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.DatabaseId);
-        Assert.True(rowCount >= 1);
+        await _spannerFixture.RunWithTemporaryDatabaseAsync(async databaseId =>
+        {
+            await _spannerFixture.InitializeTempDatabaseAsync(databaseId, insertData: true, addColumn: false);
+            DeleteUsingPartitionedDmlCoreAsyncSample sample = new DeleteUsingPartitionedDmlCoreAsyncSample();
+            
+            var rowCount = await sample.DeleteUsingPartitionedDmlCoreAsync(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.DatabaseId);
+            Assert.True(rowCount >= 1);
+        }, SpannerFixture.CreateSingersTableStatement, SpannerFixture.CreateAlbumsTableStatement);
     }
 }

--- a/spanner/api/Spanner.Samples.Tests/InsertUsingBatchDmlAsyncPostgresTest.cs
+++ b/spanner/api/Spanner.Samples.Tests/InsertUsingBatchDmlAsyncPostgresTest.cs
@@ -31,10 +31,13 @@ public class InsertUsingBatchDmlAsyncPostgresTest
     [Fact]
     public async Task TestInsertUsingBatchDmlAsyncPostgres()
     {
-        // Act.
-        var count = await _sample.InsertUsingBatchDmlAsyncPostgres(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.PostgreSqlDatabaseId);
+        await _spannerFixture.RunWithTemporaryPostgresDatabaseAsync(async databaseId =>
+        {
+            // Act.
+            var count = await _sample.InsertUsingBatchDmlAsyncPostgres(_spannerFixture.ProjectId, _spannerFixture.InstanceId, databaseId);
 
-        // Assert.
-        Assert.True(count >= 3); // Other tests may have inserted data.
+            // Assert.
+            Assert.True(count >= 3);
+        });
     }
 }

--- a/spanner/api/Spanner.Samples.Tests/InsertUsingDmlCoreAsyncTest.cs
+++ b/spanner/api/Spanner.Samples.Tests/InsertUsingDmlCoreAsyncTest.cs
@@ -28,8 +28,12 @@ public class InsertUsingDmlCoreAsyncTest
     [Fact]
     public async Task TestInsertUsingDmlCoreAsync()
     {
-        InsertUsingDmlCoreAsyncSample sample = new InsertUsingDmlCoreAsyncSample();
-        var rowCount = await sample.InsertUsingDmlCoreAsync(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.DatabaseId);
-        Assert.Equal(1, rowCount);
+        await _spannerFixture.RunWithTemporaryDatabaseAsync(async databaseId =>
+        {
+            await _spannerFixture.InitializeTempDatabaseAsync(databaseId, insertData: true, addColumn: false);
+            InsertUsingDmlCoreAsyncSample sample = new InsertUsingDmlCoreAsyncSample();
+            var rowCount = await sample.InsertUsingDmlCoreAsync(_spannerFixture.ProjectId, _spannerFixture.InstanceId, databaseId);
+            Assert.Equal(1, rowCount);
+        }, SpannerFixture.CreateSingersTableStatement, SpannerFixture.CreateAlbumsTableStatement);
     }
 }

--- a/spanner/api/Spanner.Samples.Tests/InsertUsingDmlReturningAsyncPostgresTest.cs
+++ b/spanner/api/Spanner.Samples.Tests/InsertUsingDmlReturningAsyncPostgresTest.cs
@@ -29,13 +29,16 @@ public class InsertUsingDmlReturningAsyncPostgresTest
     [Fact]
     public async Task TestInsertUsingDmlReturningAsyncPostgres()
     {
-        var sample = new InsertUsingDmlReturningAsyncPostgresSample();
-        var insertedSingerNames = await sample.InsertUsingDmlReturningAsyncPostgres(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.PostgreSqlDatabaseId);
+        await _spannerFixture.RunWithTemporaryPostgresDatabaseAsync(async databaseId =>
+        {
+            var sample = new InsertUsingDmlReturningAsyncPostgresSample();
+            var insertedSingerNames = await sample.InsertUsingDmlReturningAsyncPostgres(_spannerFixture.ProjectId, _spannerFixture.InstanceId, databaseId);
 
-        Assert.Equal(4, insertedSingerNames.Count);
-        Assert.Contains("Melissa Garcia", insertedSingerNames);
-        Assert.Contains("Russell Morales", insertedSingerNames);
-        Assert.Contains("Jacqueline Long", insertedSingerNames);
-        Assert.Contains("Dylan Shaw", insertedSingerNames);
+            Assert.Equal(4, insertedSingerNames.Count);
+            Assert.Contains("Melissa Garcia", insertedSingerNames);
+            Assert.Contains("Russell Morales", insertedSingerNames);
+            Assert.Contains("Jacqueline Long", insertedSingerNames);
+            Assert.Contains("Dylan Shaw", insertedSingerNames);
+        });
     }
 }

--- a/spanner/api/Spanner.Samples.Tests/InsertUsingDmlReturningAsyncTest.cs
+++ b/spanner/api/Spanner.Samples.Tests/InsertUsingDmlReturningAsyncTest.cs
@@ -31,7 +31,7 @@ public class InsertUsingDmlReturningAsyncTest
     {
         await _spannerFixture.RunWithTemporaryDatabaseAsync(async databaseId =>
         {
-            await CreateTableAndInsertData(databaseId);
+            await _spannerFixture.InitializeTempDatabaseAsync(databaseId, insertData: true, addColumn: false);
             InsertUsingDmlReturningAsyncSample sample = new InsertUsingDmlReturningAsyncSample();
             var insertedSingerNames = await sample.InsertUsingDmlReturningAsync(_spannerFixture.ProjectId, _spannerFixture.InstanceId, databaseId);
 
@@ -40,13 +40,7 @@ public class InsertUsingDmlReturningAsyncTest
             Assert.Contains("Russell Morales", insertedSingerNames);
             Assert.Contains("Jacqueline Long", insertedSingerNames);
             Assert.Contains("Dylan Shaw", insertedSingerNames);
-        });
-    }
 
-    private async Task CreateTableAndInsertData(string databaseId)
-    {
-        await _spannerFixture.CreateSingersAndAlbumsTableAsync(_spannerFixture.ProjectId, _spannerFixture.InstanceId, databaseId);
-        var insertDataAsyncSample = new InsertDataAsyncSample();
-        await insertDataAsyncSample.InsertDataAsync(_spannerFixture.ProjectId, _spannerFixture.InstanceId, databaseId);
+        }, SpannerFixture.CreateSingersTableStatement, SpannerFixture.CreateAlbumsTableStatement);
     }
 }

--- a/spanner/api/Spanner.Samples.Tests/InsertUsingDmlWithParametersAsyncPostgresTest.cs
+++ b/spanner/api/Spanner.Samples.Tests/InsertUsingDmlWithParametersAsyncPostgresTest.cs
@@ -31,10 +31,13 @@ public class InsertUsingDmlWithParametersAsyncPostgresTest
     [Fact]
     public async Task TestInsertUsingDmlWithParametersAsyncPostgres()
     {
-        // Act.
-        var count = await _sample.InsertUsingDmlWithParametersAsyncPostgres(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.PostgreSqlDatabaseId);
+        await _spannerFixture.RunWithTemporaryPostgresDatabaseAsync(async databaseId =>
+        {
+            // Act.
+            var count = await _sample.InsertUsingDmlWithParametersAsyncPostgres(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.PostgreSqlDatabaseId);
 
-        // Assert.
-        Assert.Equal(2, count);
+            // Assert.
+            Assert.Equal(2, count);
+        });
     }
 }

--- a/spanner/api/Spanner.Samples.Tests/OrderNullsAsyncPostgresTest.cs
+++ b/spanner/api/Spanner.Samples.Tests/OrderNullsAsyncPostgresTest.cs
@@ -34,33 +34,36 @@ public class OrderNullsAsyncPostgresTest
     [Fact]
     public async Task TestOrderNullsAsyncPostgres()
     {
-        // Arrange.
-        await CreateTableForOrderingAsync(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.PostgreSqlDatabaseId);
+        await _spannerFixture.RunWithTemporaryPostgresDatabaseAsync(async databaseId =>
+        {
+            // Arrange.
+            await CreateTableForOrderingAsync(_spannerFixture.ProjectId, _spannerFixture.InstanceId, databaseId);
 
-        // Act.
-        var result = await _sample.OrderNullsAsyncPostgres(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.PostgreSqlDatabaseId);
+            // Act.
+            var result = await _sample.OrderNullsAsyncPostgres(_spannerFixture.ProjectId, _spannerFixture.InstanceId, databaseId);
 
-        //Assert.
-        Assert.Collection(result,
-            // Alice, Bruce, null.
-            item1 => Assert.Equal("Alice", item1),
-            item2 => Assert.Equal("Bruce", item2),
-            item3 => Assert.Null(item3),
+            //Assert.
+            Assert.Collection(result,
+                // Alice, Bruce, null.
+                item1 => Assert.Equal("Alice", item1),
+                item2 => Assert.Equal("Bruce", item2),
+                item3 => Assert.Null(item3),
 
-            // null, Bruce, Alice.
-            item4 => Assert.Null(item4),
-            item5 => Assert.Equal("Bruce", item5),
-            item6 => Assert.Equal("Alice", item6),
+                // null, Bruce, Alice.
+                item4 => Assert.Null(item4),
+                item5 => Assert.Equal("Bruce", item5),
+                item6 => Assert.Equal("Alice", item6),
 
-            // null, Alice, Bruce.
-            item7 => Assert.Null(item7),
-            item8 => Assert.Equal("Alice", item8),
-            item9 => Assert.Equal("Bruce", item9),
+                // null, Alice, Bruce.
+                item7 => Assert.Null(item7),
+                item8 => Assert.Equal("Alice", item8),
+                item9 => Assert.Equal("Bruce", item9),
 
-            // Bruce, Alice, null.
-            item10 => Assert.Equal("Alice", item10),
-            item11 => Assert.Equal("Bruce", item11),
-            item12 => Assert.Null(item12));
+                // Bruce, Alice, null.
+                item10 => Assert.Equal("Alice", item10),
+                item11 => Assert.Equal("Bruce", item11),
+                item12 => Assert.Null(item12));
+        });
     }
 
     private async Task CreateTableForOrderingAsync(string projectId, string instanceId, string databaseId)

--- a/spanner/api/Spanner.Samples.Tests/UpdateDataWithJsonbAsyncPostgresTest.cs
+++ b/spanner/api/Spanner.Samples.Tests/UpdateDataWithJsonbAsyncPostgresTest.cs
@@ -27,11 +27,15 @@ public class UpdateDataWithJsonbAsyncPostgresTest
         _spannerFixture = spannerFixture;
         _sample = new UpdateDataWithJsonbAsyncPostgresSample();
     }
-    
+
     [Fact]
     public async Task TestUpdateDataWithJsonbAsyncPostgres()
     {
-        // Act - Update the VenueInformation table.
-        await _sample.UpdateDataWithJsonbAsyncPostgres(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.PostgreSqlDatabaseId);
+        await _spannerFixture.RunWithTemporaryPostgresDatabaseAsync(async databaseId =>
+        {
+            await _spannerFixture.CreateVenueTablesAndInsertDataAsyncPostgres(databaseId);
+            // Act - Update the VenueInformation table.
+            await _sample.UpdateDataWithJsonbAsyncPostgres(_spannerFixture.ProjectId, _spannerFixture.InstanceId, databaseId);
+        });
     }
 }

--- a/spanner/api/Spanner.Samples.Tests/UpdateUsingDmlWithTimestampCoreAsyncTest.cs
+++ b/spanner/api/Spanner.Samples.Tests/UpdateUsingDmlWithTimestampCoreAsyncTest.cs
@@ -30,7 +30,7 @@ public class UpdateUsingDmlWithTimestampCoreAsyncTest
     {
         await _spannerFixture.RunWithTemporaryDatabaseAsync(async databaseId =>
         {
-            await _spannerFixture.InitializeTempDatabaseAsync(databaseId);
+            await _spannerFixture.InitializeTempDatabaseAsync(databaseId, insertData: true, addColumn: false);
             AddCommitTimestampAsyncSample addCommitTimestampAsyncSample = new AddCommitTimestampAsyncSample();
             await addCommitTimestampAsyncSample.AddCommitTimestampAsync(_spannerFixture.ProjectId, _spannerFixture.InstanceId, databaseId);
 

--- a/spanner/api/Spanner.Samples.Tests/UsePgNumericAsyncPostgresTest.cs
+++ b/spanner/api/Spanner.Samples.Tests/UsePgNumericAsyncPostgresTest.cs
@@ -32,13 +32,16 @@ public class UsePgNumericAsyncPostgresTest
     [Fact]
     public async Task TestUsePgNumericAsyncPostgres()
     {
-        // Act.
-        var result = await _sample.UsePgNumericAsyncPostgres(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.PostgreSqlDatabaseId);
+        await _spannerFixture.RunWithTemporaryPostgresDatabaseAsync(async databaseId =>
+        {
+            // Act.
+            var result = await _sample.UsePgNumericAsyncPostgres(_spannerFixture.ProjectId, _spannerFixture.InstanceId, databaseId);
 
-        //Assert.
-        Assert.Collection(result,
-        item1 => Assert.Equal(PgNumeric.Parse("3150.25"), item1.Revenue),
-        item2 => Assert.Equal(PgNumeric.Parse("NaN"), item2.Revenue),
-        item3 => Assert.Null(item3.Revenue));
+            //Assert.
+            Assert.Collection(result,
+            item1 => Assert.Equal(PgNumeric.Parse("3150.25"), item1.Revenue),
+            item2 => Assert.Equal(PgNumeric.Parse("NaN"), item2.Revenue),
+            item3 => Assert.Null(item3.Revenue));
+        });
     }
 }

--- a/spanner/api/Spanner.Samples.Tests/WriteAndReadUsingDmlCoreAsyncTest.cs
+++ b/spanner/api/Spanner.Samples.Tests/WriteAndReadUsingDmlCoreAsyncTest.cs
@@ -28,8 +28,12 @@ public class WriteAndReadUsingDmlCoreAsyncTest
     [Fact]
     public async Task TestWriteAndReadUsingDmlCoreAsync()
     {
-        WriteAndReadUsingDmlCoreAsyncSample sample = new WriteAndReadUsingDmlCoreAsyncSample();
-        var rowCount = await sample.WriteAndReadUsingDmlCoreAsync(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.DatabaseId);
-        Assert.Equal(1, rowCount);
+        await _spannerFixture.RunWithTemporaryDatabaseAsync(async databaseId =>
+        {
+            await _spannerFixture.InitializeTempDatabaseAsync(databaseId, insertData: false, addColumn: false);
+            WriteAndReadUsingDmlCoreAsyncSample sample = new WriteAndReadUsingDmlCoreAsyncSample();
+            var rowCount = await sample.WriteAndReadUsingDmlCoreAsync(_spannerFixture.ProjectId, _spannerFixture.InstanceId, databaseId);
+            Assert.Equal(1, rowCount);
+        }, SpannerFixture.CreateSingersTableStatement, SpannerFixture.CreateAlbumsTableStatement);
     }
 }

--- a/spanner/api/Spanner.Samples.Tests/WriteUsingDmlCoreAsyncTest.cs
+++ b/spanner/api/Spanner.Samples.Tests/WriteUsingDmlCoreAsyncTest.cs
@@ -28,8 +28,12 @@ public class WriteUsingDmlCoreAsyncTest
     [Fact]
     public async Task TestWriteUsingDmlCoreAsync()
     {
-        WriteUsingDmlCoreAsyncSample sample = new WriteUsingDmlCoreAsyncSample();
-        var rowCount = await sample.WriteUsingDmlCoreAsync(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.DatabaseId);
-        Assert.Equal(4, rowCount);
+        await _spannerFixture.RunWithTemporaryDatabaseAsync(async databaseId =>
+        {
+            await _spannerFixture.InitializeTempDatabaseAsync(databaseId, insertData: true, addColumn: false);
+            WriteUsingDmlCoreAsyncSample sample = new WriteUsingDmlCoreAsyncSample();
+            var rowCount = await sample.WriteUsingDmlCoreAsync(_spannerFixture.ProjectId, _spannerFixture.InstanceId, databaseId);
+            Assert.Equal(4, rowCount);
+        }, SpannerFixture.CreateSingersTableStatement, SpannerFixture.CreateAlbumsTableStatement);
     }
 }


### PR DESCRIPTION
There changes are to make Spanner sample tests independent to each other. These includes :

- Changes to use temporary databases for all Google Standard SQL sample tests that modify the database.

- Changes to use temporary databases for all PostgreSQL sample tests that modify the database .