### PR TITLE
feat: Add support for editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,281 @@
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+# top-most EditorConfig file
+root = true
+###############################
+# Core EditorConfig Options   #
+###############################
+# All files
+[*]
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+# Generated code
+[*{_AssemblyInfo.cs,.g.cs}]
+generated_code = true
+
+# XML project files
+[*.{csproj}]
+indent_size = 2
+
+# Code files
+
+###############################
+# .NET Coding Conventions     #
+###############################
+[*.{cs}]
+
+# Organize usings
+dotnet_sort_system_directives_first = false
+
+# this. preferences
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
+
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:warning
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:warning
+dotnet_style_readonly_field = true:warning
+
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+csharp_prefer_simple_default_expression = true:suggestion
+
+###############################
+# Naming Conventions          #
+###############################
+# Style Definitions
+dotnet_naming_style.pascal_case_style.capitalization             = pascal_case
+
+# Use PascalCase for constant fields  
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds            = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities  = *
+dotnet_naming_symbols.constant_fields.required_modifiers          = const
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# static fields should have s_ prefix
+dotnet_naming_rule.static_fields_should_have_prefix.severity = suggestion
+dotnet_naming_rule.static_fields_should_have_prefix.symbols  = static_fields
+dotnet_naming_rule.static_fields_should_have_prefix.style = static_prefix_style
+dotnet_naming_symbols.static_fields.applicable_kinds   = field
+dotnet_naming_symbols.static_fields.required_modifiers = static
+dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
+dotnet_naming_style.static_prefix_style.required_prefix = s_
+dotnet_naming_style.static_prefix_style.capitalization = camel_case
+
+# internal and private fields should be _camelCase
+dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
+dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
+dotnet_naming_rule.camel_case_for_private_internal_fields.style = camel_case_underscore_style
+dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
+dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
+dotnet_naming_style.camel_case_underscore_style.required_prefix = _
+dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
+
+# Locals and parameters are camelCase
+dotnet_naming_rule.locals_should_be_camel_case.severity = suggestion
+dotnet_naming_rule.locals_should_be_camel_case.symbols = locals_and_parameters
+dotnet_naming_rule.locals_should_be_camel_case.style = camel_case_style
+dotnet_naming_symbols.locals_and_parameters.applicable_kinds = parameter, local
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+
+# Public property and methods should be PascalCase
+dotnet_naming_rule.public_methods_and_properties_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.public_methods_and_properties_should_be_pascal_case.symbols = public_methods_and_properties
+dotnet_naming_rule.public_methods_and_properties_should_be_pascal_case.style = pascal_case
+dotnet_naming_symbols.public_methods_and_properties.applicable_kinds = method, property
+dotnet_naming_symbols.public_methods_and_properties.applicable_accessibilities = public
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+# Private and internal methods should be PascalCase
+dotnet_naming_rule.private_and_internal_methods_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.private_and_internal_methods_should_be_pascal_case.symbols = private_and_internal_methods
+dotnet_naming_rule.private_and_internal_methods_should_be_pascal_case.style = pascal_case
+dotnet_naming_symbols.private_and_internal_methods.applicable_kinds = method
+dotnet_naming_symbols.private_and_internal_methods.applicable_accessibilities = private, internal
+###############################
+# C# Coding Conventions       #
+###############################
+[*.cs]
+# var preferences
+csharp_style_var_for_built_in_types = true:silent
+csharp_style_var_when_type_is_apparent = true:silent
+csharp_style_var_elsewhere = true:silent
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent
+dotnet_style_predefined_type_for_member_access = true:silent
+
+csharp_using_directive_placement = outside_namespace:warning
+csharp_prefer_braces = true:suggestion
+csharp_preserve_single_line_blocks = true:none
+csharp_preserve_single_line_statements = false:none
+csharp_prefer_static_local_function = true:suggestion
+csharp_prefer_simple_using_statement = true:suggestion
+csharp_style_prefer_switch_expression = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_methods = true:suggestion
+csharp_style_expression_bodied_constructors = true:suggestion
+csharp_style_expression_bodied_operators = true:suggestion
+csharp_style_expression_bodied_properties = true:suggestion
+csharp_style_expression_bodied_indexers = true:suggestion
+csharp_style_expression_bodied_accessors = true:suggestion
+csharp_style_expression_bodied_lambdas = true:suggestion
+csharp_style_expression_bodied_local_functions = true:suggestion
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+
+# Null-checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Other features
+csharp_style_prefer_index_operator = true:suggestion
+csharp_style_prefer_range_operator = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = false:none
+
+###############################
+# C# Formatting Rules         #
+###############################
+indent_size = 4
+insert_final_newline = true
+charset = utf-8
+
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = one_less_than_current
+
+# Space preferences
+csharp_space_after_cast = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_around_declaration_statements = do_not_ignore
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_square_brackets = false
+
+# Wrapping preferences
+csharp_preserve_single_line_statements = true
+csharp_preserve_single_line_blocks = true
+
+# License header
+file_header_template = Copyright 2023 Google LLC\n\nLicensed under the Apache License, Version 2.0 (the "License").\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at \n\nhttps://www.apache.org/licenses/LICENSE-2.0 \n\nUnless required by applicable law or agreed to in writing, software \ndistributed under the License is distributed on an "AS IS" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and \nlimitations under the License.
+csharp_style_namespace_declarations = file_scoped:suggestion
+csharp_style_prefer_null_check_over_type_check = true:suggestion
+csharp_style_prefer_local_over_anonymous_function = true:suggestion
+csharp_style_prefer_tuple_swap = true:suggestion
+csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
+csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+csharp_style_unused_value_expression_statement_preference = discard_variable:suggestion
+csharp_style_prefer_pattern_matching = true:suggestion
+csharp_style_prefer_not_pattern = true:suggestion
+csharp_style_prefer_extended_property_pattern = true:suggestion
+csharp_style_prefer_parameter_null_checking = true:suggestion
+csharp_style_prefer_method_group_conversion = true:suggestion
+
+# Change the severity to `error` for the rules that must not be violated, to fail the build.
+
+# IDE0005: Remove unnecessary using directives.
+dotnet_diagnostic.IDE0005.severity = suggestion
+
+# IDE0011: Add braces
+dotnet_diagnostic.IDE0011.severity = suggestion
+
+# IDE0017: Object initialization can be simplified.
+dotnet_diagnostic.IDE0017.severity = suggestion
+
+# IDE0019: Use pattern matching.
+dotnet_diagnostic.IDE0019.severity = suggestion
+
+# IDE0021: Use expression body for constructor.
+dotnet_diagnostic.IDE0021.severity = suggestion
+
+# IDE0028: Collection initialization can be simplified.
+dotnet_diagnostic.IDE0028.severity = suggestion
+
+# IDE0035: Remove unreachable code.
+dotnet_diagnostic.IDE0035.severity = suggestion
+
+# IDE0040: Accessibility modifiers required.
+dotnet_diagnostic.IDE0040.severity = suggestion
+
+# IDE0052: Remove unread private member
+dotnet_diagnostic.IDE0052.severity = suggestion
+
+# IDE0053: Use expression body for lambda expression.
+dotnet_diagnostic.IDE0053.severity = suggestion
+
+# IDE0055: All C# and .NET formatting rules.
+dotnet_diagnostic.IDE0055.severity = suggestion
+
+# IDE0060: Remove unused parameter
+dotnet_diagnostic.IDE0060.severity = suggestion
+
+# IDE0063: Using statement can be simplified
+dotnet_diagnostic.IDE0063.severity = suggestion
+
+# IDE0065: Using statement can be simplified
+dotnet_diagnostic.IDE0065.severity = suggestion
+
+# IDE0071: Interpolation can be simplified. 
+dotnet_diagnostic.IDE0071.severity = suggestion
+
+# IDE0075: Simplify conditional expression. 
+dotnet_diagnostic.IDE0075.severity = suggestion

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+    <PropertyGroup>        
+        <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
+        <!-- When set to true, the build will fail if there are code violations as per .editorconfig diagnostics with the severity of error.-->
+        <EnforceCodeStyleInBuild>False</EnforceCodeStyleInBuild>
+    </PropertyGroup>
+</Project>


### PR DESCRIPTION
To support consistent styling across the samples, there are two files in this PR:

1.  .editorconfig - This is very similar to the [.editorconfig used in google-cloud-dotnet](https://github.com/googleapis/google-cloud-dotnet/blob/main/.editorconfig). This one however has rules for public, internal and  private method names, properties etc and the list of common diagnostic listed at the bottom with the  severity set to suggestion. When all the current violations are fixed, we can change the severity of important diagnostics to warning/errors as needed.
2.  Directory.Build.Props - By adding a new property to this file placed in the root folder of the source, the property is added to every project in the subfolders. This can be used to enforce the code style in build using `<EnforceCodeStyleInBuild>` property. When this property is set to `true` and there are code violations for the .editorconfig diagnostic rules with the severity of error, the build will fail. When set to false, the violations will not fail the build.  The property can be overridden at the project/subfolder level. This is currently set to false. We can enable it when all the existing issues are fixed.

I am also sharing a document describing these. Thanks.