### PR TITLE
Don't use merge:exact on the renovate PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,8 +11,5 @@
     "schedule": [
         "before 8am"
     ],
-    "timezone": "Europe/London",
-    "labels": [
-        "automerge: exact"
-    ]
+    "timezone": "Europe/London"
 }


### PR DESCRIPTION
The label is removed within 6 hours and because of the time zone distribution of the team this is not enough. Also, the automerge bot seems to be rebasing on top of main when there's one LGTM, which then conflicts with renovate tryingt to rebase the PR as there's a commit it doesn't recognize.