### PR TITLE
fix(Video Stitcher): broken tests due to API changes

### DIFF
--- a/media/stitcher/api/Stitcher.Samples.Tests/CreateCdnKeyAkamaiAsyncTests.cs
+++ b/media/stitcher/api/Stitcher.Samples.Tests/CreateCdnKeyAkamaiAsyncTests.cs
@@ -14,37 +14,32 @@
  * limitations under the License.
  */
 
-using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Stitcher.Samples.Tests
 {
     [Collection(nameof(StitcherFixture))]
-    public class CreateCdnKeyAkamaiTest : IDisposable
+    public class CreateCdnKeyAkamaiAsyncTest
     {
         private StitcherFixture _fixture;
         private readonly CreateCdnKeyAkamaiSample _createSample;
 
         private string _akamaiCdnKeyId;
 
-        public CreateCdnKeyAkamaiTest(StitcherFixture fixture)
+        public CreateCdnKeyAkamaiAsyncTest(StitcherFixture fixture)
         {
             _fixture = fixture;
             _createSample = new CreateCdnKeyAkamaiSample();
             _akamaiCdnKeyId = $"{_fixture.AkamaiCdnKeyIdPrefix}-{_fixture.TimestampId()}";
         }
 
-        public void Dispose()
-        {
-            _fixture.DeleteCdnKey(_akamaiCdnKeyId);
-        }
-
         [Fact]
-        public void CreatesCdnKey_Akamai()
+        public async Task CreatesCdnKeyAsync_Akamai()
         {
             // Run the sample code and create an Akamai CDN key.
             _fixture.CdnKeyIds.Add(_akamaiCdnKeyId);
-            var result = _createSample.CreateCdnKeyAkamai(
+            var result = await _createSample.CreateCdnKeyAkamaiAsync(
                 _fixture.ProjectId, _fixture.LocationId,
                 _akamaiCdnKeyId, _fixture.Hostname, _fixture.AkamaiTokenKey);
 

--- a/media/stitcher/api/Stitcher.Samples.Tests/CreateCdnKeyAkamaiAsyncTests.cs
+++ b/media/stitcher/api/Stitcher.Samples.Tests/CreateCdnKeyAkamaiAsyncTests.cs
@@ -31,7 +31,7 @@ namespace Stitcher.Samples.Tests
         {
             _fixture = fixture;
             _createSample = new CreateCdnKeyAkamaiSample();
-            _akamaiCdnKeyId = $"{_fixture.AkamaiCdnKeyIdPrefix}-{_fixture.TimestampId()}";
+            _akamaiCdnKeyId = $"{_fixture.AkamaiCdnKeyIdPrefix}-{_fixture.RandomId()}-{_fixture.TimestampId()}";
         }
 
         [Fact]

--- a/media/stitcher/api/Stitcher.Samples.Tests/CreateCdnKeyAsyncTests.cs
+++ b/media/stitcher/api/Stitcher.Samples.Tests/CreateCdnKeyAsyncTests.cs
@@ -32,8 +32,8 @@ namespace Stitcher.Samples.Tests
         {
             _fixture = fixture;
             _createSample = new CreateCdnKeySample();
-            _cloudCdnKeyId = $"{_fixture.CloudCdnKeyIdPrefix}-{_fixture.TimestampId()}";
-            _mediaCdnKeyId = $"{_fixture.MediaCdnKeyIdPrefix}-{_fixture.TimestampId()}";
+            _cloudCdnKeyId = $"{_fixture.CloudCdnKeyIdPrefix}-{_fixture.RandomId()}-{_fixture.TimestampId()}";
+            _mediaCdnKeyId = $"{_fixture.MediaCdnKeyIdPrefix}-{_fixture.RandomId()}-{_fixture.TimestampId()}";
         }
 
         [Fact]

--- a/media/stitcher/api/Stitcher.Samples.Tests/CreateCdnKeyAsyncTests.cs
+++ b/media/stitcher/api/Stitcher.Samples.Tests/CreateCdnKeyAsyncTests.cs
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Stitcher.Samples.Tests
 {
     [Collection(nameof(StitcherFixture))]
-    public class CreateCdnKeyTest : IDisposable
+    public class CreateCdnKeyAsyncTest
     {
         private StitcherFixture _fixture;
         private readonly CreateCdnKeySample _createSample;
@@ -28,7 +28,7 @@ namespace Stitcher.Samples.Tests
         private string _cloudCdnKeyId;
         private string _mediaCdnKeyId;
 
-        public CreateCdnKeyTest(StitcherFixture fixture)
+        public CreateCdnKeyAsyncTest(StitcherFixture fixture)
         {
             _fixture = fixture;
             _createSample = new CreateCdnKeySample();
@@ -36,18 +36,12 @@ namespace Stitcher.Samples.Tests
             _mediaCdnKeyId = $"{_fixture.MediaCdnKeyIdPrefix}-{_fixture.TimestampId()}";
         }
 
-        public void Dispose()
-        {
-            _fixture.DeleteCdnKey(_cloudCdnKeyId);
-            _fixture.DeleteCdnKey(_mediaCdnKeyId);
-        }
-
         [Fact]
-        public void CreatesCdnKey_MediaCdn()
+        public async Task CreatesCdnKeyAsync_MediaCdn()
         {
             // Run the sample code and create a Media CDN key.
             _fixture.CdnKeyIds.Add(_mediaCdnKeyId);
-            var result = _createSample.CreateCdnKey(
+            var result = await _createSample.CreateCdnKeyAsync(
                 _fixture.ProjectId, _fixture.LocationId,
                 _mediaCdnKeyId, _fixture.Hostname, _fixture.KeyName, _fixture.MediaCdnPrivateKey, true);
 
@@ -55,11 +49,11 @@ namespace Stitcher.Samples.Tests
         }
 
         [Fact]
-        public void CreatesCdnKey_CloudCdn()
+        public async Task CreatesCdnKeyAsync_CloudCdn()
         {
             // Run the sample code and create a Cloud CDN key.
             _fixture.CdnKeyIds.Add(_cloudCdnKeyId);
-            var result = _createSample.CreateCdnKey(
+            var result = await _createSample.CreateCdnKeyAsync(
                 _fixture.ProjectId, _fixture.LocationId,
                 _cloudCdnKeyId, _fixture.Hostname, _fixture.KeyName, _fixture.CloudCdnPrivateKey, false);
 

--- a/media/stitcher/api/Stitcher.Samples.Tests/CreateLiveConfigAsyncTests.cs
+++ b/media/stitcher/api/Stitcher.Samples.Tests/CreateLiveConfigAsyncTests.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,31 +14,35 @@
  * limitations under the License.
  */
 
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Stitcher.Samples.Tests
 {
     [Collection(nameof(StitcherFixture))]
-    public class CreateLiveSessionTest
+    public class CreateLiveConfigAsyncTest
     {
         private StitcherFixture _fixture;
-        private readonly CreateLiveSessionSample _createSample;
+        private readonly CreateLiveConfigSample _createSample;
 
-        public CreateLiveSessionTest(StitcherFixture fixture)
+        private string _liveConfigId;
+
+        public CreateLiveConfigAsyncTest(StitcherFixture fixture)
         {
             _fixture = fixture;
-            _createSample = new CreateLiveSessionSample();
+            _createSample = new CreateLiveConfigSample();
+            _liveConfigId = $"{_fixture.LiveConfigIdPrefix}-{_fixture.TimestampId()}";
         }
 
         [Fact]
-        public void CreatesLiveSession()
+        public async Task CreatesLiveConfigAsync()
         {
             // Run the sample code.
-            var result = _createSample.CreateLiveSession(
-                _fixture.ProjectId, _fixture.LocationId, _fixture.TestLiveConfigId);
+            _fixture.LiveConfigIds.Add(_liveConfigId);
+            var result = await _createSample.CreateLiveConfigAsync(
+                _fixture.ProjectId, _fixture.LocationId, _liveConfigId, _fixture.LiveSourceUri, _fixture.LiveAdTagUri, _fixture.TestSlateId);
 
-            Assert.Equal(_fixture.LocationId, result.LiveSessionName.LocationId);
-            Assert.Contains("/liveSessions/", result.LiveSessionName.ToString());
+            Assert.Equal(_liveConfigId, result.LiveConfigName.LiveConfigId);
         }
     }
 }

--- a/media/stitcher/api/Stitcher.Samples.Tests/CreateLiveConfigAsyncTests.cs
+++ b/media/stitcher/api/Stitcher.Samples.Tests/CreateLiveConfigAsyncTests.cs
@@ -31,7 +31,7 @@ namespace Stitcher.Samples.Tests
         {
             _fixture = fixture;
             _createSample = new CreateLiveConfigSample();
-            _liveConfigId = $"{_fixture.LiveConfigIdPrefix}-{_fixture.TimestampId()}";
+            _liveConfigId = $"{_fixture.LiveConfigIdPrefix}-{_fixture.RandomId()}-{_fixture.TimestampId()}";
         }
 
         [Fact]

--- a/media/stitcher/api/Stitcher.Samples.Tests/CreateSlateAsyncTests.cs
+++ b/media/stitcher/api/Stitcher.Samples.Tests/CreateSlateAsyncTests.cs
@@ -31,7 +31,7 @@ namespace Stitcher.Samples.Tests
         {
             _fixture = fixture;
             _createSample = new CreateSlateSample();
-            _slateId = $"{_fixture.SlateIdPrefix}-{_fixture.TimestampId()}";
+            _slateId = $"{_fixture.SlateIdPrefix}-{_fixture.RandomId()}-{_fixture.TimestampId()}";
         }
 
         [Fact]

--- a/media/stitcher/api/Stitcher.Samples.Tests/CreateSlateAsyncTests.cs
+++ b/media/stitcher/api/Stitcher.Samples.Tests/CreateSlateAsyncTests.cs
@@ -14,41 +14,35 @@
  * limitations under the License.
  */
 
-using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Stitcher.Samples.Tests
 {
     [Collection(nameof(StitcherFixture))]
-    public class DeleteSlateTest : IDisposable
+    public class CreateSlateAsyncTest
     {
         private StitcherFixture _fixture;
         private readonly CreateSlateSample _createSample;
-        private readonly DeleteSlateSample _deleteSample;
 
         private string _slateId;
 
-        public DeleteSlateTest(StitcherFixture fixture)
+        public CreateSlateAsyncTest(StitcherFixture fixture)
         {
             _fixture = fixture;
             _createSample = new CreateSlateSample();
-            _deleteSample = new DeleteSlateSample();
             _slateId = $"{_fixture.SlateIdPrefix}-{_fixture.TimestampId()}";
-
-            _fixture.SlateIds.Add(_slateId);
-            _createSample.CreateSlate(
-                _fixture.ProjectId, _fixture.LocationId,
-                _slateId, _fixture.TestSlateUri);
-        }
-
-        public void Dispose()
-        {
-            _fixture.DeleteSlate(_slateId);
         }
 
         [Fact]
-        public void DeletesSlate() =>
+        public async Task CreatesSlateAsync()
+        {
             // Run the sample code.
-            _deleteSample.DeleteSlate(_fixture.ProjectId, _fixture.LocationId, _slateId);
+            _fixture.SlateIds.Add(_slateId);
+            var result = await _createSample.CreateSlateAsync(
+                _fixture.ProjectId, _fixture.LocationId, _slateId, _fixture.TestSlateUri);
+
+            Assert.Equal(_slateId, result.SlateName.SlateId);
+        }
     }
 }

--- a/media/stitcher/api/Stitcher.Samples.Tests/DeleteCdnKeyAsyncTests.cs
+++ b/media/stitcher/api/Stitcher.Samples.Tests/DeleteCdnKeyAsyncTests.cs
@@ -33,7 +33,7 @@ namespace Stitcher.Samples.Tests
             _fixture = fixture;
             _createSample = new CreateCdnKeySample();
             _deleteSample = new DeleteCdnKeySample();
-            _cdnKeyId = $"{_fixture.CloudCdnKeyIdPrefix}-{_fixture.TimestampId()}";
+            _cdnKeyId = $"{_fixture.CloudCdnKeyIdPrefix}-{_fixture.RandomId()}-{_fixture.TimestampId()}";
             _fixture.CdnKeyIds.Add(_cdnKeyId);
         }
 

--- a/media/stitcher/api/Stitcher.Samples.Tests/DeleteCdnKeyAsyncTests.cs
+++ b/media/stitcher/api/Stitcher.Samples.Tests/DeleteCdnKeyAsyncTests.cs
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Stitcher.Samples.Tests
 {
     [Collection(nameof(StitcherFixture))]
-    public class DeleteCdnKeyTest : IDisposable
+    public class DeleteCdnKeyAsyncTest : IAsyncLifetime
     {
         private StitcherFixture _fixture;
         private readonly CreateCdnKeySample _createSample;
@@ -28,27 +28,29 @@ namespace Stitcher.Samples.Tests
 
         private string _cdnKeyId;
 
-        public DeleteCdnKeyTest(StitcherFixture fixture)
+        public DeleteCdnKeyAsyncTest(StitcherFixture fixture)
         {
             _fixture = fixture;
             _createSample = new CreateCdnKeySample();
             _deleteSample = new DeleteCdnKeySample();
             _cdnKeyId = $"{_fixture.CloudCdnKeyIdPrefix}-{_fixture.TimestampId()}";
-
             _fixture.CdnKeyIds.Add(_cdnKeyId);
-            _createSample.CreateCdnKey(
+        }
+
+        public async Task InitializeAsync()
+        {
+            await _createSample.CreateCdnKeyAsync(
                 _fixture.ProjectId, _fixture.LocationId,
                 _cdnKeyId, _fixture.Hostname, _fixture.KeyName, _fixture.CloudCdnPrivateKey, false);
         }
 
-        public void Dispose()
+        public async Task DisposeAsync()
         {
-            _fixture.DeleteCdnKey(_cdnKeyId);
         }
 
         [Fact]
-        public void DeletesCdnKey() =>
+        public async Task DeletesCdnKeyAsync() =>
             // Run the sample code.
-            _deleteSample.DeleteCdnKey(_fixture.ProjectId, _fixture.LocationId, _cdnKeyId);
+            await _deleteSample.DeleteCdnKeyAsync(_fixture.ProjectId, _fixture.LocationId, _cdnKeyId);
     }
 }

--- a/media/stitcher/api/Stitcher.Samples.Tests/DeleteLiveConfigAsyncTests.cs
+++ b/media/stitcher/api/Stitcher.Samples.Tests/DeleteLiveConfigAsyncTests.cs
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Stitcher.Samples.Tests
+{
+    [Collection(nameof(StitcherFixture))]
+    public class DeleteLiveConfigAsyncTest : IAsyncLifetime
+    {
+        private StitcherFixture _fixture;
+        private readonly CreateLiveConfigSample _createSample;
+        private readonly DeleteLiveConfigSample _deleteSample;
+
+        private string _liveConfigId;
+
+        public DeleteLiveConfigAsyncTest(StitcherFixture fixture)
+        {
+            _fixture = fixture;
+            _createSample = new CreateLiveConfigSample();
+            _deleteSample = new DeleteLiveConfigSample();
+            _liveConfigId = $"{_fixture.LiveConfigIdPrefix}-{_fixture.TimestampId()}";
+            _fixture.LiveConfigIds.Add(_liveConfigId);
+        }
+
+        public async Task InitializeAsync()
+        {
+            await _createSample.CreateLiveConfigAsync(
+                _fixture.ProjectId, _fixture.LocationId,
+                _liveConfigId, _fixture.LiveSourceUri, _fixture.LiveAdTagUri, _fixture.TestSlateId);
+        }
+
+        public async Task DisposeAsync()
+        {
+        }
+
+        [Fact]
+        public async Task DeletesLiveConfigAsync() =>
+            // Run the sample code.
+            await _deleteSample.DeleteLiveConfigAsync(_fixture.ProjectId, _fixture.LocationId, _liveConfigId);
+    }
+}

--- a/media/stitcher/api/Stitcher.Samples.Tests/DeleteLiveConfigAsyncTests.cs
+++ b/media/stitcher/api/Stitcher.Samples.Tests/DeleteLiveConfigAsyncTests.cs
@@ -33,7 +33,7 @@ namespace Stitcher.Samples.Tests
             _fixture = fixture;
             _createSample = new CreateLiveConfigSample();
             _deleteSample = new DeleteLiveConfigSample();
-            _liveConfigId = $"{_fixture.LiveConfigIdPrefix}-{_fixture.TimestampId()}";
+            _liveConfigId = $"{_fixture.LiveConfigIdPrefix}-{_fixture.RandomId()}-{_fixture.TimestampId()}";
             _fixture.LiveConfigIds.Add(_liveConfigId);
         }
 

--- a/media/stitcher/api/Stitcher.Samples.Tests/DeleteSlateAsyncTests.cs
+++ b/media/stitcher/api/Stitcher.Samples.Tests/DeleteSlateAsyncTests.cs
@@ -33,7 +33,7 @@ namespace Stitcher.Samples.Tests
             _fixture = fixture;
             _createSample = new CreateSlateSample();
             _deleteSample = new DeleteSlateSample();
-            _slateId = $"{_fixture.SlateIdPrefix}-{_fixture.TimestampId()}";
+            _slateId = $"{_fixture.SlateIdPrefix}-{_fixture.RandomId()}-{_fixture.TimestampId()}";
             _fixture.SlateIds.Add(_slateId);
         }
 

--- a/media/stitcher/api/Stitcher.Samples.Tests/DeleteSlateAsyncTests.cs
+++ b/media/stitcher/api/Stitcher.Samples.Tests/DeleteSlateAsyncTests.cs
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Stitcher.Samples.Tests
+{
+    [Collection(nameof(StitcherFixture))]
+    public class DeleteSlateAsyncTest : IAsyncLifetime
+    {
+        private StitcherFixture _fixture;
+        private readonly CreateSlateSample _createSample;
+        private readonly DeleteSlateSample _deleteSample;
+
+        private string _slateId;
+
+        public DeleteSlateAsyncTest(StitcherFixture fixture)
+        {
+            _fixture = fixture;
+            _createSample = new CreateSlateSample();
+            _deleteSample = new DeleteSlateSample();
+            _slateId = $"{_fixture.SlateIdPrefix}-{_fixture.TimestampId()}";
+            _fixture.SlateIds.Add(_slateId);
+        }
+
+        public async Task InitializeAsync()
+        {
+            await _createSample.CreateSlateAsync(
+                _fixture.ProjectId, _fixture.LocationId,
+                _slateId, _fixture.TestSlateUri);
+        }
+
+        public async Task DisposeAsync()
+        {
+        }
+
+        [Fact]
+        public async Task DeletesSlateAsync() =>
+            // Run the sample code.
+            await _deleteSample.DeleteSlateAsync(_fixture.ProjectId, _fixture.LocationId, _slateId);
+    }
+}

--- a/media/stitcher/api/Stitcher.Samples.Tests/GetLiveAdTagDetailTests.cs
+++ b/media/stitcher/api/Stitcher.Samples.Tests/GetLiveAdTagDetailTests.cs
@@ -42,7 +42,7 @@ namespace Stitcher.Samples.Tests
         public async Task InitializeAsync()
         {
             var session = _createSample.CreateLiveSession(
-               _fixture.ProjectId, _fixture.LocationId, _fixture.LiveSourceUri, _fixture.LiveAdTagUri, _fixture.TestSlateId);
+               _fixture.ProjectId, _fixture.LocationId, _fixture.TestLiveConfigId);
             _liveSessionId = session.LiveSessionName.LiveSessionId;
             _playUri = session.PlayUri;
 

--- a/media/stitcher/api/Stitcher.Samples.Tests/GetLiveConfigTests.cs
+++ b/media/stitcher/api/Stitcher.Samples.Tests/GetLiveConfigTests.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,40 +14,27 @@
  * limitations under the License.
  */
 
-using System;
 using Xunit;
 
 namespace Stitcher.Samples.Tests
 {
     [Collection(nameof(StitcherFixture))]
-    public class CreateSlateTest : IDisposable
+    public class GetLiveConfigTest
     {
         private StitcherFixture _fixture;
-        private readonly CreateSlateSample _createSample;
+        private readonly GetLiveConfigSample _getSample;
 
-        private string _slateId;
-
-        public CreateSlateTest(StitcherFixture fixture)
+        public GetLiveConfigTest(StitcherFixture fixture)
         {
             _fixture = fixture;
-            _createSample = new CreateSlateSample();
-            _slateId = $"{_fixture.SlateIdPrefix}-{_fixture.TimestampId()}";
-        }
-
-        public void Dispose()
-        {
-            _fixture.DeleteSlate(_slateId);
+            _getSample = new GetLiveConfigSample();
         }
 
         [Fact]
-        public void CreatesSlate()
+        public void GetsLiveConfig()
         {
-            // Run the sample code.
-            _fixture.SlateIds.Add(_slateId);
-            var result = _createSample.CreateSlate(
-                _fixture.ProjectId, _fixture.LocationId, _slateId, _fixture.TestSlateUri);
-
-            Assert.Equal(_slateId, result.SlateName.SlateId);
+            var result = _getSample.GetLiveConfig(_fixture.ProjectId, _fixture.LocationId, _fixture.TestLiveConfigId);
+            Assert.Equal(_fixture.TestLiveConfigId, result.LiveConfigName.LiveConfigId);
         }
     }
 }

--- a/media/stitcher/api/Stitcher.Samples.Tests/GetLiveSessionTests.cs
+++ b/media/stitcher/api/Stitcher.Samples.Tests/GetLiveSessionTests.cs
@@ -34,7 +34,7 @@ namespace Stitcher.Samples.Tests
             _getSample = new GetLiveSessionSample();
 
             var result = _createSample.CreateLiveSession(
-               _fixture.ProjectId, _fixture.LocationId, _fixture.LiveSourceUri, _fixture.LiveAdTagUri, _fixture.TestSlateId);
+               _fixture.ProjectId, _fixture.LocationId, _fixture.TestLiveConfigId);
             _liveSessionId = result.LiveSessionName.LiveSessionId;
         }
 

--- a/media/stitcher/api/Stitcher.Samples.Tests/ListLiveAdTagDetailsTests.cs
+++ b/media/stitcher/api/Stitcher.Samples.Tests/ListLiveAdTagDetailsTests.cs
@@ -39,7 +39,7 @@ namespace Stitcher.Samples.Tests
         public async Task InitializeAsync()
         {
             var result = _createSample.CreateLiveSession(
-               _fixture.ProjectId, _fixture.LocationId, _fixture.LiveSourceUri, _fixture.LiveAdTagUri, _fixture.TestSlateId);
+               _fixture.ProjectId, _fixture.LocationId, _fixture.TestLiveConfigId);
             _liveSessionId = result.LiveSessionName.LiveSessionId;
             _playUri = result.PlayUri;
 

--- a/media/stitcher/api/Stitcher.Samples.Tests/ListLiveConfigsTests.cs
+++ b/media/stitcher/api/Stitcher.Samples.Tests/ListLiveConfigsTests.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,26 +19,22 @@ using Xunit;
 namespace Stitcher.Samples.Tests
 {
     [Collection(nameof(StitcherFixture))]
-    public class CreateLiveSessionTest
+    public class ListLiveConfigsTest
     {
         private StitcherFixture _fixture;
-        private readonly CreateLiveSessionSample _createSample;
+        private readonly ListLiveConfigsSample _listSample;
 
-        public CreateLiveSessionTest(StitcherFixture fixture)
+        public ListLiveConfigsTest(StitcherFixture fixture)
         {
             _fixture = fixture;
-            _createSample = new CreateLiveSessionSample();
+            _listSample = new ListLiveConfigsSample();
         }
 
         [Fact]
-        public void CreatesLiveSession()
+        public void ListsLiveConfigs()
         {
-            // Run the sample code.
-            var result = _createSample.CreateLiveSession(
-                _fixture.ProjectId, _fixture.LocationId, _fixture.TestLiveConfigId);
-
-            Assert.Equal(_fixture.LocationId, result.LiveSessionName.LocationId);
-            Assert.Contains("/liveSessions/", result.LiveSessionName.ToString());
+            var liveConfigs = _listSample.ListLiveConfigs(_fixture.ProjectId, _fixture.LocationId);
+            Assert.Contains(liveConfigs, r => _fixture.TestLiveConfigId == r.LiveConfigName.LiveConfigId);
         }
     }
 }

--- a/media/stitcher/api/Stitcher.Samples.Tests/StitcherFixture.cs
+++ b/media/stitcher/api/Stitcher.Samples.Tests/StitcherFixture.cs
@@ -102,6 +102,7 @@ public class StitcherFixture : IDisposable, IAsyncLifetime, ICollectionFixture<S
         try 
         {
             TestSlate = await _createSlateSample.CreateSlateAsync(ProjectId, LocationId, TestSlateId, TestSlateUri);
+            Console.WriteLine("TestSlate : " + TestSlate.SlateName.ToString());
         }
         catch (Exception e)
         {

--- a/media/stitcher/api/Stitcher.Samples.Tests/StitcherFixture.cs
+++ b/media/stitcher/api/Stitcher.Samples.Tests/StitcherFixture.cs
@@ -97,22 +97,52 @@ public class StitcherFixture : IDisposable, IAsyncLifetime, ICollectionFixture<S
         await CleanOutdatedResources();
 
         TestSlateId = $"{SlateIdPrefix}-{RandomId()}-{TimestampId()}";
-                    Console.WriteLine("TestSlateId " + TestSlateId);
-
         SlateIds.Add(TestSlateId);
-        TestSlate = await _createSlateSample.CreateSlateAsync(ProjectId, LocationId, TestSlateId, TestSlateUri);
+        Console.WriteLine("TestSlateId " + TestSlateId);
+        try 
+        {
+            TestSlate = await _createSlateSample.CreateSlateAsync(ProjectId, LocationId, TestSlateId, TestSlateUri);
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine("TestSlateId : " + TestSlateId + " failed with error: " + e.ToString());
+        }
 
         TestCloudCdnKeyId = $"{CloudCdnKeyIdPrefix}-{RandomId()}-{TimestampId()}";
         CdnKeyIds.Add(TestCloudCdnKeyId);
-        TestCloudCdnKey = await _createCdnKeySample.CreateCdnKeyAsync(ProjectId, LocationId, TestCloudCdnKeyId, Hostname, KeyName, CloudCdnPrivateKey, false);
+        Console.WriteLine("TestCloudCdnKey " + TestCloudCdnKeyId);
+        try 
+        {
+            TestCloudCdnKey = await _createCdnKeySample.CreateCdnKeyAsync(ProjectId, LocationId, TestCloudCdnKeyId, Hostname, KeyName, CloudCdnPrivateKey, false);
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine("TestCloudCdnKeyId : " + TestCloudCdnKeyId + " failed with error: " + e.ToString());
+        }
 
         TestAkamaiCdnKeyId = $"{AkamaiCdnKeyIdPrefix}-{RandomId()}-{TimestampId()}";
         CdnKeyIds.Add(TestAkamaiCdnKeyId);
-        TestAkamaiCdnKey = await _createCdnKeyAkamaiSample.CreateCdnKeyAkamaiAsync(ProjectId, LocationId, TestAkamaiCdnKeyId, Hostname, AkamaiTokenKey);
-
+        Console.WriteLine("TestAkamaiCdnKeyId " + TestAkamaiCdnKeyId);
+        try 
+        {
+            TestAkamaiCdnKey = await _createCdnKeyAkamaiSample.CreateCdnKeyAkamaiAsync(ProjectId, LocationId, TestAkamaiCdnKeyId, Hostname, AkamaiTokenKey);
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine("TestAkamaiCdnKeyId : " + TestAkamaiCdnKeyId + " failed with error: " + e.ToString());
+        }
+    
         TestLiveConfigId = $"{LiveConfigIdPrefix}-{RandomId()}-{TimestampId()}";
         LiveConfigIds.Add(TestLiveConfigId);
-        TestLiveConfig = await _createLiveConfigSample.CreateLiveConfigAsync(ProjectId, LocationId, TestLiveConfigId, LiveSourceUri, LiveAdTagUri, TestSlateId);
+        Console.WriteLine("TestLiveConfigId " + TestLiveConfigId);
+        try 
+        {
+            TestLiveConfig = await _createLiveConfigSample.CreateLiveConfigAsync(ProjectId, LocationId, TestLiveConfigId, LiveSourceUri, LiveAdTagUri, TestSlateId);
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine("TestLiveConfigId : " + TestLiveConfigId + " failed with error: " + e.ToString());
+        }
 
         httpClient = new HttpClient();
     }

--- a/media/stitcher/api/Stitcher.Samples.Tests/StitcherFixture.cs
+++ b/media/stitcher/api/Stitcher.Samples.Tests/StitcherFixture.cs
@@ -98,52 +98,19 @@ public class StitcherFixture : IDisposable, IAsyncLifetime, ICollectionFixture<S
 
         TestSlateId = $"{SlateIdPrefix}-{RandomId()}-{TimestampId()}";
         SlateIds.Add(TestSlateId);
-        Console.WriteLine("TestSlateId " + TestSlateId);
-        try 
-        {
-            TestSlate = await _createSlateSample.CreateSlateAsync(ProjectId, LocationId, TestSlateId, TestSlateUri);
-            Console.WriteLine("TestSlate : " + TestSlate.SlateName.ToString());
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine("TestSlateId : " + TestSlateId + " failed with error: " + e.ToString());
-        }
+        TestSlate = await _createSlateSample.CreateSlateAsync(ProjectId, LocationId, TestSlateId, TestSlateUri);
 
         TestCloudCdnKeyId = $"{CloudCdnKeyIdPrefix}-{RandomId()}-{TimestampId()}";
         CdnKeyIds.Add(TestCloudCdnKeyId);
-        Console.WriteLine("TestCloudCdnKey " + TestCloudCdnKeyId);
-        try 
-        {
-            TestCloudCdnKey = await _createCdnKeySample.CreateCdnKeyAsync(ProjectId, LocationId, TestCloudCdnKeyId, Hostname, KeyName, CloudCdnPrivateKey, false);
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine("TestCloudCdnKeyId : " + TestCloudCdnKeyId + " failed with error: " + e.ToString());
-        }
+        TestCloudCdnKey = await _createCdnKeySample.CreateCdnKeyAsync(ProjectId, LocationId, TestCloudCdnKeyId, Hostname, KeyName, CloudCdnPrivateKey, false);
 
         TestAkamaiCdnKeyId = $"{AkamaiCdnKeyIdPrefix}-{RandomId()}-{TimestampId()}";
         CdnKeyIds.Add(TestAkamaiCdnKeyId);
-        Console.WriteLine("TestAkamaiCdnKeyId " + TestAkamaiCdnKeyId);
-        try 
-        {
-            TestAkamaiCdnKey = await _createCdnKeyAkamaiSample.CreateCdnKeyAkamaiAsync(ProjectId, LocationId, TestAkamaiCdnKeyId, Hostname, AkamaiTokenKey);
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine("TestAkamaiCdnKeyId : " + TestAkamaiCdnKeyId + " failed with error: " + e.ToString());
-        }
-    
+        TestAkamaiCdnKey = await _createCdnKeyAkamaiSample.CreateCdnKeyAkamaiAsync(ProjectId, LocationId, TestAkamaiCdnKeyId, Hostname, AkamaiTokenKey);
+
         TestLiveConfigId = $"{LiveConfigIdPrefix}-{RandomId()}-{TimestampId()}";
         LiveConfigIds.Add(TestLiveConfigId);
-        Console.WriteLine("TestLiveConfigId " + TestLiveConfigId);
-        try 
-        {
-            TestLiveConfig = await _createLiveConfigSample.CreateLiveConfigAsync(ProjectId, LocationId, TestLiveConfigId, LiveSourceUri, LiveAdTagUri, TestSlateId);
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine("TestLiveConfigId : " + TestLiveConfigId + " failed with error: " + e.ToString());
-        }
+        TestLiveConfig = await _createLiveConfigSample.CreateLiveConfigAsync(ProjectId, LocationId, TestLiveConfigId, LiveSourceUri, LiveAdTagUri, TestSlateId);
 
         httpClient = new HttpClient();
     }

--- a/media/stitcher/api/Stitcher.Samples.Tests/StitcherFixture.cs
+++ b/media/stitcher/api/Stitcher.Samples.Tests/StitcherFixture.cs
@@ -28,11 +28,11 @@ public class StitcherFixture : IDisposable, IAsyncLifetime, ICollectionFixture<S
 {
     public string ProjectId { get; }
     public string LocationId { get; } = "us-central1";
-    public string SlateIdPrefix { get; } = "test-slate";
-    public string AkamaiCdnKeyIdPrefix { get; } = "test-akamai-cdn-key";
-    public string CloudCdnKeyIdPrefix { get; } = "test-cloud-cdn-key";
-    public string MediaCdnKeyIdPrefix { get; } = "test-media-cdn-key";
-    public string LiveConfigIdPrefix { get; } = "test-live-config";
+    public string SlateIdPrefix { get; } = "slate";
+    public string AkamaiCdnKeyIdPrefix { get; } = "akamai-cdn";
+    public string CloudCdnKeyIdPrefix { get; } = "cloud-cdn";
+    public string MediaCdnKeyIdPrefix { get; } = "media-cdn";
+    public string LiveConfigIdPrefix { get; } = "live-config";
 
     public List<string> SlateIds { get; } = new List<string>();
     public List<string> CdnKeyIds { get; } = new List<string>();
@@ -96,19 +96,21 @@ public class StitcherFixture : IDisposable, IAsyncLifetime, ICollectionFixture<S
     {
         await CleanOutdatedResources();
 
-        TestSlateId = $"{SlateIdPrefix}-{TimestampId()}";
+        TestSlateId = $"{SlateIdPrefix}-{RandomId()}-{TimestampId()}";
+                    Console.WriteLine("TestSlateId " + TestSlateId);
+
         SlateIds.Add(TestSlateId);
         TestSlate = await _createSlateSample.CreateSlateAsync(ProjectId, LocationId, TestSlateId, TestSlateUri);
 
-        TestCloudCdnKeyId = $"{CloudCdnKeyIdPrefix}-{TimestampId()}";
+        TestCloudCdnKeyId = $"{CloudCdnKeyIdPrefix}-{RandomId()}-{TimestampId()}";
         CdnKeyIds.Add(TestCloudCdnKeyId);
         TestCloudCdnKey = await _createCdnKeySample.CreateCdnKeyAsync(ProjectId, LocationId, TestCloudCdnKeyId, Hostname, KeyName, CloudCdnPrivateKey, false);
 
-        TestAkamaiCdnKeyId = $"{AkamaiCdnKeyIdPrefix}-{TimestampId()}";
+        TestAkamaiCdnKeyId = $"{AkamaiCdnKeyIdPrefix}-{RandomId()}-{TimestampId()}";
         CdnKeyIds.Add(TestAkamaiCdnKeyId);
         TestAkamaiCdnKey = await _createCdnKeyAkamaiSample.CreateCdnKeyAkamaiAsync(ProjectId, LocationId, TestAkamaiCdnKeyId, Hostname, AkamaiTokenKey);
 
-        TestLiveConfigId = $"{LiveConfigIdPrefix}-{TimestampId()}";
+        TestLiveConfigId = $"{LiveConfigIdPrefix}-{RandomId()}-{TimestampId()}";
         LiveConfigIds.Add(TestLiveConfigId);
         TestLiveConfig = await _createLiveConfigSample.CreateLiveConfigAsync(ProjectId, LocationId, TestLiveConfigId, LiveSourceUri, LiveAdTagUri, TestSlateId);
 
@@ -247,12 +249,12 @@ public class StitcherFixture : IDisposable, IAsyncLifetime, ICollectionFixture<S
 
     public string TimestampId()
     {
-        return $"csharp-{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}";
+        return $"{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}";
     }
 
     public string RandomId()
     {
-        return $"csharp-{System.Guid.NewGuid()}";
+        return $"{System.Guid.NewGuid()}";
     }
 
     public async Task<String> GetHttpResponse(string url)

--- a/media/stitcher/api/Stitcher.Samples.Tests/UpdateCdnKeyAkamaiTests.cs
+++ b/media/stitcher/api/Stitcher.Samples.Tests/UpdateCdnKeyAkamaiTests.cs
@@ -14,26 +14,27 @@
  * limitations under the License.
  */
 
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Stitcher.Samples.Tests
 {
     [Collection(nameof(StitcherFixture))]
-    public class UpdateCdnKeyAkamaiTest
+    public class UpdateCdnKeyAkamaiAsyncTest
     {
         private StitcherFixture _fixture;
         private readonly UpdateCdnKeyAkamaiSample _updateSample;
 
-        public UpdateCdnKeyAkamaiTest(StitcherFixture fixture)
+        public UpdateCdnKeyAkamaiAsyncTest(StitcherFixture fixture)
         {
             _fixture = fixture;
             _updateSample = new UpdateCdnKeyAkamaiSample();
         }
 
         [Fact]
-        public void UpdatesCdnKey_Akamai()
+        public async Task UpdatesCdnKeyAsync_Akamai()
         {
-            var result = _updateSample.UpdateCdnKeyAkamai(_fixture.ProjectId, _fixture.LocationId, _fixture.TestAkamaiCdnKeyId, _fixture.UpdatedAkamaiHostname, _fixture.UpdatedAkamaiTokenKey);
+            var result = await _updateSample.UpdateCdnKeyAkamaiAsync(_fixture.ProjectId, _fixture.LocationId, _fixture.TestAkamaiCdnKeyId, _fixture.UpdatedAkamaiHostname, _fixture.UpdatedAkamaiTokenKey);
             Assert.Equal(_fixture.TestAkamaiCdnKeyId, result.CdnKeyName.CdnKeyId);
             Assert.Equal(_fixture.UpdatedAkamaiHostname, result.Hostname);
         }

--- a/media/stitcher/api/Stitcher.Samples.Tests/UpdateCdnKeyAsyncTests.cs
+++ b/media/stitcher/api/Stitcher.Samples.Tests/UpdateCdnKeyAsyncTests.cs
@@ -14,34 +14,35 @@
  * limitations under the License.
  */
 
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Stitcher.Samples.Tests
 {
     [Collection(nameof(StitcherFixture))]
-    public class UpdateCdnKeyTest
+    public class UpdateCdnKeyAsyncTest
     {
         private StitcherFixture _fixture;
         private readonly UpdateCdnKeySample _updateSample;
 
-        public UpdateCdnKeyTest(StitcherFixture fixture)
+        public UpdateCdnKeyAsyncTest(StitcherFixture fixture)
         {
             _fixture = fixture;
             _updateSample = new UpdateCdnKeySample();
         }
 
         [Fact]
-        public void UpdatesCdnKey_MediaCdn()
+        public async Task UpdatesCdnKeyAsync_MediaCdn()
         {
-            var result = _updateSample.UpdateCdnKey(_fixture.ProjectId, _fixture.LocationId, _fixture.TestCloudCdnKeyId, _fixture.UpdatedMediaCdnHostname, _fixture.KeyName, _fixture.MediaCdnPrivateKey, true);
+            var result = await _updateSample.UpdateCdnKeyAsync(_fixture.ProjectId, _fixture.LocationId, _fixture.TestCloudCdnKeyId, _fixture.UpdatedMediaCdnHostname, _fixture.KeyName, _fixture.MediaCdnPrivateKey, true);
             Assert.Equal(_fixture.TestCloudCdnKeyId, result.CdnKeyName.CdnKeyId);
             Assert.Equal(_fixture.UpdatedMediaCdnHostname, result.Hostname);
         }
 
         [Fact]
-        public void UpdatesCdnKey_CloudCdn()
+        public async Task UpdatesCdnKeyAsync_CloudCdn()
         {
-            var result = _updateSample.UpdateCdnKey(_fixture.ProjectId, _fixture.LocationId, _fixture.TestCloudCdnKeyId, _fixture.UpdatedCloudCdnHostname, _fixture.KeyName, _fixture.CloudCdnPrivateKey, false);
+            var result = await _updateSample.UpdateCdnKeyAsync(_fixture.ProjectId, _fixture.LocationId, _fixture.TestCloudCdnKeyId, _fixture.UpdatedCloudCdnHostname, _fixture.KeyName, _fixture.CloudCdnPrivateKey, false);
             Assert.Equal(_fixture.TestCloudCdnKeyId, result.CdnKeyName.CdnKeyId);
             Assert.Equal(_fixture.UpdatedCloudCdnHostname, result.Hostname);
         }

--- a/media/stitcher/api/Stitcher.Samples.Tests/UpdateSlateAsyncTests.cs
+++ b/media/stitcher/api/Stitcher.Samples.Tests/UpdateSlateAsyncTests.cs
@@ -14,26 +14,27 @@
  * limitations under the License.
  */
 
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Stitcher.Samples.Tests
 {
     [Collection(nameof(StitcherFixture))]
-    public class UpdateSlateTest
+    public class UpdateSlateAsyncTest
     {
         private StitcherFixture _fixture;
         private readonly UpdateSlateSample _updateSample;
 
-        public UpdateSlateTest(StitcherFixture fixture)
+        public UpdateSlateAsyncTest(StitcherFixture fixture)
         {
             _fixture = fixture;
             _updateSample = new UpdateSlateSample();
         }
 
         [Fact]
-        public void UpdatesSlate()
+        public async Task UpdatesSlateAsync()
         {
-            var result = _updateSample.UpdateSlate(_fixture.ProjectId, _fixture.LocationId, _fixture.TestSlateId, _fixture.UpdateSlateUri);
+            var result = await _updateSample.UpdateSlateAsync(_fixture.ProjectId, _fixture.LocationId, _fixture.TestSlateId, _fixture.UpdateSlateUri);
             Assert.Equal(_fixture.TestSlateId, result.SlateName.SlateId);
             Assert.Equal(_fixture.UpdateSlateUri, result.Uri);
         }

--- a/media/stitcher/api/Stitcher.Samples/CreateCdnKeyAkamaiAsync.cs
+++ b/media/stitcher/api/Stitcher.Samples/CreateCdnKeyAkamaiAsync.cs
@@ -18,12 +18,13 @@
 
 using Google.Api.Gax.ResourceNames;
 using Google.Cloud.Video.Stitcher.V1;
+using Google.LongRunning;
 using Google.Protobuf;
-
+using System.Threading.Tasks;
 
 public class CreateCdnKeyAkamaiSample
 {
-    public CdnKey CreateCdnKeyAkamai(
+    public async Task<CdnKey> CreateCdnKeyAkamaiAsync(
         string projectId, string location, string cdnKeyId, string hostname,
         string akamaiTokenKey)
     {
@@ -46,11 +47,14 @@ public class CreateCdnKeyAkamaiSample
             CdnKey = cdnKey
         };
 
-        // Call the API.
-        CdnKey newCdnKey = client.CreateCdnKey(request);
+        // Make the request.
+        Operation<CdnKey, OperationMetadata> response = await client.CreateCdnKeyAsync(request);
 
-        // Return the result.
-        return newCdnKey;
+        // Poll until the returned long-running operation is complete.
+        Operation<CdnKey, OperationMetadata> completedResponse = await response.PollUntilCompletedAsync();
+
+        // Retrieve the operation result.
+        return completedResponse.Result;
     }
 }
 // [END videostitcher_create_cdn_key_akamai]

--- a/media/stitcher/api/Stitcher.Samples/CreateCdnKeyAsync.cs
+++ b/media/stitcher/api/Stitcher.Samples/CreateCdnKeyAsync.cs
@@ -18,12 +18,13 @@
 
 using Google.Api.Gax.ResourceNames;
 using Google.Cloud.Video.Stitcher.V1;
+using Google.LongRunning;
 using Google.Protobuf;
-
+using System.Threading.Tasks;
 
 public class CreateCdnKeySample
 {
-    public CdnKey CreateCdnKey(
+    public async Task<CdnKey> CreateCdnKeyAsync(
     string projectId, string location, string cdnKeyId, string hostname,
     string keyName, string privateKey, bool isMediaCdn)
     {
@@ -59,11 +60,14 @@ public class CreateCdnKeySample
             CdnKey = cdnKey
         };
 
-        // Call the API.
-        CdnKey newCdnKey = client.CreateCdnKey(request);
+        // Make the request.
+        Operation<CdnKey, OperationMetadata> response = await client.CreateCdnKeyAsync(request);
 
-        // Return the result.
-        return newCdnKey;
+        // Poll until the returned long-running operation is complete.
+        Operation<CdnKey, OperationMetadata> completedResponse = await response.PollUntilCompletedAsync();
+
+        // Retrieve the operation result.
+        return completedResponse.Result;
     }
 }
 // [END videostitcher_create_cdn_key]

--- a/media/stitcher/api/Stitcher.Samples/CreateLiveConfigAsync.cs
+++ b/media/stitcher/api/Stitcher.Samples/CreateLiveConfigAsync.cs
@@ -1,0 +1,56 @@
+﻿/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// [START videostitcher_create_live_config]
+
+using Google.Api.Gax.ResourceNames;
+using Google.Cloud.Video.Stitcher.V1;
+using Google.LongRunning;
+using System.Threading.Tasks;
+
+public class CreateLiveConfigSample
+{
+    public async Task<LiveConfig> CreateLiveConfigAsync(
+        string projectId, string location, string liveConfigId, string sourceUri, string adTagUri, string slateId)
+    {
+        // Create the client.
+        VideoStitcherServiceClient client = VideoStitcherServiceClient.Create();
+
+        CreateLiveConfigRequest request = new CreateLiveConfigRequest
+        {
+            ParentAsLocationName = LocationName.FromProjectLocation(projectId, location),
+            LiveConfigId = liveConfigId,
+            LiveConfig = new LiveConfig
+            {
+                SourceUri = sourceUri,
+                AdTagUri = adTagUri,
+                DefaultSlate = SlateName.FormatProjectLocationSlate(projectId, location, slateId),
+                AdTracking = AdTracking.Server,
+                StitchingPolicy = LiveConfig.Types.StitchingPolicy.CutCurrent
+            }
+        };
+
+        // Make the request.
+        Operation<LiveConfig, OperationMetadata> response = await client.CreateLiveConfigAsync(request);
+
+        // Poll until the returned long-running operation is complete.
+        Operation<LiveConfig, OperationMetadata> completedResponse = await response.PollUntilCompletedAsync();
+
+        // Retrieve the operation result.
+        return completedResponse.Result;
+    }
+}
+// [END videostitcher_create_live_config]

--- a/media/stitcher/api/Stitcher.Samples/CreateSlateAsync.cs
+++ b/media/stitcher/api/Stitcher.Samples/CreateSlateAsync.cs
@@ -14,35 +14,39 @@
  * limitations under the License.
  */
 
-// [START videostitcher_create_vod_session]
+// [START videostitcher_create_slate]
 
 using Google.Api.Gax.ResourceNames;
 using Google.Cloud.Video.Stitcher.V1;
+using Google.LongRunning;
+using System.Threading.Tasks;
 
-public class CreateVodSessionSample
+public class CreateSlateSample
 {
-    public VodSession CreateVodSession(
-        string projectId, string location, string sourceUri, string adTagUri)
+    public async Task<Slate> CreateSlateAsync(
+        string projectId, string location, string slateId, string slateUri)
     {
         // Create the client.
         VideoStitcherServiceClient client = VideoStitcherServiceClient.Create();
 
-        CreateVodSessionRequest request = new CreateVodSessionRequest
+        CreateSlateRequest request = new CreateSlateRequest
         {
             ParentAsLocationName = LocationName.FromProjectLocation(projectId, location),
-            VodSession = new VodSession
+            SlateId = slateId,
+            Slate = new Slate
             {
-                SourceUri = sourceUri,
-                AdTagUri = adTagUri,
-                AdTracking = AdTracking.Server
+                Uri = slateUri
             }
         };
 
-        // Call the API.
-        VodSession session = client.CreateVodSession(request);
+        // Make the request.
+        Operation<Slate, OperationMetadata> response = await client.CreateSlateAsync(request);
 
-        // Return the result.
-        return session;
+        // Poll until the returned long-running operation is complete.
+        Operation<Slate, OperationMetadata> completedResponse = await response.PollUntilCompletedAsync();
+
+        // Retrieve the operation result.
+        return completedResponse.Result;
     }
 }
-// [END videostitcher_create_vod_session]
+// [END videostitcher_create_slate]

--- a/media/stitcher/api/Stitcher.Samples/DeleteCdnKeyAsync.cs
+++ b/media/stitcher/api/Stitcher.Samples/DeleteCdnKeyAsync.cs
@@ -14,32 +14,31 @@
  * limitations under the License.
  */
 
-// [START videostitcher_create_live_session]
+// [START videostitcher_delete_cdn_key]
 
 using Google.Cloud.Video.Stitcher.V1;
+using Google.LongRunning;
+using Google.Protobuf.WellKnownTypes;
+using System.Threading.Tasks;
 
-public class CreateLiveSessionSample
+public class DeleteCdnKeySample
 {
-    public LiveSession CreateLiveSession(
-        string projectId, string location, string liveConfigId)
+    public async Task DeleteCdnKeyAsync(
+        string projectId, string location, string cdnKeyId)
     {
         // Create the client.
         VideoStitcherServiceClient client = VideoStitcherServiceClient.Create();
 
-        CreateLiveSessionRequest request = new CreateLiveSessionRequest
+        DeleteCdnKeyRequest request = new DeleteCdnKeyRequest
         {
-            Parent = $"projects/{projectId}/locations/{location}",
-            LiveSession = new LiveSession
-            {
-                LiveConfig = LiveConfigName.FormatProjectLocationLiveConfig(projectId, location, liveConfigId)
-            }
+            CdnKeyName = CdnKeyName.FromProjectLocationCdnKey(projectId, location, cdnKeyId)
         };
 
-        // Call the API.
-        LiveSession session = client.CreateLiveSession(request);
+        // Make the request.
+        Operation<Empty, OperationMetadata> response = await client.DeleteCdnKeyAsync(request);
 
-        // Return the result.
-        return session;
+        // Poll until the returned long-running operation is complete.
+        await response.PollUntilCompletedAsync();
     }
 }
-// [END videostitcher_create_live_session]
+// [END videostitcher_delete_cdn_key]

--- a/media/stitcher/api/Stitcher.Samples/DeleteLiveConfigAsync.cs
+++ b/media/stitcher/api/Stitcher.Samples/DeleteLiveConfigAsync.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,34 +14,31 @@
  * limitations under the License.
  */
 
-// [START videostitcher_update_slate]
+// [START videostitcher_delete_live_config]
 
 using Google.Cloud.Video.Stitcher.V1;
+using Google.LongRunning;
 using Google.Protobuf.WellKnownTypes;
+using System.Threading.Tasks;
 
-public class UpdateSlateSample
+public class DeleteLiveConfigSample
 {
-    public Slate UpdateSlate(
-        string projectId, string location, string slateId, string slateUri)
+    public async Task DeleteLiveConfigAsync(
+        string projectId, string location, string liveConfigId)
     {
         // Create the client.
         VideoStitcherServiceClient client = VideoStitcherServiceClient.Create();
 
-        UpdateSlateRequest request = new UpdateSlateRequest
+        DeleteLiveConfigRequest request = new DeleteLiveConfigRequest
         {
-            Slate = new Slate
-            {
-                SlateName = SlateName.FromProjectLocationSlate(projectId, location, slateId),
-                Uri = slateUri
-            },
-            UpdateMask = new FieldMask { Paths = { "uri" } }
+            LiveConfigName = LiveConfigName.FromProjectLocationLiveConfig(projectId, location, liveConfigId)
         };
 
-        // Call the API.
-        Slate slate = client.UpdateSlate(request);
+        // Make the request.
+        Operation<Empty, OperationMetadata> response = await client.DeleteLiveConfigAsync(request);
 
-        // Return the result.
-        return slate;
+        // Poll until the returned long-running operation is complete.
+        await response.PollUntilCompletedAsync();
     }
 }
-// [END videostitcher_update_slate]
+// [END videostitcher_delete_live_config]

--- a/media/stitcher/api/Stitcher.Samples/DeleteSlateAsync.cs
+++ b/media/stitcher/api/Stitcher.Samples/DeleteSlateAsync.cs
@@ -14,34 +14,31 @@
  * limitations under the License.
  */
 
-// [START videostitcher_create_slate]
+// [START videostitcher_delete_slate]
 
-using Google.Api.Gax.ResourceNames;
 using Google.Cloud.Video.Stitcher.V1;
+using Google.LongRunning;
+using Google.Protobuf.WellKnownTypes;
+using System.Threading.Tasks;
 
-public class CreateSlateSample
+public class DeleteSlateSample
 {
-    public Slate CreateSlate(
-        string projectId, string location, string slateId, string slateUri)
+    public async Task DeleteSlateAsync(
+        string projectId, string location, string slateId)
     {
         // Create the client.
         VideoStitcherServiceClient client = VideoStitcherServiceClient.Create();
 
-        CreateSlateRequest request = new CreateSlateRequest
+        DeleteSlateRequest request = new DeleteSlateRequest
         {
-            ParentAsLocationName = LocationName.FromProjectLocation(projectId, location),
-            SlateId = slateId,
-            Slate = new Slate
-            {
-                Uri = slateUri
-            }
+            SlateName = SlateName.FromProjectLocationSlate(projectId, location, slateId)
         };
 
-        // Call the API.
-        Slate slate = client.CreateSlate(request);
+        // Make the request.
+        Operation<Empty, OperationMetadata> response = await client.DeleteSlateAsync(request);
 
-        // Return the result.
-        return slate;
+        // Poll until the returned long-running operation is complete.
+        await response.PollUntilCompletedAsync();
     }
 }
-// [END videostitcher_create_slate]
+// [END videostitcher_delete_slate]

--- a/media/stitcher/api/Stitcher.Samples/GetLiveConfig.cs
+++ b/media/stitcher/api/Stitcher.Samples/GetLiveConfig.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,25 +14,28 @@
  * limitations under the License.
  */
 
-// [START videostitcher_delete_cdn_key]
+// [START videostitcher_get_live_config]
 
 using Google.Cloud.Video.Stitcher.V1;
 
-public class DeleteCdnKeySample
+public class GetLiveConfigSample
 {
-    public void DeleteCdnKey(
-        string projectId, string location, string cdnKeyId)
+    public LiveConfig GetLiveConfig(
+        string projectId, string location, string liveConfigId)
     {
         // Create the client.
         VideoStitcherServiceClient client = VideoStitcherServiceClient.Create();
 
-        DeleteCdnKeyRequest request = new DeleteCdnKeyRequest
+        GetLiveConfigRequest request = new GetLiveConfigRequest
         {
-            CdnKeyName = CdnKeyName.FromProjectLocationCdnKey(projectId, location, cdnKeyId)
+            LiveConfigName = LiveConfigName.FromProjectLocationLiveConfig(projectId, location, liveConfigId)
         };
 
         // Call the API.
-        client.DeleteCdnKey(request);
+        LiveConfig response = client.GetLiveConfig(request);
+
+        // Return the result.
+        return response;
     }
 }
-// [END videostitcher_delete_cdn_key]
+// [END videostitcher_get_live_config]

--- a/media/stitcher/api/Stitcher.Samples/ListLiveConfigs.cs
+++ b/media/stitcher/api/Stitcher.Samples/ListLiveConfigs.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,25 +14,30 @@
  * limitations under the License.
  */
 
-// [START videostitcher_delete_slate]
+// [START videostitcher_list_live_configs]
 
+using Google.Api.Gax;
+using Google.Api.Gax.ResourceNames;
 using Google.Cloud.Video.Stitcher.V1;
 
-public class DeleteSlateSample
+public class ListLiveConfigsSample
 {
-    public void DeleteSlate(
-        string projectId, string location, string slateId)
+    public PagedEnumerable<ListLiveConfigsResponse, LiveConfig> ListLiveConfigs(
+        string projectId, string regionId)
     {
         // Create the client.
         VideoStitcherServiceClient client = VideoStitcherServiceClient.Create();
 
-        DeleteSlateRequest request = new DeleteSlateRequest
+        ListLiveConfigsRequest request = new ListLiveConfigsRequest
         {
-            SlateName = SlateName.FromProjectLocationSlate(projectId, location, slateId)
+            ParentAsLocationName = LocationName.FromProjectLocation(projectId, regionId)
         };
 
-        // Call the API.
-        client.DeleteSlate(request);
+        // Make the request.
+        PagedEnumerable<ListLiveConfigsResponse, LiveConfig> response = client.ListLiveConfigs(request);
+
+        // Return the result.
+        return response;
     }
 }
-// [END videostitcher_delete_slate]
+// [END videostitcher_list_live_configs]

--- a/media/stitcher/api/Stitcher.Samples/Stitcher.Samples.csproj
+++ b/media/stitcher/api/Stitcher.Samples/Stitcher.Samples.csproj
@@ -3,6 +3,6 @@
     <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Video.Stitcher.V1" Version="2.0.0" />
+    <PackageReference Include="Google.Cloud.Video.Stitcher.V1" Version="3.0.0-beta01" />
   </ItemGroup>
 </Project>

--- a/media/stitcher/api/Stitcher.Samples/UpdateCdnKeyAkamaiAsync.cs
+++ b/media/stitcher/api/Stitcher.Samples/UpdateCdnKeyAkamaiAsync.cs
@@ -17,12 +17,14 @@
 // [START videostitcher_update_cdn_key_akamai]
 
 using Google.Cloud.Video.Stitcher.V1;
+using Google.LongRunning;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
+using System.Threading.Tasks;
 
 public class UpdateCdnKeyAkamaiSample
 {
-    public CdnKey UpdateCdnKeyAkamai(
+    public async Task<CdnKey> UpdateCdnKeyAkamaiAsync(
         string projectId, string location, string cdnKeyId, string hostname,
         string akamaiTokenKey)
     {
@@ -45,11 +47,14 @@ public class UpdateCdnKeyAkamaiSample
             UpdateMask = new FieldMask { Paths = { "hostname", "akamai_cdn_key" } }
         };
 
-        // Call the API.
-        CdnKey newCdnKey = client.UpdateCdnKey(request);
+        // Make the request.
+        Operation<CdnKey, OperationMetadata> response = await client.UpdateCdnKeyAsync(request);
 
-        // Return the result.
-        return newCdnKey;
+        // Poll until the returned long-running operation is complete.
+        Operation<CdnKey, OperationMetadata> completedResponse = await response.PollUntilCompletedAsync();
+
+        // Retrieve the operation result.
+        return completedResponse.Result;
     }
 }
 // [END videostitcher_update_cdn_key_akamai]

--- a/media/stitcher/api/Stitcher.Samples/UpdateCdnKeyAsync.cs
+++ b/media/stitcher/api/Stitcher.Samples/UpdateCdnKeyAsync.cs
@@ -17,12 +17,14 @@
 // [START videostitcher_update_cdn_key]
 
 using Google.Cloud.Video.Stitcher.V1;
+using Google.LongRunning;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
+using System.Threading.Tasks;
 
 public class UpdateCdnKeySample
 {
-    public CdnKey UpdateCdnKey(
+    public async Task<CdnKey> UpdateCdnKeyAsync(
         string projectId, string location, string cdnKeyId, string hostname,
         string keyName, string privateKey, bool isMediaCdn)
     {
@@ -61,11 +63,14 @@ public class UpdateCdnKeySample
             UpdateMask = new FieldMask { Paths = { "hostname", path } }
         };
 
-        // Call the API.
-        CdnKey newCdnKey = client.UpdateCdnKey(request);
+        // Make the request.
+        Operation<CdnKey, OperationMetadata> response = await client.UpdateCdnKeyAsync(request);
 
-        // Return the result.
-        return newCdnKey;
+        // Poll until the returned long-running operation is complete.
+        Operation<CdnKey, OperationMetadata> completedResponse = await response.PollUntilCompletedAsync();
+
+        // Retrieve the operation result.
+        return completedResponse.Result;
     }
 }
 // [END videostitcher_update_cdn_key]

--- a/media/stitcher/api/Stitcher.Samples/UpdateSlateAsync.cs
+++ b/media/stitcher/api/Stitcher.Samples/UpdateSlateAsync.cs
@@ -1,0 +1,52 @@
+﻿/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// [START videostitcher_update_slate]
+
+using Google.Cloud.Video.Stitcher.V1;
+using Google.LongRunning;
+using Google.Protobuf.WellKnownTypes;
+using System.Threading.Tasks;
+
+public class UpdateSlateSample
+{
+    public async Task<Slate> UpdateSlateAsync(
+        string projectId, string location, string slateId, string slateUri)
+    {
+        // Create the client.
+        VideoStitcherServiceClient client = VideoStitcherServiceClient.Create();
+
+        UpdateSlateRequest request = new UpdateSlateRequest
+        {
+            Slate = new Slate
+            {
+                SlateName = SlateName.FromProjectLocationSlate(projectId, location, slateId),
+                Uri = slateUri
+            },
+            UpdateMask = new FieldMask { Paths = { "uri" } }
+        };
+
+        // Make the request.
+        Operation<Slate, OperationMetadata> response = await client.UpdateSlateAsync(request);
+
+        // Poll until the returned long-running operation is complete.
+        Operation<Slate, OperationMetadata> completedResponse = await response.PollUntilCompletedAsync();
+
+        // Retrieve the operation result.
+        return completedResponse.Result;
+    }
+}
+// [END videostitcher_update_slate]

--- a/media/stitcher/api/runTests.ps1
+++ b/media/stitcher/api/runTests.ps1
@@ -16,4 +16,4 @@ import-module -DisableNameChecking ..\..\..\BuildTools.psm1
 Set-TestTimeout 600
 
 dotnet restore --force
-# dotnet test --no-restore --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }
+dotnet test --no-restore --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }


### PR DESCRIPTION
Create/delete/update methods on slates and CDN keys are now LROs.
Added live config methods (create/delete/get/list but no update) and tests.
Creating a live session now requires a live config.
Creating a VOD session now requires the `AdTracking` field.


Fixes #2100 