### PR TITLE
chore: Using Temp DB for Delete Sample Tests

### DIFF
--- a/spanner/api/Spanner.Samples.Tests/DeleteUsingDmlCoreAsyncTest.cs
+++ b/spanner/api/Spanner.Samples.Tests/DeleteUsingDmlCoreAsyncTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Google Inc.
+// Copyright 2020 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,8 +28,12 @@ public class DeleteUsingDmlCoreAsyncTest
     [Fact]
     public async Task TestDeleteUsingDmlCoreAsync()
     {
-        DeleteUsingDmlCoreAsyncSample sample = new DeleteUsingDmlCoreAsyncSample();
-        var rowCount = await sample.DeleteUsingDmlCoreAsync(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.DatabaseId);
-        Assert.Equal(1, rowCount);
+        await _spannerFixture.RunWithTemporaryDatabaseAsync(async databaseId =>
+        {
+            await _spannerFixture.CreateSingersTableAndInsertDataAsync(databaseId);
+            DeleteUsingDmlCoreAsyncSample sample = new DeleteUsingDmlCoreAsyncSample();
+            var rowCount = await sample.DeleteUsingDmlCoreAsync(_spannerFixture.ProjectId, _spannerFixture.InstanceId, databaseId);
+            Assert.Equal(1, rowCount);
+        });
     }
 }

--- a/spanner/api/Spanner.Samples.Tests/DeleteUsingDmlReturningAsyncPostgresTest.cs
+++ b/spanner/api/Spanner.Samples.Tests/DeleteUsingDmlReturningAsyncPostgresTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2023 Google Inc.
+// Copyright 2023 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,18 +30,22 @@ public class DeleteUsingDmlReturningAsyncPostgresTest
     [Fact]
     public async Task TestDeleteUsingDmlReturningAsyncPostgres()
     {
-        await InsertDataAsync();
-        var sample = new DeleteUsingDmlReturningAsyncPostgresSample();
-        var deletedSingerNames = await sample.DeleteUsingDmlReturningAsyncPostgres(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.PostgreSqlDatabaseId);
+        await _spannerFixture.RunWithTemporaryPostgresDatabaseAsync(async databaseId =>
+        {
+            await InsertDataAsync(databaseId);
+            var sample = new DeleteUsingDmlReturningAsyncPostgresSample();
+            var deletedSingerNames = await sample.DeleteUsingDmlReturningAsyncPostgres(_spannerFixture.ProjectId, _spannerFixture.InstanceId, databaseId);
 
-        Assert.Single(deletedSingerNames);
-        Assert.Equal("Lata Mangeshkar", deletedSingerNames[0]);
+            Assert.Single(deletedSingerNames);
+            Assert.Equal("Lata Mangeshkar", deletedSingerNames[0]);
+        });
     }
 
-    private async Task InsertDataAsync()
+    private async Task InsertDataAsync(string databaseId)
     {
+        using var connection = _spannerFixture.GetConnection(databaseId);
         string dml = "INSERT INTO Singers (SingerId, FirstName, LastName) VALUES (12, 'Lata', 'Mangeshkar')";
-        var insertSingerCommand = _spannerFixture.PgSpannerConnection.CreateDmlCommand(dml);
+        var insertSingerCommand = connection.CreateDmlCommand(dml);
         await insertSingerCommand.ExecuteNonQueryAsync();
     }
 }

--- a/spanner/api/Spanner.Samples.Tests/DeleteUsingPartitionedDmlCoreAsyncTest.cs
+++ b/spanner/api/Spanner.Samples.Tests/DeleteUsingPartitionedDmlCoreAsyncTest.cs
@@ -29,13 +29,13 @@ public class DeleteUsingPartitionedDmlCoreAsyncTest
     [Fact]
     public async Task TestDeleteUsingPartitionedDmlCoreAsync()
     {
-        await _spannerFixture.RunWithTemporaryPostgresDatabaseAsync(async databaseId =>
+        await _spannerFixture.RunWithTemporaryDatabaseAsync(async databaseId =>
         {
             await InsertDataAsync(databaseId);
             DeleteUsingPartitionedDmlCoreAsyncSample sample = new DeleteUsingPartitionedDmlCoreAsyncSample();
             var rowCount = await sample.DeleteUsingPartitionedDmlCoreAsync(_spannerFixture.ProjectId, _spannerFixture.InstanceId, databaseId);
-            Assert.True(rowCount >= 1);
-        });
+            Assert.Equal(2, rowCount);
+        }, SpannerFixture.CreateSingersTableStatement, SpannerFixture.CreateAlbumsTableStatement);
     }
 
     private async Task InsertDataAsync(string databaseId)


### PR DESCRIPTION
Parent Issue #2093

-  This is 1st PR containing changes to use temporary databases for all sample tests that modify the database. 

- This PR contains All Delete Sample Tests that needs to be updated.

- Number of affected tests files 3 out of 21 in closed PR #2216 