### PR TITLE
docs(scc-samples): update comments to add new parent resource types

### DIFF
--- a/securitycenter/api/src/CreateNotificationConfigSnippets.g.cs
+++ b/securitycenter/api/src/CreateNotificationConfigSnippets.g.cs
@@ -26,6 +26,9 @@ public class CreateNotificationConfigSnippets
     public static NotificationConfig CreateNotificationConfig(
         string organizationId, string notificationConfigId, string projectId, string topicName)
     {
+        // You can also use 'projectId' or 'folderId' instead of the 'organizationId'.
+        //      ProjectName projectName = new ProjectName(projectId);
+        //      FolderName folderName = new FolderName(folderId);
         OrganizationName orgName = new OrganizationName(organizationId);
         TopicName pubsubTopic = new TopicName(projectId, topicName);
 

--- a/securitycenter/api/src/DeleteNotificationConfigSnippets.g.cs
+++ b/securitycenter/api/src/DeleteNotificationConfigSnippets.g.cs
@@ -24,6 +24,7 @@ public class DeleteNotificationConfigSnippets
 {
     public static bool DeleteNotificationConfig(string organizationId, string notificationConfigId)
     {
+        // You can also use 'projectId' or 'folderId' instead of the 'organizationId'.
         NotificationConfigName notificationConfigName = new NotificationConfigName(organizationId, notificationConfigId);
         SecurityCenterClient client = SecurityCenterClient.Create();
 

--- a/securitycenter/api/src/GetNotificationConfigSnippets.g.cs
+++ b/securitycenter/api/src/GetNotificationConfigSnippets.g.cs
@@ -23,6 +23,7 @@ public class GetNotificationConfigSnippets
     public static NotificationConfig GetNotificationConfig(string organizationId, string configId)
     {
         SecurityCenterClient client = SecurityCenterClient.Create();
+        // You can also use 'projectId' or 'folderId' instead of the 'organizationId'.
         NotificationConfigName notificationConfigName = new NotificationConfigName(organizationId, configId);
 
         NotificationConfig response = client.GetNotificationConfig(notificationConfigName);

--- a/securitycenter/api/src/ListNotificationConfigSnippets.g.cs
+++ b/securitycenter/api/src/ListNotificationConfigSnippets.g.cs
@@ -26,6 +26,9 @@ public class ListNotificationConfigSnippets
 {
     public static PagedEnumerable<ListNotificationConfigsResponse, NotificationConfig> ListNotificationConfigs(string organizationId)
     {
+        // You can also use 'projectId' or 'folderId' instead of the 'organizationId'.
+        //      ProjectName projectName = new ProjectName(projectId);
+        //      FolderName folderName = new FolderName(folderId);
         OrganizationName orgName = new OrganizationName(organizationId);
         SecurityCenterClient client = SecurityCenterClient.Create();
         PagedEnumerable<ListNotificationConfigsResponse, NotificationConfig> notificationConfigs = client.ListNotificationConfigs(orgName);

--- a/securitycenter/api/src/UpdateNotificationConfigSnippets.g.cs
+++ b/securitycenter/api/src/UpdateNotificationConfigSnippets.g.cs
@@ -27,6 +27,7 @@ public class UpdateNotificationConfigSnippets
     public static NotificationConfig UpdateNotificationConfig(
         string organizationId, string notificationConfigId, string projectId, string topicName)
     {
+        // You can also use 'projectId' or 'folderId' instead of the 'organizationId'.
         NotificationConfigName notificationConfigName = new NotificationConfigName(organizationId, notificationConfigId);
         TopicName pubsubTopic = new TopicName(projectId, topicName);
 


### PR DESCRIPTION
## Security Command Center Samples
Contains only comment updates to allow new parent types (b/263299056)