### PR TITLE
DLP: Added sample for Deidentify and Reidentify content using deterministic

### DIFF
--- a/dlp/api/Snippets.Tests/DeidentifyWithDeterministicTests.cs
+++ b/dlp/api/Snippets.Tests/DeidentifyWithDeterministicTests.cs
@@ -1,0 +1,36 @@
+// Copyright 2023 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+using Google.Cloud.Dlp.V2;
+using Xunit;
+
+namespace GoogleCloudSamples
+{
+    public class DeidentifyWithDeterministicTests : IClassFixture<DlpTestFixture>
+    {
+        private DlpTestFixture _fixture;
+        public DeidentifyWithDeterministicTests(DlpTestFixture fixture) => _fixture = fixture;
+
+        [Fact]
+        public void TestDeidentifyWithDeterministic()
+        {
+            var infoTypes = new InfoType[] { new InfoType { Name = "US_SOCIAL_SECURITY_NUMBER" } };
+            var surrogate = new InfoType { Name = "SSN_TOKEN" };
+            var text = "My SSN is 372819127.";
+            var response = DeidentifyWithDeterministic.Deidentify(_fixture.ProjectId, text, _fixture.KeyName, _fixture.WrappedKey, surrogate, infoTypes);
+            Assert.NotEqual(text, response.Item.Value);
+            Assert.Contains("SSN_TOKEN", response.Item.Value);
+        }
+    }
+}

--- a/dlp/api/Snippets.Tests/ReidenitifyContentUsingDeterministicTests.cs
+++ b/dlp/api/Snippets.Tests/ReidenitifyContentUsingDeterministicTests.cs
@@ -1,0 +1,37 @@
+﻿// Copyright 2023 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+using Google.Cloud.Dlp.V2;
+
+namespace GoogleCloudSamples
+{
+    public class ReidenitifyContentUsingDeterministicTests : IClassFixture<DlpTestFixture>
+    {
+        private DlpTestFixture _fixture;
+        public ReidenitifyContentUsingDeterministicTests(DlpTestFixture fixture) => _fixture = fixture;
+
+        [Fact]
+        public void TestReidentifyWithDeterministic()
+        {
+            var infoTypes = new InfoType[] { new InfoType { Name = "PHONE_NUMBER" } };
+            var surrogate = new InfoType { Name = "PHONE_TOKEN" };
+            var inputText = "My phone number is 1234567890.";
+            var response = DeidentifyWithDeterministic.Deidentify(_fixture.ProjectId, inputText, _fixture.KeyName, _fixture.WrappedKey, surrogate, infoTypes);
+            var reidentifyInput = response.Item.Value;
+            var result = ReidentifyContentUsingDeterministic.ReidentifyDeterministic(_fixture.ProjectId, reidentifyInput, _fixture.KeyName, _fixture.WrappedKey, surrogate);
+            Assert.Equal(inputText, result.Item.Value);
+        }
+    }
+}

--- a/dlp/api/Snippets/DeidentifyWithDeterministic.cs
+++ b/dlp/api/Snippets/DeidentifyWithDeterministic.cs
@@ -1,0 +1,95 @@
+// Copyright 2023 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+// [START dlp_deidentify_deterministic]
+
+using System;
+using System.Collections.Generic;
+using Google.Api.Gax.ResourceNames;
+using Google.Cloud.Dlp.V2;
+
+public class DeidentifyWithDeterministic
+{
+    public static DeidentifyContentResponse Deidentify(
+        string projectId,
+        string text,
+        string keyName,
+        string wrapperKey,
+        InfoType surrogateType = null,
+        IEnumerable<InfoType> infoTypes = null)
+    {
+        // Instantiate a client.
+        var dlp = DlpServiceClient.Create();
+
+        // Construct the inspect config by specifying the type of info to be inspected.
+        var inspectConfig = new InspectConfig
+        {
+            InfoTypes =
+            {
+                infoTypes ?? new InfoType[] { new InfoType { Name = "PHONE_NUMBER" } }
+            }
+        };
+
+        // Construct the crypto deterministic config by providing key name, wrapped key and surrogate type.
+        var cryptoDeterministicConfig = new CryptoDeterministicConfig
+        {
+            CryptoKey = new CryptoKey
+            {
+                KmsWrapped = new KmsWrappedCryptoKey
+                {
+                    CryptoKeyName = keyName,
+                    WrappedKey = Google.Protobuf.ByteString.FromBase64(wrapperKey)
+                }
+            },
+            SurrogateInfoType = surrogateType ?? new InfoType { Name = "PHONE_TOKEN" }
+        };
+
+
+        // Construct the deidentify config using crypto deterministic config.
+        var deidentifyConfig = new DeidentifyConfig
+        {
+            InfoTypeTransformations = new InfoTypeTransformations
+            {
+                Transformations =
+                {
+                    new InfoTypeTransformations.Types.InfoTypeTransformation
+                    {
+                        PrimitiveTransformation = new PrimitiveTransformation
+                        {
+                            CryptoDeterministicConfig = cryptoDeterministicConfig
+                        }
+                    }
+                }
+            }
+        };
+
+        // Construct the request.
+        var request = new DeidentifyContentRequest
+        {
+            ParentAsLocationName = new LocationName(projectId, "global"),
+            DeidentifyConfig = deidentifyConfig,
+            InspectConfig = inspectConfig,
+            Item = new ContentItem { Value = text }
+        };
+
+        // Call the API.
+        DeidentifyContentResponse response = dlp.DeidentifyContent(request);
+
+        // Check the de-identified content.
+        Console.WriteLine($"De-identified content: {response.Item.Value}");
+        return response;
+    }
+}
+
+// [END dlp_deidentify_deterministic]

--- a/dlp/api/Snippets/ReidentifyContentUsingDeterministic.cs
+++ b/dlp/api/Snippets/ReidentifyContentUsingDeterministic.cs
@@ -1,0 +1,100 @@
+// Copyright 2023 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+// [START dlp_reidentify_deterministic]
+
+using System;
+using Google.Api.Gax.ResourceNames;
+using Google.Cloud.Dlp.V2;
+using Google.Protobuf;
+
+public class ReidentifyContentUsingDeterministic
+{
+    public static ReidentifyContentResponse ReidentifyDeterministic(
+        string projectId,
+        string text,
+        string keyName,
+        string wrappedKey,
+        InfoType surrogateType = null)
+    {
+        // Instantiate the client.
+        var dlp = DlpServiceClient.Create();
+
+        // Construct the infoType if null which will be used as surrogate type and infoType both.
+        var infoType = surrogateType ?? new InfoType { Name = "PHONE_TOKEN" };
+
+        // Construct crypto deterministic config using the crypto key name and wrapped key.
+        var cryptoDeterministicConfig = new CryptoDeterministicConfig
+        {
+            CryptoKey = new CryptoKey
+            {
+                KmsWrapped = new KmsWrappedCryptoKey
+                {
+                    CryptoKeyName = keyName,
+                    WrappedKey = ByteString.FromBase64(wrappedKey)
+                }
+            },
+            SurrogateInfoType = infoType,
+        };
+
+        // Construct the reidentify config using crypto config.
+        var reidentifyConfig = new DeidentifyConfig
+        {
+            InfoTypeTransformations = new InfoTypeTransformations
+            {
+                Transformations =
+                {
+                    new InfoTypeTransformations.Types.InfoTypeTransformation
+                    {
+                        PrimitiveTransformation = new PrimitiveTransformation
+                        {
+                            CryptoDeterministicConfig = cryptoDeterministicConfig
+                        }
+                    }
+                }
+            }
+        };
+
+        // Construct the inspect config.
+        var inspectConfig = new InspectConfig
+        {
+            CustomInfoTypes =
+            {
+                new CustomInfoType
+                {
+                    InfoType = infoType,
+                    SurrogateType = new CustomInfoType.Types.SurrogateType()
+                }
+            }
+        };
+
+        // Construct the request.
+        var request = new ReidentifyContentRequest
+        {
+            ParentAsLocationName = new LocationName(projectId, "global"),
+            ReidentifyConfig = reidentifyConfig,
+            InspectConfig = inspectConfig,
+            Item = new ContentItem { Value = text },
+        };
+
+        // Call the API.
+        ReidentifyContentResponse response = dlp.ReidentifyContent(request);
+
+        // Inspect the response.
+        Console.WriteLine($"Reidentified content: {response.Item.Value}");
+        return response;
+    }
+}
+
+// [END dlp_reidentify_deterministic]


### PR DESCRIPTION
- Added sample for [De-identify content through deterministic encryption](https://cloud.google.com/dlp/docs/samples/dlp-deidentify-deterministic) and [Re-identify content encrypted by deterministic encryption](https://cloud.google.com/dlp/docs/samples/dlp-reidentify-deterministic) and unit tests