### PR TITLE
DLP: Added sample for create, update and inspect with stored infoTypes

### DIFF
--- a/dlp/api/Snippets.Tests/CreateStoredInfoTypesTests.cs
+++ b/dlp/api/Snippets.Tests/CreateStoredInfoTypesTests.cs
@@ -1,0 +1,55 @@
+// Copyright 2023 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+using Google.Cloud.Dlp.V2;
+using Google.Cloud.Storage.V1;
+using Xunit;
+using System;
+
+namespace GoogleCloudSamples
+{
+    public class CreateStoredInfoTypesTests : IClassFixture<DlpTestFixture>
+    {
+        private DlpTestFixture _fixture;
+        public CreateStoredInfoTypesTests(DlpTestFixture fixture) => _fixture = fixture;
+
+        [Fact]
+        public void TestCreate()
+        {
+            Random random = new Random();
+            // Create a bucket.
+            var storage = StorageClient.Create();
+            var bucket = storage.CreateBucket(_fixture.ProjectId, $"dlp_dotnet_test_bucket_samples_{random.Next()}");
+
+            var dlp = DlpServiceClient.Create();
+            try
+            {
+                var storedInfoTypeId = $"github-usernames-create-{random.Next()}";
+                var result = CreateStoredInfoTypes.Create(_fixture.ProjectId, $"gs://{bucket.Name}", storedInfoTypeId);
+                Assert.Contains(storedInfoTypeId, result.Name);
+
+                // Delete the created stored infoTypes.
+                dlp.DeleteStoredInfoType(new DeleteStoredInfoTypeRequest
+                {
+                    Name = result.Name
+                });
+            }
+            finally
+            {
+                // Delete the created bucket.
+                storage.DeleteBucket(bucket.Name);
+            }
+        }
+    }
+}

--- a/dlp/api/Snippets.Tests/InspectDataWithStoredInfotypesTests.cs
+++ b/dlp/api/Snippets.Tests/InspectDataWithStoredInfotypesTests.cs
@@ -1,0 +1,67 @@
+// Copyright 2023 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+using Google.Cloud.Dlp.V2;
+using Google.Cloud.Storage.V1;
+using System;
+using System.Runtime.Intrinsics.Arm;
+using System.Threading;
+using Xunit;
+
+namespace GoogleCloudSamples
+{
+    public class InspectDataWithStoredInfotypesTests : IClassFixture<DlpTestFixture>
+    {
+        private DlpTestFixture _fixture;
+        public InspectDataWithStoredInfotypesTests(DlpTestFixture fixture) => _fixture = fixture;
+
+        [Fact]
+        public void TestInspect()
+        {
+            // Create the bucket for creating stored infoType.
+            Random random = new Random();
+            var storage = StorageClient.Create();
+            var bucket = storage.CreateBucket(_fixture.ProjectId, $"dlp_dotnet_test_bucket_samples_{random.Next()}");
+
+            try
+            {
+                // Create Stored InfoType first.
+                var storedInfoTypeId = $"github-usernames-inspect-{random.Next()}";
+                var response = CreateStoredInfoTypes.Create(_fixture.ProjectId, $"gs://{bucket.Name}", storedInfoTypeId);
+                Thread.Sleep(TimeSpan.FromSeconds(30)); // Sleep until created stored infotype gets ready.
+
+                var githubUser = "jamesC311";
+                var text = $"Commit was made by {githubUser}.";
+                var result = InspectDataWithStoredInfotypes.Inspect(_fixture.ProjectId, response.Name, text);
+                Assert.Single(result.Result.Findings);
+                Assert.Contains(result.Result.Findings, f => f.InfoType.Name == "GITHUB_LOGINS");
+                Assert.Contains(result.Result.Findings, f => f.Quote == githubUser);
+
+                var dlp = DlpServiceClient.Create();
+
+                // Delete the created stored infoTypes
+                dlp.DeleteStoredInfoType(new DeleteStoredInfoTypeRequest
+                {
+                    Name = response.Name
+                });
+
+            }
+            finally
+            {
+                // Delete the created bucket.
+                storage.DeleteBucket(bucket.Name);
+            }
+        }
+    }
+}

--- a/dlp/api/Snippets.Tests/UpdateStoredInfoTypesTests.cs
+++ b/dlp/api/Snippets.Tests/UpdateStoredInfoTypesTests.cs
@@ -1,0 +1,72 @@
+// Copyright 2023 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+using Google.Cloud.Dlp.V2;
+using Google.Cloud.Storage.V1;
+using System;
+using System.IO;
+using Xunit;
+
+namespace GoogleCloudSamples
+{
+    public class UpdateStoredInfoTypesTests : IClassFixture<DlpTestFixture>
+    {
+        private DlpTestFixture _fixture;
+        public UpdateStoredInfoTypesTests(DlpTestFixture fixture) => _fixture = fixture;
+
+        [Fact]
+        public void TestUpdate()
+        {
+            Random random = new Random();
+            // Create the bucket for creating stored infoType.
+            var storage = StorageClient.Create();
+            var bucket = storage.CreateBucket(_fixture.ProjectId, $"dlp_update_dotnet_test_bucket_samples_{random.Next()}");
+
+            // Create output bucket.
+            var bucketOutput = storage.CreateBucket(_fixture.ProjectId, $"dlp_update_dotnet_test_stored_infotype_bucket_{random.Next()}");
+
+            // Upload the file to cloud storage.
+            var filePath = Path.Combine(_fixture.ResourcePath, "test.txt");
+            using var fileStream = File.OpenRead(filePath);
+            storage.UploadObject(bucket.Name, "test.txt", null, fileStream);
+
+            try
+            {
+                // Create Stored InfoType first.
+                var storedInfoTypeId = $"github-usernames-update-{random.Next()}";
+                var response = CreateStoredInfoTypes.Create(_fixture.ProjectId, $"gs://{bucket.Name}", storedInfoTypeId);
+
+                var result = UpdateStoredInfoTypes.Update($"gs://{bucket.Name}/test.txt", response.Name, $"gs://{bucketOutput.Name}");
+
+                // Check whether stored infoType contains cloud storage file set field or not
+                // as we are changing source from Bigquery to GCS.
+                Assert.Contains("cloudStorageFileSet", result.ToString());
+
+                var dlp = DlpServiceClient.Create();
+
+                // Delete the created stored infoType.
+                dlp.DeleteStoredInfoType(new DeleteStoredInfoTypeRequest
+                {
+                    Name = result.Name
+                });
+            }
+            finally
+            {
+                // Delete the created buckets.
+                storage.DeleteBucket(bucketOutput.Name);
+                storage.DeleteBucket(bucket.Name, new DeleteBucketOptions { DeleteObjects = true });
+            }
+        }
+    }
+}

--- a/dlp/api/Snippets/CreateStoredInfoTypes.cs
+++ b/dlp/api/Snippets/CreateStoredInfoTypes.cs
@@ -1,0 +1,77 @@
+// Copyright 2023 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+// [START dlp_create_stored_infotype]
+
+using System;
+using Google.Api.Gax.ResourceNames;
+using Google.Cloud.Dlp.V2;
+
+public class CreateStoredInfoTypes
+{
+    public static StoredInfoType Create(
+        string projectId,
+        string outputPath,
+        string storedInfoTypeId)
+    {
+        // Instantiate the dlp client.
+        var dlp = DlpServiceClient.Create();
+
+        // Construct the stored infotype config by specifying the public table and 
+        // cloud storage output path.
+        var storedInfoTypeConfig = new StoredInfoTypeConfig
+        {
+            DisplayName = "Github Usernames",
+            Description = "Dictionary of Github usernames used in commits.",
+            LargeCustomDictionary = new LargeCustomDictionaryConfig
+            {
+                BigQueryField = new BigQueryField
+                {
+                    Table = new BigQueryTable
+                    {
+                        DatasetId = "samples",
+                        ProjectId = "bigquery-public-data",
+                        TableId = "github_nested"
+                    },
+                    Field = new FieldId
+                    {
+                        Name = "actor"
+                    }
+                },
+                OutputPath = new CloudStoragePath
+                {
+                    Path = outputPath
+                }
+            },
+        };
+
+        // Construct the request.
+        var request = new CreateStoredInfoTypeRequest
+        {
+            ParentAsLocationName = new LocationName(projectId, "global"),
+            Config = storedInfoTypeConfig,
+            StoredInfoTypeId = storedInfoTypeId
+        };
+
+        // Call the API.
+        StoredInfoType response = dlp.CreateStoredInfoType(request);
+
+        // Inspect the response.
+        Console.WriteLine($"Created the stored infotype at path: {response.Name}");
+
+        return response;
+    }
+}
+
+// [END dlp_create_stored_infotype]

--- a/dlp/api/Snippets/InspectDataWithStoredInfotypes.cs
+++ b/dlp/api/Snippets/InspectDataWithStoredInfotypes.cs
@@ -1,0 +1,75 @@
+﻿// Copyright 2023 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+// [START dlp_inspect_with_stored_infotype]
+
+using System;
+using Google.Api.Gax.ResourceNames;
+using Google.Cloud.Dlp.V2;
+
+public class InspectDataWithStoredInfotypes
+{
+    public static InspectContentResponse Inspect(
+        string projectId,
+        string storedInfotypePath,
+        string text,
+        InfoType infoType = null)
+    {
+        // Instantiate the dlp client.
+        var dlp = DlpServiceClient.Create();
+
+        // Construct the infotype if null.
+        var infotype = infoType ?? new InfoType { Name = "GITHUB_LOGINS" };
+
+        // Construct the inspect config using stored infotype.
+        var inspectConfig = new InspectConfig
+        {
+            CustomInfoTypes =
+            {
+                new CustomInfoType
+                {
+                    InfoType = infotype,
+                    StoredType = new StoredType { Name = storedInfotypePath }
+                }
+            },
+            IncludeQuote = true
+        };
+
+        // Construct the request using inspect config.
+        var request = new InspectContentRequest
+        {
+            ParentAsLocationName = new LocationName(projectId, "global"),
+            InspectConfig = inspectConfig,
+            Item = new ContentItem { Value = text }
+        };
+
+        // Call the API.
+        InspectContentResponse response = dlp.InspectContent(request);
+
+        // Inspect the results.
+        var findings = response.Result.Findings;
+        Console.WriteLine($"Findings: {findings.Count}");
+        foreach (var f in findings)
+        {
+            Console.WriteLine("\tQuote: " + f.Quote);
+            Console.WriteLine("\tInfo type: " + f.InfoType.Name);
+            Console.WriteLine("\tLikelihood: " + f.Likelihood);
+        }
+
+        return response;
+    }
+}
+
+// [END dlp_inspect_with_stored_infotype]
+

--- a/dlp/api/Snippets/UpdateStoredInfoTypes.cs
+++ b/dlp/api/Snippets/UpdateStoredInfoTypes.cs
@@ -1,0 +1,71 @@
+﻿// Copyright 2023 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+// [START dlp_update_stored_infotype]
+
+using System;
+using Google.Cloud.Dlp.V2;
+using Google.Protobuf.WellKnownTypes;
+
+public class UpdateStoredInfoTypes
+{
+    public static StoredInfoType Update(
+        string gcsFileUri,
+        string storedInfoTypePath,
+        string outputPath)
+    {
+        // Instantiate the client.
+        var dlp = DlpServiceClient.Create();
+
+        // Construct the stored infotype config. Here, we will change the source from bigquery table to GCS file.
+        var storedConfig = new StoredInfoTypeConfig
+        {
+            LargeCustomDictionary = new LargeCustomDictionaryConfig
+            {
+                CloudStorageFileSet = new CloudStorageFileSet
+                {
+                    Url = gcsFileUri
+                },
+                OutputPath = new CloudStoragePath
+                {
+                    Path = outputPath
+                }
+            }
+        };
+
+        // Construct the request using the stored config by specifying the update mask object
+        // which represent the path of field to be updated.
+        var request = new UpdateStoredInfoTypeRequest
+        {
+            Config = storedConfig,
+            Name = storedInfoTypePath,
+            UpdateMask = new FieldMask
+            {
+                Paths =
+                {
+                    "large_custom_dictionary.cloud_storage_file_set.url"
+                }
+            }
+        };
+
+        // Call the API.
+        StoredInfoType response = dlp.UpdateStoredInfoType(request);
+
+        // Inspect the result.
+        Console.WriteLine(response);
+        return response;
+    }
+}
+
+// [END dlp_update_stored_infotype]


### PR DESCRIPTION
- Added sample for [Create a stored infoType](https://cloud.google.com/dlp/docs/creating-stored-infotypes#create-storedinfotye), [Update a stored infoType](https://cloud.google.com/dlp/docs/creating-stored-infotypes#rebuild) and [Inspect Data with stored infoType](https://cloud.google.com/dlp/docs/creating-stored-infotypes#scan-with-large-custom-infotype) and unit tests