### PR TITLE
chore: Update gcs samples

### DIFF
--- a/storage/api/Storage.Samples.Tests/GenerateV4ReadSignedUrlTest.cs
+++ b/storage/api/Storage.Samples.Tests/GenerateV4ReadSignedUrlTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Google Inc.
+// Copyright 2020 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,8 +30,7 @@ public class GenerateV4ReadSignedUrlTest
     public async void GenerateV4ReadSignedUrl()
     {
         GenerateV4SignedReadUrlSample generateV4SignedReadUrlSample = new GenerateV4SignedReadUrlSample();
-        var credentialFilePath = Environment.GetEnvironmentVariable("GOOGLE_APPLICATION_CREDENTIALS");
-        var signedUrl = generateV4SignedReadUrlSample.GenerateV4SignedReadUrl(_fixture.BucketNameGeneric, _fixture.FileName, credentialFilePath);
+        var signedUrl = generateV4SignedReadUrlSample.GenerateV4SignedReadUrl(_fixture.BucketNameGeneric, _fixture.FileName);
 
         using var client = new HttpClient();
         var response = await client.GetAsync(signedUrl);

--- a/storage/api/Storage.Samples.Tests/GenerateV4UploadSignedUrlTest.cs
+++ b/storage/api/Storage.Samples.Tests/GenerateV4UploadSignedUrlTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Google Inc.
+// Copyright 2020 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,8 +29,7 @@ public class GenerateV4UploadSignedUrlTest
     public void TestGenerateV4UploadSignedUrl()
     {
         GenerateV4UploadSignedUrlSample generateV4UploadSignedUrlSample = new GenerateV4UploadSignedUrlSample();
-        var credentialFilePath = Environment.GetEnvironmentVariable("GOOGLE_APPLICATION_CREDENTIALS");
-        var signedUrl = generateV4UploadSignedUrlSample.GenerateV4UploadSignedUrl(_fixture.BucketNameGeneric, _fixture.FileName, credentialFilePath);
+        var signedUrl = generateV4UploadSignedUrlSample.GenerateV4UploadSignedUrl(_fixture.BucketNameGeneric, _fixture.FileName);
         Assert.NotNull(signedUrl);
     }
 }

--- a/storage/api/Storage.Samples/GenerateV4ReadSignedUrl.cs
+++ b/storage/api/Storage.Samples/GenerateV4ReadSignedUrl.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Google Inc.
+// Copyright 2020 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ public class GenerateV4SignedReadUrlSample
         string objectName = "your-object-name",
         string credentialFilePath = "my-local-path/my-credential-file-name")
     {
-        UrlSigner urlSigner = UrlSigner.FromServiceAccountPath(credentialFilePath);
+        UrlSigner urlSigner = UrlSigner.FromCredentialFile(credentialFilePath);
         // V4 is the default signing version.
         string url = urlSigner.Sign(bucketName, objectName, TimeSpan.FromHours(1), HttpMethod.Get);
         Console.WriteLine("Generated GET signed URL:");

--- a/storage/api/Storage.Samples/GenerateV4ReadSignedUrl.cs
+++ b/storage/api/Storage.Samples/GenerateV4ReadSignedUrl.cs
@@ -14,6 +14,7 @@
 
 // [START storage_generate_signed_url_v4]
 
+using Google.Apis.Auth.OAuth2;
 using Google.Cloud.Storage.V1;
 using System;
 using System.Net.Http;
@@ -22,10 +23,9 @@ public class GenerateV4SignedReadUrlSample
 {
     public string GenerateV4SignedReadUrl(
         string bucketName = "your-unique-bucket-name",
-        string objectName = "your-object-name",
-        string credentialFilePath = "my-local-path/my-credential-file-name")
+        string objectName = "your-object-name")
     {
-        UrlSigner urlSigner = UrlSigner.FromCredentialFile(credentialFilePath);
+        UrlSigner urlSigner = UrlSigner.FromCredential(GoogleCredential.GetApplicationDefault());
         // V4 is the default signing version.
         string url = urlSigner.Sign(bucketName, objectName, TimeSpan.FromHours(1), HttpMethod.Get);
         Console.WriteLine("Generated GET signed URL:");

--- a/storage/api/Storage.Samples/GenerateV4UploadSignedUrl.cs
+++ b/storage/api/Storage.Samples/GenerateV4UploadSignedUrl.cs
@@ -14,6 +14,7 @@
 
 // [START storage_generate_upload_signed_url_v4]
 
+using Google.Apis.Auth.OAuth2;
 using Google.Cloud.Storage.V1;
 using System;
 using System.Collections.Generic;
@@ -23,10 +24,9 @@ public class GenerateV4UploadSignedUrlSample
 {
     public string GenerateV4UploadSignedUrl(
         string bucketName = "your-unique-bucket-name",
-        string objectName = "your-object-name",
-        string credentialFilePath = "my-local-path/my-credential-file-name")
+        string objectName = "your-object-name")
     {
-        UrlSigner urlSigner = UrlSigner.FromCredentialFile(credentialFilePath);
+        UrlSigner urlSigner = UrlSigner.FromCredential(GoogleCredential.GetApplicationDefault());
 
         var contentHeaders = new Dictionary<string, IEnumerable<string>>
         {

--- a/storage/api/Storage.Samples/GenerateV4UploadSignedUrl.cs
+++ b/storage/api/Storage.Samples/GenerateV4UploadSignedUrl.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Google Inc.
+// Copyright 2020 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ public class GenerateV4UploadSignedUrlSample
         string objectName = "your-object-name",
         string credentialFilePath = "my-local-path/my-credential-file-name")
     {
-        UrlSigner urlSigner = UrlSigner.FromServiceAccountPath(credentialFilePath);
+        UrlSigner urlSigner = UrlSigner.FromCredentialFile(credentialFilePath);
 
         var contentHeaders = new Dictionary<string, IEnumerable<string>>
         {


### PR DESCRIPTION
updated GenerateV4SignedReadUrlSample and GenerateV4UploadSignedUrlSample to use UrlSigner.FromCredentialFile(credentialFilePath) instead of the deprecated UrlSigner.FromServiceAccountPath(credentialFilePath).
