### PR TITLE
docs: update custom retry and timeout sample

### DIFF
--- a/spanner/api/Spanner.Samples/CustomTimeoutsAndRetriesAsync.cs
+++ b/spanner/api/Spanner.Samples/CustomTimeoutsAndRetriesAsync.cs
@@ -53,10 +53,10 @@ public class CustomTimeoutsAndRetriesAsyncSample
             .WithRetry(RetrySettings.FromExponentialBackoff(
                 maxAttempts: 12,
                 initialBackoff: TimeSpan.FromMilliseconds(500),
-                maxBackoff: TimeSpan.FromMilliseconds(6400),
+                maxBackoff: TimeSpan.FromSeconds(16),
                 backoffMultiplier: 1.5,
                 retryFilter: RetrySettings.FilterForStatusCodes(
-                    new StatusCode[] { StatusCode.Unavailable, StatusCode.DeadlineExceeded })));
+                    new StatusCode[] { StatusCode.Unavailable })));
 
         ResultSet result = await session.ExecuteSqlAsync(request, settings);
         await session.CommitAsync(new CommitRequest(), null);


### PR DESCRIPTION
Fixes a couple of minor issues in the retry- and timeout sample:
1. Remove `DeadlineExceeded` as a retryable code, as the sample uses a single timeout will not retry on `DeadlineExceeded` anyways, meaning that the addition of that error code was just confusing.
2. Update the `maxBackoff` to 16 seconds. It was currently 6400ms, which was a typo, as all the other client libraries used 64s. That was also the value that was mentioned in the documentation page that imports this sample, meaning that there was a discrepancy between the documentation and the sample. We are setting this value to 16 seconds for all client libraries, as it makes the sample confusing when the max backoff is larger than the total timeout (60 seconds).

The documentation page that uses this sample is https://cloud.google.com/spanner/docs/custom-timeout-and-retry#c

Do not merge: Please hold off on merging until all the samples have been updated.