### PR TITLE
docs(pubsub): Add CreateCloudStorageSubscription sample

### DIFF
--- a/pubsub/api/Pubsub.Samples.Tests/CreateBigQuerySubscriptionTest.cs
+++ b/pubsub/api/Pubsub.Samples.Tests/CreateBigQuerySubscriptionTest.cs
@@ -36,8 +36,8 @@ public class CreateBigQuerySubscriptionTest
 
         _pubsubFixture.CreateTopic(topicId);
 
-        var subscription = _createBigQuerySubscriptionSample.CreateBigQuerySubscription(_pubsubFixture.ProjectId, topicId, subscriptionId, tablePath);
         _pubsubFixture.TempSubscriptionIds.Add(subscriptionId);
+        var subscription = _createBigQuerySubscriptionSample.CreateBigQuerySubscription(_pubsubFixture.ProjectId, topicId, subscriptionId, tablePath);
 
         Assert.Equal(subscription.BigqueryConfig.Table, tablePath);
     }

--- a/pubsub/api/Pubsub.Samples.Tests/CreateCloudStorageSubscriptionTest.cs
+++ b/pubsub/api/Pubsub.Samples.Tests/CreateCloudStorageSubscriptionTest.cs
@@ -1,0 +1,46 @@
+// Copyright 2024 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Xunit;
+
+[Collection(nameof(PubsubFixture))]
+public class CreateCloudStorageSubscriptionTest
+{
+    private readonly PubsubFixture _pubsubFixture;
+    private readonly CreateCloudStorageSubscriptionSample _createCloudStorageSubscriptionSample;
+
+    public CreateCloudStorageSubscriptionTest(PubsubFixture pubsubFixture)
+    {
+        _pubsubFixture = pubsubFixture;
+        _createCloudStorageSubscriptionSample = new CreateCloudStorageSubscriptionSample();
+    }
+
+    [Fact]
+    public void TestCreateCloudStorageSubscription()
+    {
+        string randomName = _pubsubFixture.RandomName().Replace("-", "_");
+        string topicId = $"testTopicForCreateCloudStorageSubscription{randomName}";
+        string subscriptionId = $"testSubscriptionForCreateCloudStorageSubscription{randomName}";
+        string bucket = _pubsubFixture.CloudStorageBucketName;
+
+        _pubsubFixture.CreateTopic(topicId);
+
+        _pubsubFixture.TempSubscriptionIds.Add(subscriptionId);
+        var subscription = _createCloudStorageSubscriptionSample.CreateCloudStorageSubscription(
+            _pubsubFixture.ProjectId, topicId, subscriptionId, bucket, "prefix", "suffix", TimeSpan.FromMinutes(5));
+
+        Assert.Equal(subscription.CloudStorageConfig.Bucket, bucket);
+    }
+}

--- a/pubsub/api/Pubsub.Samples.Tests/CreatePushSubscriptionTest.cs
+++ b/pubsub/api/Pubsub.Samples.Tests/CreatePushSubscriptionTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Google Inc.
+// Copyright 2020 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ public class CreatePushSubscriptionTest
 {
     private readonly PubsubFixture _pubsubFixture;
     private readonly CreatePushSubscriptionSample _createPushSubscriptionSample;
-    private ListSubscriptionsSample _listSubscriptionsSample;
+    private readonly ListSubscriptionsSample _listSubscriptionsSample;
 
     public CreatePushSubscriptionTest(PubsubFixture pubsubFixture)
     {

--- a/pubsub/api/Pubsub.Samples.Tests/UpdatePushConfigurationTest.cs
+++ b/pubsub/api/Pubsub.Samples.Tests/UpdatePushConfigurationTest.cs
@@ -19,8 +19,8 @@ public class UpdatePushConfigurationTest
 {
     private readonly PubsubFixture _pubsubFixture;
     private readonly CreatePushSubscriptionSample _createPushSubscriptionSample;
-    private UpdatePushConfigurationSample _updatePushConfigurationSample;
-    private ListSubscriptionsSample _listSubscriptionsSample;
+    private readonly UpdatePushConfigurationSample _updatePushConfigurationSample;
+    private readonly ListSubscriptionsSample _listSubscriptionsSample;
 
     public UpdatePushConfigurationTest(PubsubFixture pubsubFixture)
     {

--- a/pubsub/api/Pubsub.Samples/CreateBigQuerySubscription.cs
+++ b/pubsub/api/Pubsub.Samples/CreateBigQuerySubscription.cs
@@ -24,15 +24,13 @@ public class CreateBigQuerySubscriptionSample
         TopicName topicName = TopicName.FromProjectTopic(projectId, topicId);
         SubscriptionName subscriptionName = SubscriptionName.FromProjectSubscription(projectId, subscriptionId);
 
-        BigQueryConfig bigqueryConfig = new BigQueryConfig { Table = bigqueryTableId };
-
         var subscriptionRequest = new Subscription
         {
             SubscriptionName = subscriptionName,
             TopicAsTopicName = topicName,
             BigqueryConfig = new BigQueryConfig
             {
-              Table = bigqueryTableId
+                Table = bigqueryTableId
             }
         };
         var subscription = subscriber.CreateSubscription(subscriptionRequest);

--- a/pubsub/api/Pubsub.Samples/CreateCloudStorageSubscription.cs
+++ b/pubsub/api/Pubsub.Samples/CreateCloudStorageSubscription.cs
@@ -1,0 +1,46 @@
+// Copyright 2024 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START pubsub_create_cloud_storage_subscription]
+
+using Google.Cloud.PubSub.V1;
+using Google.Protobuf.WellKnownTypes;
+using System;
+
+public class CreateCloudStorageSubscriptionSample
+{
+    public Subscription CreateCloudStorageSubscription(string projectId, string topicId, string subscriptionId,
+        string bucket, string filenamePrefix, string filenameSuffix, TimeSpan maxDuration)
+    {
+        SubscriberServiceApiClient subscriber = SubscriberServiceApiClient.Create();
+        TopicName topicName = TopicName.FromProjectTopic(projectId, topicId);
+        SubscriptionName subscriptionName = SubscriptionName.FromProjectSubscription(projectId, subscriptionId);
+
+        var subscriptionRequest = new Subscription
+        {
+            SubscriptionName = subscriptionName,
+            TopicAsTopicName = topicName,
+            CloudStorageConfig = new CloudStorageConfig
+            {
+                Bucket = bucket,
+                FilenamePrefix = filenamePrefix,
+                FilenameSuffix = filenameSuffix,
+                MaxDuration = Duration.FromTimeSpan(maxDuration)
+            }
+        };
+        var subscription = subscriber.CreateSubscription(subscriptionRequest);
+        return subscription;
+    }
+}
+// [END pubsub_create_cloud_storage_subscription]


### PR DESCRIPTION
First commit is just tidy-up.

Currently the test fails due to permissions ("Cloud Pub/Sub did not have the necessary permissions configured to access the provided bucket [...]") - but so does the BigQuery test (in a different way).

I thought I'd create the PR to get feedback on whether this is the right approach and I should add an IAM call to grant permission for the Pub/Sub service account to the bucket, or something else.