### PR TITLE
Fix failing InspectImage test from issue #2511

### DIFF
--- a/dlp/api/Snippets.Tests/InspectImagesForSensitiveDataWithInfoTypesTests.cs
+++ b/dlp/api/Snippets.Tests/InspectImagesForSensitiveDataWithInfoTypesTests.cs
@@ -28,6 +28,9 @@ namespace GoogleCloudSamples
             var input = Path.Combine(_fixture.ResourcePath, "test.png");
             var result = InspectImageForSensitiveDataWithInfoTypes.InspectImage(_fixture.ProjectId, input);
             Assert.Equal(3, result.Result.Findings.Count);
+            Assert.Contains(result.Result.Findings, f => f.InfoType.Name == "PHONE_NUMBER" && f.Quote == "223-456-7890");
+            Assert.Contains(result.Result.Findings, f => f.InfoType.Name == "EMAIL_ADDRESS" && f.Quote == "gary@somedomain.com");
+            Assert.Contains(result.Result.Findings, f => f.InfoType.Name == "PERSON_NAME" && f.Quote == "gary");
         }
     }
 }

--- a/dlp/api/Snippets.Tests/runTest.ps1
+++ b/dlp/api/Snippets.Tests/runTest.ps1
@@ -13,7 +13,7 @@
 # the License.
 import-module -DisableNameChecking ..\..\..\BuildTools.psm1
 
-Set-TestTimeout 1800
+Set-TestTimeout 2100
 
 dotnet restore --force
 dotnet test --no-restore --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }

--- a/dlp/api/Snippets.Tests/runTest.ps1
+++ b/dlp/api/Snippets.Tests/runTest.ps1
@@ -13,7 +13,7 @@
 # the License.
 import-module -DisableNameChecking ..\..\..\BuildTools.psm1
 
-Set-TestTimeout 2100
+Set-TestTimeout 1800
 
 dotnet restore --force
 dotnet test --no-restore --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }

--- a/dlp/api/Snippets/InspectImageForSensitiveDataWithInfoTypes.cs
+++ b/dlp/api/Snippets/InspectImageForSensitiveDataWithInfoTypes.cs
@@ -44,7 +44,17 @@ public class InspectImageForSensitiveDataWithInfoTypes
         var request = new InspectContentRequest
         {
             ParentAsLocationName = new LocationName(projectId, "global"),
-            Item = contentItem
+            Item = contentItem,
+            InspectConfig = new InspectConfig
+            {
+                IncludeQuote = true,
+                InfoTypes =
+                    {
+                        new InfoType { Name = "PHONE_NUMBER" },
+                        new InfoType { Name = "EMAIL_ADDRESS" },
+                        new InfoType { Name = "PERSON_NAME" }
+                    }
+            }
         };
 
         // Call the API.
@@ -62,6 +72,7 @@ public class InspectImageForSensitiveDataWithInfoTypes
                        select new { b.Height, b.Width, b.Top, b.Left };
             Console.WriteLine("Info type: " + f.InfoType.Name);
             Console.WriteLine("\tImageLocations: " + string.Join(',', data));
+            Console.WriteLine("\tQuote: " + f.Quote);
             Console.WriteLine("\tLikelihood: " + f.Likelihood + "\n");
         }
 


### PR DESCRIPTION
Test as written was somewhat flaky, verifying only on the number of findings. Location detector gave an unlikely but valid additional finding which increased the response finding count. 

Fixed by setting specific InfoTypes to search for (thus ignoring unlikely fringe findings) and updating test assertions.