### PR TITLE
build[Spanner]: Update Google.Cloud.Spanner.Data dependencies

### DIFF
--- a/spanner/api/QuickStart/QuickStart.csproj
+++ b/spanner/api/QuickStart/QuickStart.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Spanner.Data" Version="4.6.0" />
+    <PackageReference Include="Google.Cloud.Spanner.Data" Version="5.0.0-beta02" />
   </ItemGroup>
 
 </Project>

--- a/spanner/api/Spanner.Samples.Tests/TransactionTagAsyncTest.cs
+++ b/spanner/api/Spanner.Samples.Tests/TransactionTagAsyncTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2021 Google Inc.
+// Copyright 2021 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,8 +29,9 @@ public class TransactionTagAsyncTest
     public async Task TestTransactionTagAsync()
     {
         var sample = new TransactionTagAsyncSample();
-        var insertCount = await sample.TransactionTagAsync(_spannerFixture.ProjectId, _spannerFixture.InstanceId,
+        var modifiedCount = await sample.TransactionTagAsync(_spannerFixture.ProjectId, _spannerFixture.InstanceId,
             _spannerFixture.DatabaseId);
-        Assert.Equal(1, insertCount);
+        // At least a row has been modified and a few may have been updated.
+        Assert.InRange(modifiedCount, 1, int.MaxValue);
     }
 }

--- a/spanner/api/Spanner.Samples/Spanner.Samples.csproj
+++ b/spanner/api/Spanner.Samples/Spanner.Samples.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Spanner.Data" Version="4.6.0" />
+    <PackageReference Include="Google.Cloud.Spanner.Data" Version="5.0.0-beta02" />
   </ItemGroup>
 
 </Project>

--- a/spanner/api/Spanner.Samples/TransactionTagAsync.cs
+++ b/spanner/api/Spanner.Samples/TransactionTagAsync.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2021 Google Inc.
+// Copyright 2021 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,7 +37,8 @@ public class TransactionTagAsyncSample
             var updateCommand =
                 connection.CreateDmlCommand("UPDATE Venues SET Capacity = DIV(Capacity, 4) WHERE OutdoorVenue = false");
             updateCommand.Tag = "app=concert,env=dev,action=update";
-            await updateCommand.ExecuteNonQueryAsync();
+            updateCommand.Transaction = transaction;
+            int rowsModified = await updateCommand.ExecuteNonQueryAsync();
 
             var insertCommand = connection.CreateDmlCommand(
                 @"INSERT INTO Venues (VenueId, VenueName, Capacity, OutdoorVenue, LastUpdateTime)
@@ -53,7 +54,9 @@ public class TransactionTagAsyncSample
             // Sets the request tag to "app=concert,env=dev,action=insert".
             // This request tag will only be set on this request.
             insertCommand.Tag = "app=concert,env=dev,action=insert";
-            return await insertCommand.ExecuteNonQueryAsync();
+            insertCommand.Transaction = transaction;
+            rowsModified += await insertCommand.ExecuteNonQueryAsync();
+            return rowsModified;
         });
     }
 }


### PR DESCRIPTION
And fix a sample that was not using the intended transaction. Caught because of transaction inlining.