### PR TITLE
feat: Use an appropriate CancellationToken in all Functions Frameworks samples

### DIFF
--- a/functions/concepts/EnvironmentVariables/Function.cs
+++ b/functions/concepts/EnvironmentVariables/Function.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ public class Function : IHttpFunction
     {
         string foo = Environment.GetEnvironmentVariable("FOO")
             ?? "Specified environment variable is not set.";
-        await context.Response.WriteAsync(foo);
+        await context.Response.WriteAsync(foo, context.RequestAborted);
     }
 }
 // [END functions_env_vars]

--- a/functions/concepts/ExecutionCount/Function.cs
+++ b/functions/concepts/ExecutionCount/Function.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ public class Function : IHttpFunction
         // Note: the total function invocation count across
         // all servers may not be equal to this value!
         int currentCount = Interlocked.Increment(ref _count);
-        await context.Response.WriteAsync($"Server execution count: {currentCount}");
+        await context.Response.WriteAsync($"Server execution count: {currentCount}", context.RequestAborted);
     }
 }
 // [END functions_concepts_stateless]

--- a/functions/concepts/FileSystem/Function.cs
+++ b/functions/concepts/FileSystem/Function.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,10 +26,10 @@ public class Function : IHttpFunction
     {
         string[] files = Directory.GetFiles(".");
 
-        await context.Response.WriteAsync("Files:\n");
+        await context.Response.WriteAsync("Files:\n", context.RequestAborted);
         foreach (string file in files)
         {
-            await context.Response.WriteAsync($"\t{file}\n");
+            await context.Response.WriteAsync($"\t{file}\n", context.RequestAborted);
         }
     }
 }

--- a/functions/concepts/LazyFields/Function.cs
+++ b/functions/concepts/LazyFields/Function.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,8 @@ public class Function : IHttpFunction
         // and others that don't. The computation is only performed when necessary, and
         // only once per server.
         await context.Response.WriteAsync(
-            $"Lazy global: {LazyGlobal.Value}; non-lazy global: {NonLazyGlobal}");
+            $"Lazy global: {LazyGlobal.Value}; non-lazy global: {NonLazyGlobal}",
+            context.RequestAborted);
     }
 
     private static int FunctionSpecificComputation()

--- a/functions/concepts/Scopes/Function.cs
+++ b/functions/concepts/Scopes/Function.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,7 +37,9 @@ public class Function : IHttpFunction
         // This computation runs every time this function is called.
         int functionVariable = LightComputation();
 
-        await context.Response.WriteAsync($"Global: {GlobalVariable}; function: {functionVariable}");
+        await context.Response.WriteAsync(
+            $"Global: {GlobalVariable}; function: {functionVariable}",
+            context.RequestAborted);
     }
 
     private static int LightComputation()

--- a/functions/firebase/FirestoreReactive/Function.cs
+++ b/functions/firebase/FirestoreReactive/Function.cs
@@ -76,7 +76,7 @@ public class Function : ICloudEventFunction<DocumentEventData>
         string documentPath = cloudEvent.Subject.Substring("documents/".Length);
 
         _logger.LogInformation("Replacing '{current}' with '{new}' in '{path}'", currentValue, newValue, documentPath);
-        await _firestoreDb.Document(documentPath).UpdateAsync("original", newValue);
+        await _firestoreDb.Document(documentPath).UpdateAsync("original", newValue, cancellationToken: cancellationToken);
     }
 }
 // [END functions_firebase_reactive]

--- a/functions/helloworld/HelloHttp/Function.cs
+++ b/functions/helloworld/HelloHttp/Function.cs
@@ -59,7 +59,7 @@ public class Function : IHttpFunction
             }
         }
 
-        await context.Response.WriteAsync($"Hello {name}!");
+        await context.Response.WriteAsync($"Hello {name}!", context.RequestAborted);
     }
 }
 // [END functions_helloworld_http]

--- a/functions/helloworld/HelloWorld/Function.cs
+++ b/functions/helloworld/HelloWorld/Function.cs
@@ -23,7 +23,7 @@ public class Function : IHttpFunction
 {
     public async Task HandleAsync(HttpContext context)
     {
-        await context.Response.WriteAsync("Hello World!");
+        await context.Response.WriteAsync("Hello World!", context.RequestAborted);
     }
 }
 // [END functions_helloworld_get]

--- a/functions/http/Cors/Function.cs
+++ b/functions/http/Cors/Function.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ public class Function : IHttpFunction
             return;
         }
 
-        await response.WriteAsync("CORS headers set successfully!");
+        await response.WriteAsync("CORS headers set successfully!", context.RequestAborted);
     }
 }
 // [END functions_http_cors]

--- a/functions/http/HttpFormData/Function.cs
+++ b/functions/http/HttpFormData/Function.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ public class Function : IHttpFunction
             // Persistent files should be stored elsewhere, e.g. a Cloud Storage bucket.
             using (FileStream output = File.Create(outputPath))
             {
-                await file.CopyToAsync(output);
+                await file.CopyToAsync(output, context.RequestAborted);
             }
 
             // TODO(developer): process saved files here

--- a/functions/http/HttpRequestMethod/Function.cs
+++ b/functions/http/HttpRequestMethod/Function.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,15 +29,15 @@ public class Function : IHttpFunction
         {
             case "GET":
                 response.StatusCode = (int) HttpStatusCode.OK;
-                await response.WriteAsync("Hello world!");
+                await response.WriteAsync("Hello world!", context.RequestAborted);
                 break;
             case "PUT":
                 response.StatusCode = (int) HttpStatusCode.Forbidden;
-                await response.WriteAsync("Forbidden!");
+                await response.WriteAsync("Forbidden!", context.RequestAborted);
                 break;
             default:
                 response.StatusCode = (int) HttpStatusCode.MethodNotAllowed;
-                await response.WriteAsync("Something blew up!");
+                await response.WriteAsync("Something blew up!", context.RequestAborted);
                 break;
         }
     }

--- a/functions/http/ParseContentType/Function.cs
+++ b/functions/http/ParseContentType/Function.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -78,7 +78,7 @@ public class Function : IHttpFunction
         }
         if (name is object)
         {
-            await response.WriteAsync($"Hello {name}!");
+            await response.WriteAsync($"Hello {name}!", context.RequestAborted);
         }
         else
         {

--- a/functions/http/SendHttpRequest/Function.cs
+++ b/functions/http/SendHttpRequest/Function.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -49,9 +49,11 @@ public class Function : IHttpFunction
     public async Task HandleAsync(HttpContext context)
     {
         string url = "http://example.com";
-        using (HttpResponseMessage clientResponse = await _httpClient.GetAsync(url))
+        using (HttpResponseMessage clientResponse = await _httpClient.GetAsync(url, context.RequestAborted))
         {
-            await context.Response.WriteAsync($"Received code '{(int) clientResponse.StatusCode}' from URL '{url}'.");
+            await context.Response.WriteAsync(
+                $"Received code '{(int) clientResponse.StatusCode}' from URL '{url}'.",
+                context.RequestAborted);
         }
     }
 }

--- a/functions/logging/LogHelloWorld/Function.cs
+++ b/functions/logging/LogHelloWorld/Function.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ public class Function : IHttpFunction
         _logger.LogInformation("I am an info log!");
         _logger.LogWarning("I am a warning log!");
 
-        await context.Response.WriteAsync("Messages successfully logged!");
+        await context.Response.WriteAsync("Messages successfully logged!", context.RequestAborted);
     }
 }
 // [END functions_log_helloworld]

--- a/functions/responsestreaming/StreamBigQuery/Function.cs
+++ b/functions/responsestreaming/StreamBigQuery/Function.cs
@@ -33,12 +33,12 @@ public class Function : IHttpFunction
         // Example to retrieve a large payload from BigQuery public dataset.
         string query = "SELECT title FROM `bigquery-public-data.breathe.bioasq` LIMIT 1000";
         BigQueryParameter[] parameters = null;
-        BigQueryResults results = client.ExecuteQuery(query, parameters);
+        BigQueryResults results = await client.ExecuteQueryAsync(query, parameters, cancellationToken: context.RequestAborted);
 
         // Stream out the payload response by iterating rows.
         foreach (BigQueryRow row in results)
         {
-            await context.Response.WriteAsync($"{row["title"]}\n");
+            await context.Response.WriteAsync($"{row["title"]}\n", context.RequestAborted);
             // Artificially add a 50ms delay per line, just to make the streaming nature clearer
             // when viewing the results in a browser.
             await Task.Delay(50);


### PR DESCRIPTION
There are a few samples that use StreamReader or TextReader to read the request, and ReadLineAsync / ReadToEndAsync don't accept cancellation tokens in .NET 6; we should update those if and when we update the samples to .NET 8.