### PR TITLE
ci: Add AIPlatform projects to the existing solution

### DIFF
--- a/aiplatform/api/AIPlatform.Samples.Tests/AIPlatform.Samples.Tests.csproj
+++ b/aiplatform/api/AIPlatform.Samples.Tests/AIPlatform.Samples.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/aiplatform/api/AIPlatform.Samples/AIPlatform.Samples.csproj
+++ b/aiplatform/api/AIPlatform.Samples/AIPlatform.Samples.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/aiplatform/api/AIPlatform.sln
+++ b/aiplatform/api/AIPlatform.sln
@@ -3,10 +3,24 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AIPlatform.Samples", "AIPlatform.Samples\AIPlatform.Samples.csproj", "{F81A3363-A9B1-4319-AB7E-A637F1227502}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AIPlatform.Samples.Tests", "AIPlatform.Samples.Tests\AIPlatform.Samples.Tests.csproj", "{A37C568B-169E-4BDA-A465-92FA0D082BEA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F81A3363-A9B1-4319-AB7E-A637F1227502}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F81A3363-A9B1-4319-AB7E-A637F1227502}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F81A3363-A9B1-4319-AB7E-A637F1227502}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F81A3363-A9B1-4319-AB7E-A637F1227502}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A37C568B-169E-4BDA-A465-92FA0D082BEA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A37C568B-169E-4BDA-A465-92FA0D082BEA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A37C568B-169E-4BDA-A465-92FA0D082BEA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A37C568B-169E-4BDA-A465-92FA0D082BEA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This is so the test script can pick up the projects to restore and run tests from.

Also, upgrading to .NET 8