### PR TITLE
chore: Stop automatic upgrade of some samples to .NET 8

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,11 +8,28 @@
     ],
     "packageRules": [
         {
+            "ignorePaths": [
+                "appengine/flexible/**",
+                "run/**",
+                "applications/clouddemo/netcore/**"
+            ],
             "matchPackagePrefixes": [
                 "Microsoft.AspNetCore.",
                 "mcr.microsoft.com/dotnet/"
             ],
             "allowedVersions": "<9.0.0"
+        },
+        {
+            "includePaths": [
+                "appengine/flexible/**",
+                "run/**",
+                "applications/clouddemo/netcore/**"
+            ],
+            "matchPackagePrefixes": [
+                "Microsoft.AspNetCore.",
+                "mcr.microsoft.com/dotnet/"
+            ],
+            "allowedVersions": "<7.0.0"
         }
     ],
     "schedule": [


### PR DESCRIPTION
For these, we need to confirm that the environments they are meant for support .NET 8 and documentation needs to be updated also.