### PR TITLE
build[Functions]: Make ResponseStreaming test target .NET 6

### DIFF
--- a/functions/responsestreaming/StreamBigQuery.Tests/StreamBigQuery.Tests.csproj
+++ b/functions/responsestreaming/StreamBigQuery.Tests/StreamBigQuery.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
This will be upgraded to .NET 8 in #2729 but there are still some documentation aspects that need to be cleared out before that can be merged.

And this sample has been failing since we updated CI to support .NET 6 and .NET 8 only.