### PR TITLE
docs(generativeai): add region tags for code samples

### DIFF
--- a/aiplatform/api/AIPlatform.Samples/GeminiQuickstart.cs
+++ b/aiplatform/api/AIPlatform.Samples/GeminiQuickstart.cs
@@ -16,6 +16,7 @@
 
 // [START generativeaionvertexai_gemini_image]
 // [START aiplatform_gemini_get_started]
+// [START generativeaionvertexai_gemini_get_started]
 
 using Google.Api.Gax.Grpc;
 using Google.Cloud.AIPlatform.V1;
@@ -79,4 +80,5 @@ public class GeminiQuickstart
 }
 
 // [END aiplatform_gemini_get_started]
+// [END generativeaionvertexai_gemini_get_started]
 // [END generativeaionvertexai_gemini_image]

--- a/aiplatform/api/AIPlatform.Samples/PredictChatPromptSample.cs
+++ b/aiplatform/api/AIPlatform.Samples/PredictChatPromptSample.cs
@@ -15,6 +15,7 @@
  */
 
 // [START aiplatform_sdk_chat]
+// [START generativeaionvertexai_sdk_chat]
 
 using Google.Cloud.AIPlatform.V1;
 using Newtonsoft.Json;
@@ -95,3 +96,4 @@ public class PredictChatPromptSample
 }
 
 // [END aiplatform_sdk_chat]
+// [END generativeaionvertexai_sdk_chat]

--- a/aiplatform/api/AIPlatform.Samples/PredictTextPrompt.cs
+++ b/aiplatform/api/AIPlatform.Samples/PredictTextPrompt.cs
@@ -15,6 +15,7 @@
  */
 
 // [START aiplatform_sdk_ideation]
+// [START generativeaionvertexai_sdk_ideation]
 
 using Google.Cloud.AIPlatform.V1;
 using System;
@@ -80,3 +81,4 @@ public class PredictTextPromptSample
 }
 
 // [END aiplatform_sdk_ideation]
+// [END generativeaionvertexai_sdk_ideation]


### PR DESCRIPTION
No code changes. 

Adding `generativeaionvertexai_` region tags to replace old `aiplatform_`

In near future GenAI code samples, will only use `generativeaionvertexai_` region tag prefix.