### PR TITLE
chore: cleanup unused region tags

### DIFF
--- a/aiplatform/api/AIPlatform.Samples/GeminiQuickstart.cs
+++ b/aiplatform/api/AIPlatform.Samples/GeminiQuickstart.cs
@@ -15,7 +15,6 @@
  */
 
 // [START generativeaionvertexai_gemini_image]
-// [START aiplatform_gemini_get_started]
 
 using Google.Api.Gax.Grpc;
 using Google.Cloud.AIPlatform.V1;
@@ -78,5 +77,4 @@ public class GeminiQuickstart
     }
 }
 
-// [END aiplatform_gemini_get_started]
 // [END generativeaionvertexai_gemini_image]

--- a/aiplatform/api/AIPlatform.Samples/MultiTurnChatSample.cs
+++ b/aiplatform/api/AIPlatform.Samples/MultiTurnChatSample.cs
@@ -15,7 +15,6 @@
  */
 
 // [START generativeaionvertexai_gemini_multiturn_chat]
-// [START aiplatform_gemini_multiturn_chat]
 
 using Google.Cloud.AIPlatform.V1;
 using System;
@@ -110,5 +109,4 @@ public class MultiTurnChatSample
     }
 }
 
-// [END aiplatform_gemini_multiturn_chat]
 // [END generativeaionvertexai_gemini_multiturn_chat]

--- a/aiplatform/api/AIPlatform.Samples/MultimodalMultiImage.cs
+++ b/aiplatform/api/AIPlatform.Samples/MultimodalMultiImage.cs
@@ -15,7 +15,6 @@
  */
 
 // [START generativeaionvertexai_gemini_single_turn_multi_image]
-// [START aiplatform_gemini_single_turn_multi_image]
 
 using Google.Api.Gax.Grpc;
 using Google.Cloud.AIPlatform.V1;
@@ -88,5 +87,4 @@ public class MultimodalMultiImage
     }
 }
 
-// [END aiplatform_gemini_single_turn_multi_image]
 // [END generativeaionvertexai_gemini_single_turn_multi_image]

--- a/aiplatform/api/AIPlatform.Samples/MultimodalVideoInput.cs
+++ b/aiplatform/api/AIPlatform.Samples/MultimodalVideoInput.cs
@@ -15,7 +15,6 @@
  */
 
 // [START generativeaionvertexai_gemini_single_turn_video]
-// [START aiplatform_gemini_single_turn_video]
 
 using Google.Api.Gax.Grpc;
 using Google.Cloud.AIPlatform.V1;
@@ -66,5 +65,4 @@ public class MultimodalVideoInput
     }
 }
 
-// [END aiplatform_gemini_single_turn_video]
 // [END generativeaionvertexai_gemini_single_turn_video]

--- a/aiplatform/api/AIPlatform.Samples/WithSafetySettings.cs
+++ b/aiplatform/api/AIPlatform.Samples/WithSafetySettings.cs
@@ -15,7 +15,6 @@
  */
 
 // [START generativeaionvertexai_gemini_safety_settings]
-// [START aiplatform_gemini_safety_settings]
 
 using Google.Api.Gax.Grpc;
 using Google.Cloud.AIPlatform.V1;
@@ -90,5 +89,4 @@ public class WithSafetySettings
     }
 }
 
-// [END aiplatform_gemini_safety_settings]
 // [END generativeaionvertexai_gemini_safety_settings]


### PR DESCRIPTION
Adding `generativeaionvertexai_` region tags to replace old `aiplatform_`

In near future GenAI code samples, will only use `generativeaionvertexai_` region tag prefix.