### PR TITLE
chore: Revert to Google.Cloud.Spanner.Data version 5.0.0-beta03

### DIFF
--- a/spanner/api/Spanner.Samples.Tests/Spanner.Samples.Tests.csproj
+++ b/spanner/api/Spanner.Samples.Tests/Spanner.Samples.Tests.csproj
@@ -3,8 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <!-- Update samples and restore this to true when 5.0.0 is released. See b/360755482 -->
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/spanner/api/Spanner.Samples/Spanner.Samples.csproj
+++ b/spanner/api/Spanner.Samples/Spanner.Samples.csproj
@@ -2,11 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <!-- Update samples and restore this to true when 5.0.0 is released. See b/360755482 -->
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Spanner.Data" Version="5.0.0-beta04" />
+    <PackageReference Include="Google.Cloud.Spanner.Data" Version="5.0.0-beta03" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Assuming we want the samples to refer to GA library versions, we won't be able to update the dependency until 5.0.0 has been released.