### PR TITLE
feat(Spanner): Add samples for Cloud Spanner Scheduled Backups

### DIFF
--- a/spanner/api/Spanner.Samples.Tests/CreateFullBackupScheduleTest.cs
+++ b/spanner/api/Spanner.Samples.Tests/CreateFullBackupScheduleTest.cs
@@ -1,0 +1,35 @@
+// Copyright 2024 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+
+[Collection(nameof(SpannerFixture))]
+public class CreateFullBackupScheduleTest
+{
+    private readonly SpannerFixture _spannerFixture;
+
+    public CreateFullBackupScheduleTest(SpannerFixture spannerFixture) => _spannerFixture = spannerFixture;
+
+    [Fact]
+    public void TestCreateFullBackupSchedule()
+    {
+        var scheduleId = SpannerFixture.GenerateId("schedule-");
+        var sample = new CreateFullBackupScheduleSample();
+        var schedule = sample.CreateFullBackupSchedule(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.DatabaseId, scheduleId);
+        Assert.NotNull(schedule);
+
+        new DeleteBackupScheduleSample()
+            .DeleteBackupSchedule(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.DatabaseId, scheduleId);
+    }
+}

--- a/spanner/api/Spanner.Samples.Tests/CreateIncrementalBackupScheduleTest.cs
+++ b/spanner/api/Spanner.Samples.Tests/CreateIncrementalBackupScheduleTest.cs
@@ -1,0 +1,35 @@
+// Copyright 2024 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+
+[Collection(nameof(SpannerFixture))]
+public class CreateIncrementalBackupScheduleTest
+{
+    private readonly SpannerFixture _spannerFixture;
+
+    public CreateIncrementalBackupScheduleTest(SpannerFixture spannerFixture) => _spannerFixture = spannerFixture;
+
+    [Fact]
+    public void TestCreateIncrementalBackupSchedule()
+    {
+        var scheduleId = SpannerFixture.GenerateId("schedule-");
+        var sample = new CreateIncrementalBackupScheduleSample();
+        var schedule = sample.CreateIncrementalBackupSchedule(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.DatabaseId, scheduleId);
+        Assert.NotNull(schedule);
+
+        new DeleteBackupScheduleSample()
+            .DeleteBackupSchedule(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.DatabaseId, scheduleId);
+    }
+}

--- a/spanner/api/Spanner.Samples.Tests/DeleteBackupScheduleTest.cs
+++ b/spanner/api/Spanner.Samples.Tests/DeleteBackupScheduleTest.cs
@@ -1,0 +1,36 @@
+// Copyright 2024 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+
+[Collection(nameof(SpannerFixture))]
+public class DeleteBackupScheduleTest
+{
+    private readonly SpannerFixture _spannerFixture;
+
+    public DeleteBackupScheduleTest(SpannerFixture spannerFixture) => _spannerFixture = spannerFixture;
+
+    [Fact]
+    public void TestDeleteBackupSchedule()
+    {
+        var scheduleId = SpannerFixture.GenerateId("schedule-");
+        Assert.NotNull(
+            new CreateFullBackupScheduleSample()
+                .CreateFullBackupSchedule(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.DatabaseId, scheduleId)
+        );
+
+        var sample = new DeleteBackupScheduleSample();
+        sample.DeleteBackupSchedule(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.DatabaseId, scheduleId);
+    }
+}

--- a/spanner/api/Spanner.Samples.Tests/GetBackupScheduleTest.cs
+++ b/spanner/api/Spanner.Samples.Tests/GetBackupScheduleTest.cs
@@ -1,0 +1,40 @@
+// Copyright 2024 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+
+[Collection(nameof(SpannerFixture))]
+public class GetBackupScheduleTest
+{
+    private readonly SpannerFixture _spannerFixture;
+
+    public GetBackupScheduleTest(SpannerFixture spannerFixture) => _spannerFixture = spannerFixture;
+
+    [Fact]
+    public void TestGetBackupSchedule()
+    {
+        var scheduleId = SpannerFixture.GenerateId("schedule-");
+        Assert.NotNull(
+            new CreateFullBackupScheduleSample()
+                .CreateFullBackupSchedule(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.DatabaseId, scheduleId)
+        );
+
+        var sample = new GetBackupScheduleSample();
+        var schedule = sample.GetBackupSchedule(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.DatabaseId, scheduleId);
+        Assert.NotNull(schedule);
+
+        new DeleteBackupScheduleSample()
+            .DeleteBackupSchedule(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.DatabaseId, scheduleId);
+    }
+}

--- a/spanner/api/Spanner.Samples.Tests/ListBackupSchedulesTest.cs
+++ b/spanner/api/Spanner.Samples.Tests/ListBackupSchedulesTest.cs
@@ -1,0 +1,41 @@
+// Copyright 2024 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+
+[Collection(nameof(SpannerFixture))]
+public class ListBackupSchedulesTest
+{
+    private readonly SpannerFixture _spannerFixture;
+
+    public ListBackupSchedulesTest(SpannerFixture spannerFixture) => _spannerFixture = spannerFixture;
+
+    [Fact]
+    public void TestListBackupSchedules()
+    {
+        var scheduleId = SpannerFixture.GenerateId("schedule-");
+        Assert.NotNull(
+            new CreateFullBackupScheduleSample()
+                .CreateFullBackupSchedule(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.DatabaseId, scheduleId)
+        );
+
+        var sample = new ListBackupSchedulesSample();
+        var schedules = sample.ListBackupSchedules(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.DatabaseId);
+        Assert.NotNull(schedules);
+        Assert.NotEmpty(schedules);
+
+        new DeleteBackupScheduleSample()
+            .DeleteBackupSchedule(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.DatabaseId, scheduleId);
+    }
+}

--- a/spanner/api/Spanner.Samples.Tests/UpdateBackupScheduleTest.cs
+++ b/spanner/api/Spanner.Samples.Tests/UpdateBackupScheduleTest.cs
@@ -1,0 +1,40 @@
+// Copyright 2024 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+
+[Collection(nameof(SpannerFixture))]
+public class UpdateBackupScheduleTest
+{
+    private readonly SpannerFixture _spannerFixture;
+
+    public UpdateBackupScheduleTest(SpannerFixture spannerFixture) => _spannerFixture = spannerFixture;
+
+    [Fact]
+    public void TestUpdateBackupSchedule()
+    {
+        var scheduleId = SpannerFixture.GenerateId("schedule-");
+        Assert.NotNull(
+            new CreateFullBackupScheduleSample()
+                .CreateFullBackupSchedule(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.DatabaseId, scheduleId)
+        );
+
+        var sample = new UpdateBackupScheduleSample();
+        var schedule = sample.UpdateBackupSchedule(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.DatabaseId, scheduleId);
+        Assert.NotNull(schedule);
+
+        new DeleteBackupScheduleSample()
+            .DeleteBackupSchedule(_spannerFixture.ProjectId, _spannerFixture.InstanceId, _spannerFixture.DatabaseId, scheduleId);
+    }
+}

--- a/spanner/api/Spanner.Samples/CreateFullBackupSchedule.cs
+++ b/spanner/api/Spanner.Samples/CreateFullBackupSchedule.cs
@@ -1,0 +1,57 @@
+// Copyright 2024 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START spanner_create_full_backup_schedule]
+using Google.Cloud.Spanner.Admin.Database.V1;
+using Google.Cloud.Spanner.Common.V1;
+using Google.Protobuf.WellKnownTypes;
+using System;
+
+public class CreateFullBackupScheduleSample
+{
+    public BackupSchedule CreateFullBackupSchedule(string projectId, string instanceId, string databaseId, string scheduleId)
+    {
+        DatabaseAdminClient client = DatabaseAdminClient.Create();
+
+        BackupSchedule response = client.CreateBackupSchedule(
+            new CreateBackupScheduleRequest
+            {
+                ParentAsDatabaseName = DatabaseName.FromProjectInstanceDatabase(projectId, instanceId, databaseId),
+                BackupScheduleId = scheduleId,
+                BackupSchedule = new BackupSchedule
+                {
+                    Spec = new BackupScheduleSpec
+                    {
+                        CronSpec = new CrontabSpec
+                        {
+                            Text = "30 12 * * *",
+                        }
+                    },
+                    RetentionDuration = new Duration
+                    {
+                        Seconds = 86400,
+                    },
+                    EncryptionConfig = new CreateBackupEncryptionConfig
+                    {
+                        EncryptionType = CreateBackupEncryptionConfig.Types.EncryptionType.UseDatabaseEncryption,
+                    },
+                    FullBackupSpec = new FullBackupSpec { },
+                }
+            });
+
+        Console.WriteLine($"Created full backup schedule: {response}");
+        return response;
+    }
+}
+// [END spanner_create_full_backup_schedule]

--- a/spanner/api/Spanner.Samples/CreateIncrementalBackupSchedule.cs
+++ b/spanner/api/Spanner.Samples/CreateIncrementalBackupSchedule.cs
@@ -1,0 +1,57 @@
+// Copyright 2024 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START spanner_create_incremental_backup_schedule]
+using Google.Cloud.Spanner.Admin.Database.V1;
+using Google.Cloud.Spanner.Common.V1;
+using Google.Protobuf.WellKnownTypes;
+using System;
+
+public class CreateIncrementalBackupScheduleSample
+{
+    public BackupSchedule CreateIncrementalBackupSchedule(string projectId, string instanceId, string databaseId, string scheduleId)
+    {
+        DatabaseAdminClient client = DatabaseAdminClient.Create();
+
+        BackupSchedule response = client.CreateBackupSchedule(
+            new CreateBackupScheduleRequest
+            {
+                ParentAsDatabaseName = DatabaseName.FromProjectInstanceDatabase(projectId, instanceId, databaseId),
+                BackupScheduleId = scheduleId,
+                BackupSchedule = new BackupSchedule
+                {
+                    Spec = new BackupScheduleSpec
+                    {
+                        CronSpec = new CrontabSpec
+                        {
+                            Text = "30 12 * * *",
+                        }
+                    },
+                    RetentionDuration = new Duration
+                    {
+                        Seconds = 86400,
+                    },
+                    EncryptionConfig = new CreateBackupEncryptionConfig
+                    {
+                        EncryptionType = CreateBackupEncryptionConfig.Types.EncryptionType.GoogleDefaultEncryption,
+                    },
+                    IncrementalBackupSpec = new IncrementalBackupSpec { },
+                }
+            });
+
+        Console.WriteLine($"Created incremental backup schedule: {response}");
+        return response;
+    }
+}
+// [END spanner_create_incremental_backup_schedule]

--- a/spanner/api/Spanner.Samples/DeleteBackupSchedule.cs
+++ b/spanner/api/Spanner.Samples/DeleteBackupSchedule.cs
@@ -1,0 +1,34 @@
+// Copyright 2024 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START spanner_delete_backup_schedule]
+using Google.Cloud.Spanner.Admin.Database.V1;
+using System;
+
+public class DeleteBackupScheduleSample
+{
+    public void DeleteBackupSchedule(string projectId, string instanceId, string databaseId, string scheduleId)
+    {
+        DatabaseAdminClient client = DatabaseAdminClient.Create();
+
+        client.DeleteBackupSchedule(
+            new DeleteBackupScheduleRequest
+            {
+                BackupScheduleName = BackupScheduleName.FromProjectInstanceDatabaseSchedule(projectId, instanceId, databaseId, scheduleId),
+            });
+
+        Console.WriteLine("Deleted backup schedule");
+    }
+}
+// [END spanner_delete_backup_schedule]

--- a/spanner/api/Spanner.Samples/GetBackupSchedule.cs
+++ b/spanner/api/Spanner.Samples/GetBackupSchedule.cs
@@ -1,0 +1,35 @@
+// Copyright 2024 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START spanner_get_backup_schedule]
+using Google.Cloud.Spanner.Admin.Database.V1;
+using System;
+
+public class GetBackupScheduleSample
+{
+    public BackupSchedule GetBackupSchedule(string projectId, string instanceId, string databaseId, string scheduleId)
+    {
+        DatabaseAdminClient client = DatabaseAdminClient.Create();
+
+        BackupSchedule response = client.GetBackupSchedule(
+            new GetBackupScheduleRequest
+            {
+                BackupScheduleName = BackupScheduleName.FromProjectInstanceDatabaseSchedule(projectId, instanceId, databaseId, scheduleId),
+            });
+
+        Console.WriteLine($"Backup schedule: {response}");
+        return response;
+    }
+}
+// [END spanner_get_backup_schedule]

--- a/spanner/api/Spanner.Samples/ListBackupSchedules.cs
+++ b/spanner/api/Spanner.Samples/ListBackupSchedules.cs
@@ -1,0 +1,40 @@
+// Copyright 2024 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START spanner_list_backup_schedules]
+using Google.Cloud.Spanner.Admin.Database.V1;
+using Google.Cloud.Spanner.Common.V1;
+using System;
+using System.Collections.Generic;
+
+public class ListBackupSchedulesSample
+{
+    public IEnumerable<BackupSchedule> ListBackupSchedules(string projectId, string instanceId, string databaseId)
+    {
+        DatabaseAdminClient client = DatabaseAdminClient.Create();
+
+        var backupSchedules = client.ListBackupSchedules(
+            new ListBackupSchedulesRequest
+            {
+                ParentAsDatabaseName = DatabaseName.FromProjectInstanceDatabase(projectId, instanceId, databaseId),
+            });
+
+        foreach (BackupSchedule backupSchedule in backupSchedules)
+        {
+            Console.WriteLine($"Backup schedule: {backupSchedule}");
+        }
+        return backupSchedules;
+    }
+}
+// [END spanner_list_backup_schedules]

--- a/spanner/api/Spanner.Samples/UpdateBackupSchedule.cs
+++ b/spanner/api/Spanner.Samples/UpdateBackupSchedule.cs
@@ -1,0 +1,58 @@
+// Copyright 2024 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START spanner_update_backup_schedule]
+using Google.Cloud.Spanner.Admin.Database.V1;
+using Google.Protobuf.WellKnownTypes;
+using System;
+
+public class UpdateBackupScheduleSample
+{
+    public BackupSchedule UpdateBackupSchedule(string projectId, string instanceId, string databaseId, string scheduleId)
+    {
+        DatabaseAdminClient client = DatabaseAdminClient.Create();
+
+        BackupSchedule response = client.UpdateBackupSchedule(
+            new UpdateBackupScheduleRequest
+            {
+                BackupSchedule = new BackupSchedule
+                {
+                    BackupScheduleName = BackupScheduleName.FromProjectInstanceDatabaseSchedule(projectId, instanceId, databaseId, scheduleId),
+                    Spec = new BackupScheduleSpec
+                    {
+                        CronSpec = new CrontabSpec
+                        {
+                            Text = "45 15 * * *",
+                        },
+                    },
+                    RetentionDuration = new Duration
+                    {
+                        Seconds = 172800,
+                    },
+                    EncryptionConfig = new CreateBackupEncryptionConfig
+                    {
+                        EncryptionType = CreateBackupEncryptionConfig.Types.EncryptionType.UseDatabaseEncryption,
+                    },
+                },
+                UpdateMask = new FieldMask
+                {
+                    Paths = { "spec.cron_spec.text", "retention_duration", "encryption_config" },
+                },
+            });
+
+        Console.WriteLine($"Updated backup schedule: {response}");
+        return response;
+    }
+}
+// [END spanner_update_backup_schedule]


### PR DESCRIPTION
This PR adds code samples for the following APIs:

1. CreateBackupSchedule (both full and incremental backup schedules)
2. ListBackupSchedules
3. GetBackupSchedule
4. UpdateBackupSchedule
5. DeleteBackupSchedule