### PR TITLE
chore(deps): update dependency google.cloud.spanner.data to v5.0.0-beta04

### DIFF
--- a/spanner/api/Spanner.Samples/BatchReadRecordsAsync.cs
+++ b/spanner/api/Spanner.Samples/BatchReadRecordsAsync.cs
@@ -30,7 +30,7 @@ public class BatchReadRecordsAsyncSample
         using var connection = new SpannerConnection(connectionString);
         await connection.OpenAsync();
 
-        using var transaction = await connection.BeginReadOnlyTransactionAsync();
+        using var transaction = await connection.BeginTransactionAsync(SpannerTransactionCreationOptions.ReadOnly.WithIsDetached(true), cancellationToken: default);
         transaction.DisposeBehavior = DisposeBehavior.CloseResources;
         using var cmd = connection.CreateSelectCommand("SELECT SingerId, FirstName, LastName FROM Singers");
         cmd.Transaction = transaction;
@@ -50,7 +50,7 @@ public class BatchReadRecordsAsyncSample
     {
         var localId = Interlocked.Increment(ref _partitionCount);
         using var connection = new SpannerConnection(id.ConnectionString);
-        using var transaction = connection.BeginReadOnlyTransaction(id);
+        using var transaction = await connection.BeginTransactionAsync(SpannerTransactionCreationOptions.FromReadOnlyTransactionId(id), cancellationToken: default);
         using var cmd = connection.CreateCommandWithPartition(readPartition, transaction);
         using var reader = await cmd.ExecuteReaderAsync();
         while (await reader.ReadAsync())

--- a/spanner/api/Spanner.Samples/QueryDataWithTransactionAsync.cs
+++ b/spanner/api/Spanner.Samples/QueryDataWithTransactionAsync.cs
@@ -39,7 +39,7 @@ public class QueryDataWithTransactionAsyncSample
 
         // Opens the connection so that the Spanner transaction included in the TransactionScope
         // is read-only TimestampBound.Strong.
-        await connection.OpenAsync(AmbientTransactionOptions.ForTimestampBoundReadOnly(), default);
+        await connection.OpenAsync(SpannerTransactionCreationOptions.ReadOnly, options: null, cancellationToken: default);
         using var cmd = connection.CreateSelectCommand("SELECT SingerId, AlbumId, AlbumTitle FROM Albums");
 
         // Read #1.

--- a/spanner/api/Spanner.Samples/QueryDataWithTransactionCoreAsync.cs
+++ b/spanner/api/Spanner.Samples/QueryDataWithTransactionCoreAsync.cs
@@ -38,7 +38,7 @@ public class QueryDataWithTransactionCoreAsyncSample
         await connection.OpenAsync();
 
         // Open a new read only transaction.
-        using var transaction = await connection.BeginReadOnlyTransactionAsync();
+        using var transaction = await connection.BeginTransactionAsync(SpannerTransactionCreationOptions.ReadOnly, cancellationToken: default);
         using var cmd = connection.CreateSelectCommand("SELECT SingerId, AlbumId, AlbumTitle FROM Albums");
         cmd.Transaction = transaction;
 

--- a/spanner/api/Spanner.Samples/ReadStaleDataAsync.cs
+++ b/spanner/api/Spanner.Samples/ReadStaleDataAsync.cs
@@ -36,7 +36,7 @@ public class ReadStaleDataAsyncSample
         await connection.OpenAsync();
 
         var staleness = TimestampBound.OfExactStaleness(TimeSpan.FromSeconds(15));
-        using var transaction = await connection.BeginReadOnlyTransactionAsync(staleness);
+        using var transaction = await connection.BeginTransactionAsync(SpannerTransactionCreationOptions.ForTimestampBoundReadOnly(staleness), cancellationToken: default);
         using var cmd = connection.CreateSelectCommand("SELECT SingerId, AlbumId, MarketingBudget FROM Albums");
         cmd.Transaction = transaction;
 

--- a/spanner/api/Spanner.Samples/Spanner.Samples.csproj
+++ b/spanner/api/Spanner.Samples/Spanner.Samples.csproj
@@ -5,7 +5,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Spanner.Data" Version="5.0.0-beta03" />
+    <PackageReference Include="Google.Cloud.Spanner.Data" Version="5.0.0-beta04" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR upgrades google.cloud.spanner.data to v5.0.0-beta04 dependency and fixes the broken samples.