### PR TITLE
Add secrets team to codeowners

### DIFF
--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -3,7 +3,7 @@ assign_issues_by:
   - 'api: bigtable'
   - 'api: datastore'
   - 'api: firestore'
-  to: 
+  to:
   - GoogleCloudPlatform/cloud-native-db-dpes
 - labels:
   - 'api: storage'
@@ -47,7 +47,11 @@ assign_issues_by:
   - 'api: vertex-ai'
   to:
   - meteatamel
-  
+- labels:
+  - 'api: secretmanager'
+  to:
+  - GoogleCloudPlatform/cloud-secrets-team
+
 assign_issues:
   - GoogleCloudPlatform/dotnet-samples-reviewers
 
@@ -107,3 +111,7 @@ assign_prs_by:
   - 'api: vertex-ai'
   to:
   - meteatamel
+- labels:
+  - 'api: secretmanager'
+  to:
+  - GoogleCloudPlatform/cloud-secrets-team

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -29,7 +29,7 @@ dlp/        @GoogleCloudPlatform/googleapis-dlp @GoogleCloudPlatform/dotnet-samp
 appengine/flexible/ @GoogleCloudPlatform/serverless-runtimes @GoogleCloudPlatform/dotnet-samples-reviewers
 
 kms/            @GoogleCloudPlatform/dotnet-samples-reviewers
-secretmanager/  @GoogleCloudPlatform/dotnet-samples-reviewers @GoogleCloudPlatform/cloud-samples-reviewers @GoogleCloudPlatform/cloud-secrets-team
+secretmanager/  @GoogleCloudPlatform/dotnet-samples-reviewers @GoogleCloudPlatform/cloud-secrets-team
 
 applications/googlehome-meets-dotnetcontainers/  @meteatamel @GoogleCloudPlatform/dotnet-samples-reviewers
 run/                                             @meteatamel @GoogleCloudPlatform/dotnet-samples-reviewers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -29,7 +29,7 @@ dlp/        @GoogleCloudPlatform/googleapis-dlp @GoogleCloudPlatform/dotnet-samp
 appengine/flexible/ @GoogleCloudPlatform/serverless-runtimes @GoogleCloudPlatform/dotnet-samples-reviewers
 
 kms/            @GoogleCloudPlatform/dotnet-samples-reviewers
-secretmanager/  @GoogleCloudPlatform/dotnet-samples-reviewers
+secretmanager/  @GoogleCloudPlatform/dotnet-samples-reviewers @GoogleCloudPlatform/cloud-samples-reviewers @GoogleCloudPlatform/cloud-secrets-team
 
 applications/googlehome-meets-dotnetcontainers/  @meteatamel @GoogleCloudPlatform/dotnet-samples-reviewers
 run/                                             @meteatamel @GoogleCloudPlatform/dotnet-samples-reviewers


### PR DESCRIPTION
### Changes
* Add secrets manager team to the `secretmanager/` code-owners in _CODEOWNERS_ file

### Description
* Need access to the secrets-manager team to be able to review and partake in the review process. 