### PR TITLE
Updating dotnet docs samples for .NET v8

### DIFF
--- a/appengine/flexible/Datastore/Datastore.Sample/Datastore.Sample.csproj
+++ b/appengine/flexible/Datastore/Datastore.Sample/Datastore.Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/appengine/flexible/HelloWorld/HelloWorld.Sample/HelloWorld.Sample.csproj
+++ b/appengine/flexible/HelloWorld/HelloWorld.Sample/HelloWorld.Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/appengine/flexible/HelloWorld/HelloWorld.Sample/app.yaml
+++ b/appengine/flexible/HelloWorld/HelloWorld.Sample/app.yaml
@@ -4,7 +4,7 @@ env: flex
 runtime_config:
   operating_system: ubuntu22
 
-# This sample incurs costs to run on the App Engine flexible environment. 
+# This sample incurs costs to run on the App Engine flexible environment.
 # The settings below are to reduce costs during testing and are not appropriate
 # for production use. For more information, see:
 # https://cloud.google.com/appengine/docs/flexible/dotnet/configuring-your-app-with-app-yaml


### PR DESCRIPTION
As per this [doc](https://docs.google.com/document/d/1o7iOL-E1qevyL8-ftEDS_wZ13Lw_N97DFtmfN0izg-o/edit?usp=sharing)

Updated the `HelloWorld.Sample` and `Datastore.Sample` to use .NET v8.0