### PR TITLE
chore(cloudrun): migrate region "cloudrun_pubsub_dockerfile" at run/pubsub/Run.Samples.Pubsub.MinimalApi/Dockerfile

### DIFF
--- a/run/pubsub/Run.Samples.Pubsub.MinimalApi/Dockerfile
+++ b/run/pubsub/Run.Samples.Pubsub.MinimalApi/Dockerfile
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START cloudrun_pubsub_dockerfile_csharp]
 # [START cloudrun_pubsub_dockerfile]
 # Build in SDK base image
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
@@ -33,3 +34,4 @@ ENV PORT=8080
 
 ENTRYPOINT ["dotnet", "Run.Samples.Pubsub.MinimalApi.dll"]
 # [END cloudrun_pubsub_dockerfile]
+# [END cloudrun_pubsub_dockerfile_csharp]


### PR DESCRIPTION
## Description
Migrate region "cloudrun_pubsub_dockerfile" to "cloudrun_pubsub_dockerfile_csharp" in order to align with pattern "product_regiontag_typeoffile_language" and create a consistency between languages.

Fixes [b/393606199](http://b/393606199)

## Checklist
- [x] Please **merge** this PR for me once it is approved