### PR TITLE
chore(cloudrun): delete old region tag "cloudrun_pubsub_dockerfile"

### DIFF
--- a/run/pubsub/Run.Samples.Pubsub.MinimalApi/Dockerfile
+++ b/run/pubsub/Run.Samples.Pubsub.MinimalApi/Dockerfile
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 # [START cloudrun_pubsub_dockerfile_csharp]
-# [START cloudrun_pubsub_dockerfile]
 # Build in SDK base image
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
 WORKDIR /app
@@ -33,5 +32,4 @@ COPY --from=build-env /app/out .
 ENV PORT=8080
 
 ENTRYPOINT ["dotnet", "Run.Samples.Pubsub.MinimalApi.dll"]
-# [END cloudrun_pubsub_dockerfile]
 # [END cloudrun_pubsub_dockerfile_csharp]


### PR DESCRIPTION
## Description
Delete old region tag "cloudrun_pubsub_dockerfile" from run/pubsub/Run.Samples.Pubsub.MinimalApi/Dockerfile

Fixes [b/393606199](http://b/393606199)

## Checklist
- [x] Please **merge** this PR for me once it is approved