### PR TITLE
feat(parametermanager): Added samples for creating params

### DIFF
--- a/parametermanager/api/ParameterManager.Samples.Tests/CreateParamTests.cs
+++ b/parametermanager/api/ParameterManager.Samples.Tests/CreateParamTests.cs
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Google.Cloud.ParameterManager.V1;
+
+[Collection(nameof(ParameterManagerFixture))]
+public class CreateParamTests
+{
+    private readonly ParameterManagerFixture _fixture;
+    private readonly CreateParamSample _sample;
+
+    public CreateParamTests(ParameterManagerFixture fixture)
+    {
+        _fixture = fixture;
+        _sample = new CreateParamSample();
+    }
+
+    [Fact]
+    public void CreateParam()
+    {
+        ParameterName parameterName = _fixture.ParameterName;
+        Parameter result = _sample.CreateParam(
+          projectId: parameterName.ProjectId, parameterId: parameterName.ParameterId);
+
+        Assert.NotNull(result);
+        Assert.Equal(result.Name, parameterName.ToString());
+        Assert.Equal(result.Format.ToString(), ParameterFormat.Unformatted.ToString());
+    }
+}

--- a/parametermanager/api/ParameterManager.Samples.Tests/CreateParamVersionTests.cs
+++ b/parametermanager/api/ParameterManager.Samples.Tests/CreateParamVersionTests.cs
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Google.Cloud.ParameterManager.V1;
+
+[Collection(nameof(ParameterManagerFixture))]
+public class CreateParamVersionTests
+{
+    private readonly ParameterManagerFixture _fixture;
+    private readonly CreateParamVersionSample _sample;
+
+    public CreateParamVersionTests(ParameterManagerFixture fixture)
+    {
+        _fixture = fixture;
+        _sample = new CreateParamVersionSample();
+    }
+
+    [Fact]
+    public void CreateParamVersion()
+    {
+        ParameterVersionName parameterVersionName = _fixture.ParameterVersionName;
+        string payload = _fixture.Payload;
+        ParameterVersion result = _sample.CreateParamVersion(
+          projectId: parameterVersionName.ProjectId, parameterId: parameterVersionName.ParameterId, versionId: parameterVersionName.ParameterVersionId, payload: payload);
+
+        Assert.NotNull(result);
+        Assert.Equal(result.Name, parameterVersionName.ToString());
+    }
+}

--- a/parametermanager/api/ParameterManager.Samples.Tests/CreateParamVersionWithSecretTests.cs
+++ b/parametermanager/api/ParameterManager.Samples.Tests/CreateParamVersionWithSecretTests.cs
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Google.Cloud.ParameterManager.V1;
+
+[Collection(nameof(ParameterManagerFixture))]
+public class CreateParamVersionWithSecretTests
+{
+    private readonly ParameterManagerFixture _fixture;
+    private readonly CreateParamVersionWithSecretSample _sample;
+
+    public CreateParamVersionWithSecretTests(ParameterManagerFixture fixture)
+    {
+        _fixture = fixture;
+        _sample = new CreateParamVersionWithSecretSample();
+    }
+
+    [Fact]
+    public void CreateParamVersionWithSecret()
+    {
+        ParameterVersionName parameterVersionName = _fixture.ParameterVersionNameWithSecretReference;
+        string secretId = _fixture.SecretId;
+        ParameterVersion result = _sample.CreateParamVersionWithSecret(
+          projectId: parameterVersionName.ProjectId, parameterId: parameterVersionName.ParameterId, versionId: parameterVersionName.ParameterVersionId, secretId: secretId);
+
+        Assert.NotNull(result);
+        Assert.Equal(result.Name, parameterVersionName.ToString());
+    }
+}

--- a/parametermanager/api/ParameterManager.Samples.Tests/CreateStructuredParamTests.cs
+++ b/parametermanager/api/ParameterManager.Samples.Tests/CreateStructuredParamTests.cs
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Google.Cloud.ParameterManager.V1;
+
+[Collection(nameof(ParameterManagerFixture))]
+public class CreateStructuredParamTests
+{
+    private readonly ParameterManagerFixture _fixture;
+    private readonly CreateStructuredParamSample _sample;
+
+    public CreateStructuredParamTests(ParameterManagerFixture fixture)
+    {
+        _fixture = fixture;
+        _sample = new CreateStructuredParamSample();
+    }
+
+    [Fact]
+    public void CreateStructuredParam()
+    {
+        ParameterName parameterName = _fixture.ParameterNameWithFormat;
+        Parameter result = _sample.CreateStructuredParam(
+          projectId: parameterName.ProjectId, parameterId: parameterName.ParameterId, format: ParameterFormat.Json);
+
+        Assert.NotNull(result);
+        Assert.Equal(result.Format.ToString(), ParameterFormat.Json.ToString());
+        Assert.Equal(result.Name, parameterName.ToString());
+    }
+}

--- a/parametermanager/api/ParameterManager.Samples.Tests/CreateStructuredParamVersionTests.cs
+++ b/parametermanager/api/ParameterManager.Samples.Tests/CreateStructuredParamVersionTests.cs
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Google.Cloud.ParameterManager.V1;
+
+[Collection(nameof(ParameterManagerFixture))]
+public class CreateStructureParamVersionTests
+{
+    private readonly ParameterManagerFixture _fixture;
+    private readonly CreateStructuredParamVersionSample _sample;
+
+    public CreateStructureParamVersionTests(ParameterManagerFixture fixture)
+    {
+        _fixture = fixture;
+        _sample = new CreateStructuredParamVersionSample();
+    }
+
+    [Fact]
+    public void CreateStructureParamVersion()
+    {
+        ParameterVersionName parameterVersionName = _fixture.ParameterVersionNameWithFormat;
+        string payload = _fixture.JsonPayload;
+        ParameterVersion result = _sample.CreateStructuredParamVersion(
+          projectId: parameterVersionName.ProjectId, parameterId: parameterVersionName.ParameterId, versionId: parameterVersionName.ParameterVersionId, payload: payload);
+
+        Assert.NotNull(result);
+        Assert.Equal(result.Name, parameterVersionName.ToString());
+    }
+}

--- a/parametermanager/api/ParameterManager.Samples.Tests/ParameterManager.Samples.Tests.csproj
+++ b/parametermanager/api/ParameterManager.Samples.Tests/ParameterManager.Samples.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/parametermanager/api/ParameterManager.Samples.Tests/ParameterManager.Samples.Tests.csproj
+++ b/parametermanager/api/ParameterManager.Samples.Tests/ParameterManager.Samples.Tests.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Google.Cloud.Iam.V1" Version="3.4.0" />
+    <PackageReference Include="Google.Cloud.SecretManager.V1" Version="2.5.0" />
+    <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ParameterManager.Samples\ParameterManager.Samples.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/parametermanager/api/ParameterManager.Samples.Tests/ParameterManagerFixture.cs
+++ b/parametermanager/api/ParameterManager.Samples.Tests/ParameterManagerFixture.cs
@@ -1,0 +1,255 @@
+// Copyright(c) 2025 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+using Google.Api.Gax.ResourceNames;
+using Google.Cloud.Iam.V1;
+using Google.Cloud.ParameterManager.V1;
+using Google.Cloud.SecretManager.V1;
+using Google.Protobuf;
+using System.Text;
+
+[CollectionDefinition(nameof(ParameterManagerFixture))]
+public class ParameterManagerFixture : IDisposable, ICollectionFixture<ParameterManagerFixture>
+{
+    public string ProjectId { get; }
+    public string LocationId = "global";
+
+    public string Payload = "test123";
+    public string JsonPayload = "{\"username\": \"test-user\", \"host\": \"localhost\"}";
+    public string SecretReference { get; }
+    public string SecretId = "projects/project-id/secrets/secret-id/versions/latest";
+
+    public ParameterName ParameterName { get; }
+    public ParameterName ParameterNameWithFormat { get; }
+
+    public string ParameterId { get; }
+    public Parameter Parameter { get; }
+    public ParameterVersionName ParameterVersionName { get; }
+
+    public Parameter ParameterWithFormat { get; }
+    public ParameterVersionName ParameterVersionNameWithFormat { get; }
+
+    public Parameter ParameterWithSecretReference { get; }
+    public ParameterVersionName ParameterVersionNameWithSecretReference { get; }
+
+    public Parameter ParameterToDelete { get; }
+    public ParameterName ParameterNameToDelete { get; }
+
+    public string ParameterVersionId { get; }
+    public Parameter ParameterToDeleteVersion { get; }
+    public ParameterVersion ParameterVersionToDelete { get; }
+    public ParameterVersionName ParameterVersionNameToDelete { get; }
+
+    public ParameterName ParameterNameForQuickstart { get; }
+    public ParameterVersionName ParameterVersionNameForQuickstart { get; }
+
+    public Parameter ParameterToRender { get; }
+    public ParameterVersion ParameterVersionToRender { get; }
+    public ParameterVersionName ParameterVersionNameToRender { get; }
+    public Secret Secret { get; }
+    public SecretVersion SecretVersion { get; }
+    public Policy Policy { get; }
+    public ParameterManagerFixture()
+    {
+        ProjectId = Environment.GetEnvironmentVariable("GOOGLE_PROJECT_ID");
+        if (String.IsNullOrEmpty(ProjectId))
+        {
+            throw new Exception("missing GOOGLE_PROJECT_ID");
+        }
+
+        ParameterName = new ParameterName(ProjectId, LocationId, RandomId());
+        ParameterNameWithFormat = new ParameterName(ProjectId, LocationId, RandomId());
+
+        ParameterId = RandomId();
+        Parameter = CreateParameter(ParameterId, ParameterFormat.Unformatted);
+        ParameterVersionName = new ParameterVersionName(ProjectId, LocationId, ParameterId, RandomId());
+
+        ParameterId = RandomId();
+        ParameterWithFormat = CreateParameter(ParameterId, ParameterFormat.Json);
+        ParameterVersionNameWithFormat = new ParameterVersionName(ProjectId, LocationId, ParameterId, RandomId());
+
+        ParameterId = RandomId();
+        ParameterWithSecretReference = CreateParameter(ParameterId, ParameterFormat.Unformatted);
+        ParameterVersionNameWithSecretReference = new ParameterVersionName(ProjectId, LocationId, ParameterId, RandomId());
+
+        ParameterId = RandomId();
+        ParameterToDelete = CreateParameter(ParameterId, ParameterFormat.Unformatted);
+        ParameterNameToDelete = new ParameterName(ProjectId, LocationId, ParameterId);
+
+        ParameterId = RandomId();
+        ParameterVersionId = RandomId();
+        ParameterToDeleteVersion = CreateParameter(ParameterId, ParameterFormat.Unformatted);
+        ParameterVersionToDelete = CreateParameterVersion(ParameterId, ParameterVersionId, Payload);
+        ParameterVersionNameToDelete = new ParameterVersionName(ProjectId, LocationId, ParameterId, ParameterVersionId);
+
+        ParameterId = RandomId();
+        ParameterVersionId = RandomId();
+        ParameterNameForQuickstart = new ParameterName(ProjectId, LocationId, ParameterId);
+        ParameterVersionNameForQuickstart = new ParameterVersionName(ProjectId, LocationId, ParameterId, ParameterVersionId);
+
+        ParameterId = RandomId();
+        ParameterVersionId = RandomId();
+        ParameterToRender = CreateParameter(ParameterId, ParameterFormat.Json);
+        Secret = CreateSecret(RandomId());
+        SecretVersion = AddSecretVersion(Secret);
+        SecretReference = $"{{\"username\": \"test-user\", \"password\": \"__REF__(//secretmanager.googleapis.com/{Secret.SecretName}/versions/latest)\"}}";
+        ParameterVersionToRender = CreateParameterVersion(ParameterId, ParameterVersionId, SecretReference);
+        Policy = GrantIAMAccess(Secret.SecretName, ParameterToRender.PolicyMember.IamPolicyUidPrincipal.ToString());
+        ParameterVersionNameToRender = new ParameterVersionName(ProjectId, LocationId, ParameterId, ParameterVersionId);
+    }
+
+    public void Dispose()
+    {
+        DeleteParameter(ParameterName);
+        DeleteParameter(ParameterNameWithFormat);
+        DeleteParameterVersion(ParameterVersionName);
+        DeleteParameter(Parameter.ParameterName);
+        DeleteParameterVersion(ParameterVersionNameWithFormat);
+        DeleteParameter(ParameterWithFormat.ParameterName);
+        DeleteParameterVersion(ParameterVersionNameWithSecretReference);
+        DeleteParameter(ParameterWithSecretReference.ParameterName);
+        DeleteParameter(ParameterNameToDelete);
+        DeleteParameterVersion(ParameterVersionNameToDelete);
+        DeleteParameter(ParameterToDeleteVersion.ParameterName);
+        DeleteParameterVersion(ParameterVersionNameForQuickstart);
+        DeleteParameter(ParameterNameForQuickstart);
+        DeleteParameterVersion(ParameterVersionNameToRender);
+        DeleteParameter(ParameterToRender.ParameterName);
+        DeleteSecret(Secret.SecretName);
+    }
+
+    public String RandomId()
+    {
+        return $"csharp-{System.Guid.NewGuid()}";
+    }
+
+    public Parameter CreateParameter(string parameterId, ParameterFormat format)
+    {
+        ParameterManagerClient client = ParameterManagerClient.Create();
+        LocationName projectName = new LocationName(ProjectId, LocationId);
+
+        Parameter parameter = new Parameter
+        {
+            Format = format
+        };
+
+        return client.CreateParameter(projectName, parameter, parameterId);
+    }
+
+    public ParameterVersion CreateParameterVersion(string parameterId, string versionId, string payload)
+    {
+        ParameterManagerClient client = ParameterManagerClient.Create();
+
+        ParameterName parameterName = new ParameterName(ProjectId, LocationId, parameterId);
+        ParameterVersion parameterVersion = new ParameterVersion
+        {
+            Payload = new ParameterVersionPayload
+            {
+                Data = ByteString.CopyFrom(payload, Encoding.UTF8)
+            }
+        };
+
+        return client.CreateParameterVersion(parameterName.ToString(), parameterVersion, versionId);
+    }
+
+    private void DeleteParameter(ParameterName name)
+    {
+        ParameterManagerClient client = ParameterManagerClient.Create();
+        try
+        {
+            client.DeleteParameter(name);
+        }
+        catch (Grpc.Core.RpcException e) when (e.StatusCode == Grpc.Core.StatusCode.NotFound)
+        {
+            // Ignore error - Parameter was already deleted
+        }
+    }
+
+    private void DeleteParameterVersion(ParameterVersionName name)
+    {
+        ParameterManagerClient client = ParameterManagerClient.Create();
+        try
+        {
+            client.DeleteParameterVersion(name);
+        }
+        catch (Grpc.Core.RpcException e) when (e.StatusCode == Grpc.Core.StatusCode.NotFound)
+        {
+            // Ignore error - Parameter version was already deleted
+        }
+    }
+
+    public Secret CreateSecret(string secretId)
+    {
+        SecretManagerServiceClient client = SecretManagerServiceClient.Create();
+        ProjectName projectName = new ProjectName(ProjectId);
+
+        Secret secret = new Secret
+        {
+            Replication = new Replication
+            {
+                Automatic = new Replication.Types.Automatic(),
+            },
+        };
+
+        return client.CreateSecret(projectName, secretId, secret);
+    }
+
+    public Policy GrantIAMAccess(SecretName secretName, string member)
+    {
+        // Create the client.
+        SecretManagerServiceClient client = SecretManagerServiceClient.Create();
+
+        // Get current policy.
+        Policy policy = client.GetIamPolicy(new GetIamPolicyRequest
+        {
+            ResourceAsResourceName = secretName,
+        });
+
+        // Add the user to the list of bindings.
+        policy.AddRoleMember("roles/secretmanager.secretAccessor", member);
+
+        // Save the updated policy.
+        policy = client.SetIamPolicy(new SetIamPolicyRequest
+        {
+            ResourceAsResourceName = secretName,
+            Policy = policy,
+        });
+        return policy;
+    }
+    private SecretVersion AddSecretVersion(Secret secret)
+    {
+        SecretManagerServiceClient client = SecretManagerServiceClient.Create();
+
+        SecretPayload payload = new SecretPayload
+        {
+            Data = ByteString.CopyFrom("my super secret data", Encoding.UTF8),
+        };
+
+        return client.AddSecretVersion(secret.SecretName, payload);
+    }
+
+    private void DeleteSecret(SecretName name)
+    {
+        SecretManagerServiceClient client = SecretManagerServiceClient.Create();
+
+        try
+        {
+            client.DeleteSecret(name);
+        }
+        catch (Grpc.Core.RpcException e) when (e.StatusCode == Grpc.Core.StatusCode.NotFound)
+        {
+            // Ignore error - secret was already deleted
+        }
+    }
+}

--- a/parametermanager/api/ParameterManager.Samples/CreateParam.cs
+++ b/parametermanager/api/ParameterManager.Samples/CreateParam.cs
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// [START parametermanager_create_param]
+
+using Google.Api.Gax.ResourceNames;
+using Google.Cloud.ParameterManager.V1;
+
+/// <summary>
+/// This function creates a parameter of the format type "unformatted" using the Parameter Manager SDK for GCP.
+/// </summary>
+/// <param name="projectId">The ID of the project where the parameter is to be created.</param>
+/// <param name="parameterId">The ID to assign to the new parameter. This ID must be unique within the project.</param>
+/// <returns>The created Parameter object.</returns>
+public class CreateParamSample
+{
+    public Parameter CreateParam(
+        string projectId,
+        string parameterId)
+    {
+        // Create the client.
+        ParameterManagerClient client = ParameterManagerClient.Create();
+
+        // Build the parent resource name. 
+        LocationName parent = new LocationName(projectId, "global");
+
+        // Build the parameter.
+        Parameter parameter = new Parameter();
+
+        // Call the API to create the parameter.
+        Parameter createdParameter = client.CreateParameter(parent, parameter, parameterId);
+
+        // Print the created parameter name.
+        Console.WriteLine($"Created parameter: {createdParameter.Name}");
+
+        // Return the created parameter.
+        return createdParameter;
+    }
+}
+// [END parametermanager_create_param]  

--- a/parametermanager/api/ParameterManager.Samples/CreateParamVersion.cs
+++ b/parametermanager/api/ParameterManager.Samples/CreateParamVersion.cs
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// [START parametermanager_create_param_version]
+
+using Google.Cloud.ParameterManager.V1;
+using Google.Protobuf;
+using System.Text;
+
+/// <summary>
+/// This function creates a parameter version with an unformatted payload using the Parameter Manager SDK for GCP.
+/// </summary>
+/// <param name="projectId">The ID of the project where the parameter is located.</param>
+/// <param name="parameterId">The ID of the parameter for which the version is to be created.</param>
+/// <param name="versionId">The ID of the version to be created.</param>
+/// <param name="payload">The unformatted string payload to be stored in the new parameter version.</param>
+/// <returns>The created ParameterVersion object.</returns>
+public class CreateParamVersionSample
+{
+    public ParameterVersion CreateParamVersion(
+        string projectId,
+        string parameterId,
+        string versionId,
+        string payload)
+    {
+        // Create the client.
+        ParameterManagerClient client = ParameterManagerClient.Create();
+
+        // Build the parent resource name.
+        ParameterName parent = new ParameterName(projectId, "global", parameterId);
+
+        // Convert the payload to bytes.
+        ByteString data = ByteString.CopyFrom(payload, Encoding.UTF8);
+
+        // Build the parameter version with the unformatted payload.
+        ParameterVersion parameterVersion = new ParameterVersion
+        {
+            Payload = new ParameterVersionPayload
+            {
+                Data = data
+            }
+        };
+
+        // Call the API to create the parameter version.
+        ParameterVersion createdParameterVersion = client.CreateParameterVersion(parent.ToString(), parameterVersion, versionId);
+
+        // Print the created parameter version name.
+        Console.WriteLine($"Created parameter version: {createdParameterVersion.Name}");
+
+        // Return the created parameter version.
+        return createdParameterVersion;
+    }
+}
+// [END parametermanager_create_param_version]

--- a/parametermanager/api/ParameterManager.Samples/CreateParamVersionWithSecret.cs
+++ b/parametermanager/api/ParameterManager.Samples/CreateParamVersionWithSecret.cs
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// [START parametermanager_create_param_version_with_secret]
+
+using Google.Cloud.ParameterManager.V1;
+using Google.Protobuf;
+using System.Text;
+
+/// <summary>
+/// This function creates a parameter version with a JSON payload that includes a secret reference using the Parameter Manager SDK for GCP.
+/// </summary>
+/// <param name="projectId">The ID of the project where the parameter is located.</param>
+/// <param name="parameterId">The ID of the parameter for which the version is to be created.</param>
+/// <param name="versionId">The ID of the version to be created.</param>
+/// <param name="secretId">The ID of the secret to be referenced.</param>
+/// <returns>The created ParameterVersion object.</returns>
+public class CreateParamVersionWithSecretSample
+{
+    public ParameterVersion CreateParamVersionWithSecret(
+        string projectId,
+        string parameterId,
+        string versionId,
+        string secretId)
+    {
+        // Create the client.
+        ParameterManagerClient client = ParameterManagerClient.Create();
+
+        // Build the parent resource name.
+        ParameterName parent = new ParameterName(projectId, "global", parameterId);
+
+        // Convert the JSON payload to bytes.
+        string payload = $"{{\"username\": \"test-user\", \"password\": \"__REF__(//secretmanager.googleapis.com/{secretId}\"}}";
+        ByteString data = ByteString.CopyFrom(payload, Encoding.UTF8);
+
+        // Build the parameter version with the JSON payload that includes a secret reference.
+        ParameterVersion parameterVersion = new ParameterVersion
+        {
+            Payload = new ParameterVersionPayload
+            {
+                Data = data
+            }
+        };
+
+        // Call the API to create the parameter version.
+        ParameterVersion createdParameterVersion = client.CreateParameterVersion(parent.ToString(), parameterVersion, versionId);
+
+        // Print the created parameter version name.
+        Console.WriteLine($"Created parameter version: {createdParameterVersion.Name}");
+
+        // Return the created parameter version.
+        return createdParameterVersion;
+    }
+}
+// [END parametermanager_create_param_version_with_secret]

--- a/parametermanager/api/ParameterManager.Samples/CreateStructuredParam.cs
+++ b/parametermanager/api/ParameterManager.Samples/CreateStructuredParam.cs
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// [START parametermanager_create_structured_param]
+
+using Google.Api.Gax.ResourceNames;
+using Google.Cloud.ParameterManager.V1;
+
+/// <summary>
+/// This function creates a parameter of the specified format type using the Parameter Manager SDK for GCP.
+/// </summary>
+/// <param name="projectId">The ID of the project where the parameter is to be created.</param>
+/// <param name="parameterId">The ID to assign to the new parameter. This ID must be unique within the project.</param>
+/// <param name="format">The format type of the parameter (UNFORMATTED, YAML, JSON).</param>
+/// <returns>The created Parameter object.</returns>
+public class CreateStructuredParamSample
+{
+    public Parameter CreateStructuredParam(
+        string projectId,
+        string parameterId,
+        ParameterFormat format)
+    {
+        // Create the client.
+        ParameterManagerClient client = ParameterManagerClient.Create();
+
+        // Build the parent resource name. 
+        LocationName parent = new LocationName(projectId, "global");
+
+        // Build the parameter with the specified format.
+        Parameter parameter = new Parameter
+        {
+            Format = format
+        };
+
+        // Call the API to create the parameter.
+        Parameter createdParameter = client.CreateParameter(parent, parameter, parameterId);
+
+        // Print the created parameter name.
+        Console.WriteLine($"Created parameter {createdParameter.Name} with format {createdParameter.Format}");
+
+        // Return the created parameter.
+        return createdParameter;
+    }
+}
+// [END parametermanager_create_structured_param]

--- a/parametermanager/api/ParameterManager.Samples/CreateStructuredParamVersion.cs
+++ b/parametermanager/api/ParameterManager.Samples/CreateStructuredParamVersion.cs
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// [START parametermanager_create_structured_param_version]
+
+using Google.Cloud.ParameterManager.V1;
+using Google.Protobuf;
+using System.Text;
+
+/// <summary>
+/// This function creates a parameter version with a JSON payload using the Parameter Manager SDK for GCP.
+/// </summary>
+/// <param name="projectId">The ID of the project where the parameter is located.</param>
+/// <param name="parameterId">The ID of the parameter for which the version is to be created.</param>
+/// <param name="versionId">The ID of the version to be created.</param>
+/// <param name="payload">The JSON dictionary payload to be stored in the new parameter version.</param>
+/// <returns>The created ParameterVersion object.</returns>
+public class CreateStructuredParamVersionSample
+{
+    public ParameterVersion CreateStructuredParamVersion(
+        string projectId,
+        string parameterId,
+        string versionId,
+        string payload)
+    {
+        // Create the client.
+        ParameterManagerClient client = ParameterManagerClient.Create();
+
+        // Build the parent resource name.
+        ParameterName parent = new ParameterName(projectId, "global", parameterId);
+
+        // Convert the JSON payload to bytes.
+        ByteString data = ByteString.CopyFrom(payload, Encoding.UTF8);
+
+        // Build the parameter version with the JSON payload.
+        ParameterVersion parameterVersion = new ParameterVersion
+        {
+            Payload = new ParameterVersionPayload
+            {
+                Data = data
+            }
+        };
+
+        // Call the API to create the parameter version.
+        ParameterVersion createdParameterVersion = client.CreateParameterVersion(parent.ToString(), parameterVersion, versionId);
+
+        // Print the created parameter version name.
+        Console.WriteLine($"Created parameter version: {createdParameterVersion.Name}");
+
+        // Return the created parameter version.
+        return createdParameterVersion;
+    }
+}
+// [END parametermanager_create_structured_param_version]

--- a/parametermanager/api/ParameterManager.Samples/ParameterManager.Samples.csproj
+++ b/parametermanager/api/ParameterManager.Samples/ParameterManager.Samples.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/parametermanager/api/ParameterManager.Samples/ParameterManager.Samples.csproj
+++ b/parametermanager/api/ParameterManager.Samples/ParameterManager.Samples.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Cloud.Common" Version="2.2.0" />
+    <PackageReference Include="Google.Cloud.ParameterManager.V1" Version="1.0.0-beta01" />
+  </ItemGroup>
+
+</Project>

--- a/parametermanager/api/ParameterManager.sln
+++ b/parametermanager/api/ParameterManager.sln
@@ -1,0 +1,48 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ParameterManager.Samples", "ParameterManager.Samples\ParameterManager.Samples.csproj", "{69519423-44D8-46E8-A531-09427272363F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ParameterManager.Samples.Tests", "ParameterManager.Samples.Tests\ParameterManager.Samples.Tests.csproj", "{2ED39537-73EA-4186-A92D-82F59005FE14}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{69519423-44D8-46E8-A531-09427272363F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{69519423-44D8-46E8-A531-09427272363F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{69519423-44D8-46E8-A531-09427272363F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{69519423-44D8-46E8-A531-09427272363F}.Debug|x64.Build.0 = Debug|Any CPU
+		{69519423-44D8-46E8-A531-09427272363F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{69519423-44D8-46E8-A531-09427272363F}.Debug|x86.Build.0 = Debug|Any CPU
+		{69519423-44D8-46E8-A531-09427272363F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{69519423-44D8-46E8-A531-09427272363F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{69519423-44D8-46E8-A531-09427272363F}.Release|x64.ActiveCfg = Release|Any CPU
+		{69519423-44D8-46E8-A531-09427272363F}.Release|x64.Build.0 = Release|Any CPU
+		{69519423-44D8-46E8-A531-09427272363F}.Release|x86.ActiveCfg = Release|Any CPU
+		{69519423-44D8-46E8-A531-09427272363F}.Release|x86.Build.0 = Release|Any CPU
+		{2ED39537-73EA-4186-A92D-82F59005FE14}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2ED39537-73EA-4186-A92D-82F59005FE14}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2ED39537-73EA-4186-A92D-82F59005FE14}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2ED39537-73EA-4186-A92D-82F59005FE14}.Debug|x64.Build.0 = Debug|Any CPU
+		{2ED39537-73EA-4186-A92D-82F59005FE14}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2ED39537-73EA-4186-A92D-82F59005FE14}.Debug|x86.Build.0 = Debug|Any CPU
+		{2ED39537-73EA-4186-A92D-82F59005FE14}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2ED39537-73EA-4186-A92D-82F59005FE14}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2ED39537-73EA-4186-A92D-82F59005FE14}.Release|x64.ActiveCfg = Release|Any CPU
+		{2ED39537-73EA-4186-A92D-82F59005FE14}.Release|x64.Build.0 = Release|Any CPU
+		{2ED39537-73EA-4186-A92D-82F59005FE14}.Release|x86.ActiveCfg = Release|Any CPU
+		{2ED39537-73EA-4186-A92D-82F59005FE14}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/parametermanager/api/runTests.ps1
+++ b/parametermanager/api/runTests.ps1
@@ -1,0 +1,16 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+dotnet restore --force
+dotnet test --no-restore --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }


### PR DESCRIPTION
## Description
Created samples for creating parameter and parameter version using Parameter Manager SDK


Sample List:

[parameter-structured-data](https://cloud.google.com/secret-manager/parameter-manager/docs/create-parameter#parameter-structured-data)
[parameter-unstructured-data](https://cloud.google.com/secret-manager/parameter-manager/docs/create-parameter#parameter-unstructured-data)
[add-parameter-version](https://cloud.google.com/secret-manager/parameter-manager/docs/add-parameter-version#add-parameter-version) (structured, unstructured)
[create-parameter-secret-reference](https://cloud.google.com/secret-manager/parameter-manager/docs/reference-secrets-in-parameter#create-parameter-secret-reference)