### PR TITLE
chore(secretmanager): Add global samples for delayed destroy

### DIFF
--- a/secretmanager/api/SecretManager.Samples.Tests/CreateSecretWithDelayedDestroyTests.cs
+++ b/secretmanager/api/SecretManager.Samples.Tests/CreateSecretWithDelayedDestroyTests.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secretmanager/api/SecretManager.Samples.Tests/CreateSecretWithDelayedDestroyTests.cs
+++ b/secretmanager/api/SecretManager.Samples.Tests/CreateSecretWithDelayedDestroyTests.cs
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Google.Cloud.SecretManager.V1;
+using Google.Protobuf.WellKnownTypes;
+using System;
+using Xunit;
+
+
+[Collection(nameof(SecretManagerFixture))]
+public class CreateSecretWithDelayedDestroyTests
+{
+    private readonly SecretManagerFixture _fixture;
+    private readonly CreateSecretWithDelayedDestroySample _sample;
+
+    public CreateSecretWithDelayedDestroyTests(SecretManagerFixture fixture)
+    {
+        _fixture = fixture;
+        _sample = new CreateSecretWithDelayedDestroySample();
+    }
+
+    [Fact]
+    public void CreatesSecretsWithDelayedDestroy()
+    {
+
+        // Get the SecretName from the set ProjectId & RandomId.
+        SecretName secretName = new SecretName(_fixture.ProjectId, _fixture.RandomId());
+
+        // Set duration for delayed destruction.
+        int timeToLive = 86400;
+
+        // Run the sample code.
+        Secret result = _sample.CreateSecretWithDelayedDestroy(
+          projectId: secretName.ProjectId, secretId: secretName.SecretId, timeToLive: timeToLive);
+
+        // Assert that the secret was created with the correct configurations.
+        Assert.Equal(result.SecretName.SecretId, secretName.SecretId);
+        Assert.Equal(result.VersionDestroyTtl, Duration.FromTimeSpan(TimeSpan.FromSeconds(timeToLive)));
+
+        // Clean the created secret.
+        _fixture.DeleteSecret(secretName);
+    }
+}

--- a/secretmanager/api/SecretManager.Samples.Tests/DestroySecretVersionTests.cs
+++ b/secretmanager/api/SecretManager.Samples.Tests/DestroySecretVersionTests.cs
@@ -45,28 +45,8 @@ public class DestroySecretVersionTests
         SecretVersion secretVersion = _sample.DestroySecretVersion(
           projectId: secretVersionName.ProjectId, secretId: secretVersionName.SecretId, secretVersionId: secretVersionName.SecretVersionId);
 
-        // Assert that the Secret gets disabled.
+        // Assert that the Secret is destroyed.
         Assert.Equal(SecretVersion.Types.State.Destroyed, secretVersion.State);
-
-        // Clean up the created resource
-        _fixture.DeleteSecret(secret.SecretName);
-    }
-
-    [Fact]
-    public void DisablesSecretVersionWhenDelayedDestroyEnabled()
-    {
-        // Create the secret and add secret version.
-        Secret secret = _fixture.CreateSecretWithDelayedDestroy();
-
-        // Add the secret version to the created secret.
-        SecretVersion version = _fixture.AddSecretVersion(secret);
-
-        // Run the sample code.
-        SecretVersion secretVersion = _sample.DestroySecretVersion(
-          projectId: secret.SecretName.ProjectId, secretId: secret.SecretName.SecretId, secretVersionId: version.SecretVersionName.SecretVersionId);
-
-        // Assert that the Secret gets disabled.
-        Assert.Equal(SecretVersion.Types.State.Disabled, secretVersion.State);
 
         // Clean up the created resource
         _fixture.DeleteSecret(secret.SecretName);

--- a/secretmanager/api/SecretManager.Samples.Tests/DestroySecretVersionTests.cs
+++ b/secretmanager/api/SecretManager.Samples.Tests/DestroySecretVersionTests.cs
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-using Xunit;
 using Google.Cloud.SecretManager.V1;
+using Xunit;
 
 [Collection(nameof(SecretManagerFixture))]
 public class DestroySecretVersionTests
@@ -32,9 +32,43 @@ public class DestroySecretVersionTests
     [Fact]
     public void DestroysSecretVersions()
     {
-        SecretVersionName secretVersionName = _fixture.SecretVersionToDestroy.SecretVersionName;
+        // Create the secret and add secret version.
+        Secret secret = _fixture.CreateSecret(_fixture.RandomId());
+
+        // Add the secret version to the created secret.
+        SecretVersion version = _fixture.AddSecretVersion(secret);
+
+        // Get the secret version name.
+        SecretVersionName secretVersionName = version.SecretVersionName;
+
+        // Run the sample code.
         SecretVersion secretVersion = _sample.DestroySecretVersion(
           projectId: secretVersionName.ProjectId, secretId: secretVersionName.SecretId, secretVersionId: secretVersionName.SecretVersionId);
+
+        // Assert that the Secret gets disabled.
         Assert.Equal(SecretVersion.Types.State.Destroyed, secretVersion.State);
+
+        // Clean up the created resource
+        _fixture.DeleteSecret(secret.SecretName);
+    }
+
+    [Fact]
+    public void DisablesSecretVersionWhenDelayedDestroyEnabled()
+    {
+        // Create the secret and add secret version.
+        Secret secret = _fixture.CreateSecretWithDelayedDestroy();
+
+        // Add the secret version to the created secret.
+        SecretVersion version = _fixture.AddSecretVersion(secret);
+
+        // Run the sample code.
+        SecretVersion secretVersion = _sample.DestroySecretVersion(
+          projectId: secret.SecretName.ProjectId, secretId: secret.SecretName.SecretId, secretVersionId: version.SecretVersionName.SecretVersionId);
+
+        // Assert that the Secret gets disabled.
+        Assert.Equal(SecretVersion.Types.State.Disabled, secretVersion.State);
+
+        // Clean up the created resource
+        _fixture.DeleteSecret(secret.SecretName);
     }
 }

--- a/secretmanager/api/SecretManager.Samples.Tests/DisableSecretDelayedDestroyTests.cs
+++ b/secretmanager/api/SecretManager.Samples.Tests/DisableSecretDelayedDestroyTests.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secretmanager/api/SecretManager.Samples.Tests/DisableSecretDelayedDestroyTests.cs
+++ b/secretmanager/api/SecretManager.Samples.Tests/DisableSecretDelayedDestroyTests.cs
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Google.Cloud.SecretManager.V1;
+using Xunit;
+
+[Collection(nameof(SecretManagerFixture))]
+public class DisableSecretDelayedDestroyTests
+{
+    private readonly SecretManagerFixture _fixture;
+    private readonly DisableSecretDelayedDestroySample _sample;
+
+    public DisableSecretDelayedDestroyTests(SecretManagerFixture fixture)
+    {
+        _fixture = fixture;
+        _sample = new DisableSecretDelayedDestroySample();
+    }
+
+    [Fact]
+    public void DisablesSecretDelayedDestroy()
+    {
+        // Create the secret and add secret version.
+        Secret secret = _fixture.CreateSecretWithDelayedDestroy();
+
+        // Run the sample code.
+        Secret disabledSecret = _sample.DisableSecretDelayedDestroy(
+          projectId: secret.SecretName.ProjectId, secretId: secret.SecretName.SecretId);
+
+        // Assert that the secret was created with the correct configurations.
+        Assert.Null(disabledSecret.VersionDestroyTtl);
+
+        // Clean the created secret.
+        _fixture.DeleteSecret(secret.SecretName);
+    }
+}

--- a/secretmanager/api/SecretManager.Samples.Tests/DisableSecretVersionTests.cs
+++ b/secretmanager/api/SecretManager.Samples.Tests/DisableSecretVersionTests.cs
@@ -51,27 +51,4 @@ public class DisableSecretVersionTests
         // Clean up the created resource
         _fixture.DeleteSecret(secret.SecretName);
     }
-
-    [Fact]
-    public void DisableSecretVersionScheduledForDestruction()
-    {
-        // Create the secret and add secret version.
-        Secret secret = _fixture.CreateSecretWithDelayedDestroy();
-
-        // Add the secret version to the created secret.
-        SecretVersion version = _fixture.AddSecretVersion(secret);
-
-        // Destroy the created secret.
-        SecretVersion destroyedVersion = _fixture.DestroySecretVersion(version);
-
-        // Run the sample code.
-        SecretVersion secretVersion = _sample.DisableSecretVersion(
-          projectId: destroyedVersion.SecretVersionName.ProjectId, secretId: destroyedVersion.SecretVersionName.SecretId, secretVersionId: destroyedVersion.SecretVersionName.SecretVersionId);
-
-        // Assert that the Secret gets disabled.
-        Assert.Equal(SecretVersion.Types.State.Disabled, secretVersion.State);
-
-        // Clean up the created resource
-        _fixture.DeleteSecret(secret.SecretName);
-    }
 }

--- a/secretmanager/api/SecretManager.Samples.Tests/DisableSecretVersionTests.cs
+++ b/secretmanager/api/SecretManager.Samples.Tests/DisableSecretVersionTests.cs
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-using Xunit;
 using Google.Cloud.SecretManager.V1;
+using Xunit;
 
 [Collection(nameof(SecretManagerFixture))]
 public class DisableSecretVersionTests
@@ -32,9 +32,46 @@ public class DisableSecretVersionTests
     [Fact]
     public void DisablesSecretVersions()
     {
-        SecretVersionName secretVersionName = _fixture.SecretVersionToDisable.SecretVersionName;
+        // Create the secret and add secret version.
+        Secret secret = _fixture.CreateSecret(_fixture.RandomId());
+
+        // Add the secret version to the created secret.
+        SecretVersion version = _fixture.AddSecretVersion(secret);
+
+        // Get the SecretVersionName.
+        SecretVersionName secretVersionName = version.SecretVersionName;
+
+        // Run the sample code.
         SecretVersion secretVersion = _sample.DisableSecretVersion(
           projectId: secretVersionName.ProjectId, secretId: secretVersionName.SecretId, secretVersionId: secretVersionName.SecretVersionId);
+
+        // Assert that the Secret gets disabled.
         Assert.Equal(SecretVersion.Types.State.Disabled, secretVersion.State);
+
+        // Clean up the created resource
+        _fixture.DeleteSecret(secret.SecretName);
+    }
+
+    [Fact]
+    public void DisableSecretVersionScheduledForDestruction()
+    {
+        // Create the secret and add secret version.
+        Secret secret = _fixture.CreateSecretWithDelayedDestroy();
+
+        // Add the secret version to the created secret.
+        SecretVersion version = _fixture.AddSecretVersion(secret);
+
+        // Destroy the created secret.
+        SecretVersion destroyedVersion = _fixture.DestroySecretVersion(version);
+
+        // Run the sample code.
+        SecretVersion secretVersion = _sample.DisableSecretVersion(
+          projectId: destroyedVersion.SecretVersionName.ProjectId, secretId: destroyedVersion.SecretVersionName.SecretId, secretVersionId: destroyedVersion.SecretVersionName.SecretVersionId);
+
+        // Assert that the Secret gets disabled.
+        Assert.Equal(SecretVersion.Types.State.Disabled, secretVersion.State);
+
+        // Clean up the created resource
+        _fixture.DeleteSecret(secret.SecretName);
     }
 }

--- a/secretmanager/api/SecretManager.Samples.Tests/EnableSecretVersionTests.cs
+++ b/secretmanager/api/SecretManager.Samples.Tests/EnableSecretVersionTests.cs
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-using Xunit;
 using Google.Cloud.SecretManager.V1;
+using Xunit;
 
 [Collection(nameof(SecretManagerFixture))]
 public class EnableSecretVersionTests
@@ -32,9 +32,49 @@ public class EnableSecretVersionTests
     [Fact]
     public void EnablesSecretVersions()
     {
-        SecretVersionName secretVersionName = _fixture.SecretVersionToEnable.SecretVersionName;
+        // Create the secret and add secret version.
+        Secret secret = _fixture.CreateSecret(_fixture.RandomId());
+
+        // Add the secret version to the created secret.
+        SecretVersion version = _fixture.AddSecretVersion(secret);
+
+        // Get the SecretVersionName.
+        SecretVersionName secretVersionName = version.SecretVersionName;
+
+        // Disable the SecretVersion.
+        _fixture.DisableSecretVersion(version);
+
+        // Run the sample code.
         SecretVersion secretVersion = _sample.EnableSecretVersion(
           projectId: secretVersionName.ProjectId, secretId: secretVersionName.SecretId, secretVersionId: secretVersionName.SecretVersionId);
+
+        // Assert that the Secret gets disabled.
         Assert.Equal(SecretVersion.Types.State.Enabled, secretVersion.State);
+
+        // Clean up the created resource
+        _fixture.DeleteSecret(secret.SecretName);
+    }
+
+    [Fact]
+    public void EnableSecretVersionScheduledForDestruction()
+    {
+        // Create the secret and add secret version.
+        Secret secret = _fixture.CreateSecretWithDelayedDestroy();
+
+        // Add the secret version to the created secret.
+        SecretVersion version = _fixture.AddSecretVersion(secret);
+
+        // Destroy the created secret.
+        SecretVersion destroyedVersion = _fixture.DestroySecretVersion(version);
+
+        // Run the sample code.
+        SecretVersion secretVersion = _sample.EnableSecretVersion(
+          projectId: destroyedVersion.SecretVersionName.ProjectId, secretId: destroyedVersion.SecretVersionName.SecretId, secretVersionId: destroyedVersion.SecretVersionName.SecretVersionId);
+
+        // Assert that the Secret gets disabled.
+        Assert.Equal(SecretVersion.Types.State.Enabled, secretVersion.State);
+
+        // Clean up the created resource
+        _fixture.DeleteSecret(secret.SecretName);
     }
 }

--- a/secretmanager/api/SecretManager.Samples.Tests/EnableSecretVersionTests.cs
+++ b/secretmanager/api/SecretManager.Samples.Tests/EnableSecretVersionTests.cs
@@ -48,30 +48,7 @@ public class EnableSecretVersionTests
         SecretVersion secretVersion = _sample.EnableSecretVersion(
           projectId: secretVersionName.ProjectId, secretId: secretVersionName.SecretId, secretVersionId: secretVersionName.SecretVersionId);
 
-        // Assert that the Secret gets disabled.
-        Assert.Equal(SecretVersion.Types.State.Enabled, secretVersion.State);
-
-        // Clean up the created resource
-        _fixture.DeleteSecret(secret.SecretName);
-    }
-
-    [Fact]
-    public void EnableSecretVersionScheduledForDestruction()
-    {
-        // Create the secret and add secret version.
-        Secret secret = _fixture.CreateSecretWithDelayedDestroy();
-
-        // Add the secret version to the created secret.
-        SecretVersion version = _fixture.AddSecretVersion(secret);
-
-        // Destroy the created secret.
-        SecretVersion destroyedVersion = _fixture.DestroySecretVersion(version);
-
-        // Run the sample code.
-        SecretVersion secretVersion = _sample.EnableSecretVersion(
-          projectId: destroyedVersion.SecretVersionName.ProjectId, secretId: destroyedVersion.SecretVersionName.SecretId, secretVersionId: destroyedVersion.SecretVersionName.SecretVersionId);
-
-        // Assert that the Secret gets disabled.
+        // Assert that the Secret gets enabled.
         Assert.Equal(SecretVersion.Types.State.Enabled, secretVersion.State);
 
         // Clean up the created resource

--- a/secretmanager/api/SecretManager.Samples.Tests/UpdateSecretWithDelayedDestroyTests.cs
+++ b/secretmanager/api/SecretManager.Samples.Tests/UpdateSecretWithDelayedDestroyTests.cs
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Google.Cloud.SecretManager.V1;
+using Google.Protobuf.WellKnownTypes;
+using System;
+using Xunit;
+
+[Collection(nameof(SecretManagerFixture))]
+public class UpdateSecretWithDelayedDestroyTests
+{
+    private readonly SecretManagerFixture _fixture;
+    private readonly UpdateSecretWithDelayedDestroySample _sample;
+
+    public UpdateSecretWithDelayedDestroyTests(SecretManagerFixture fixture)
+    {
+        _fixture = fixture;
+        _sample = new UpdateSecretWithDelayedDestroySample();
+    }
+
+    [Fact]
+    public void UpdatesSecretsDelayedDestroyDuration()
+    {
+        // Create the secret and add secret version.
+        Secret secret = _fixture.CreateSecretWithDelayedDestroy();
+
+        // Set the updated duration for delayed destruction.
+        int updatedTimeToLive = 172800;
+
+        // Run the sample code.
+        Secret result = _sample.UpdateSecretWithDelayedDestroy(
+          projectId: secret.SecretName.ProjectId, secretId: secret.SecretName.SecretId, updatedTimeToLive: updatedTimeToLive);
+
+        // Assert that the secret was updated with the correct configurations.
+        Assert.Equal(result.SecretName.SecretId, secret.SecretName.SecretId);
+        Assert.Equal(result.VersionDestroyTtl, Duration.FromTimeSpan(TimeSpan.FromSeconds(updatedTimeToLive)));
+
+        // Clean the created secret.
+        _fixture.DeleteSecret(secret.SecretName);
+    }
+}

--- a/secretmanager/api/SecretManager.Samples/CreateSecretWithDelayedDestroy.cs
+++ b/secretmanager/api/SecretManager.Samples/CreateSecretWithDelayedDestroy.cs
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// [START secretmanager_create_secret_with_delayed_destroy]
+
+using Google.Api.Gax.ResourceNames;
+using Google.Cloud.SecretManager.V1;
+using Google.Protobuf.WellKnownTypes;
+
+public class CreateSecretWithDelayedDestroySample
+{
+    public Secret CreateSecretWithDelayedDestroy(
+      string projectId = "my-project", string secretId = "my-secret", int timeToLive = 86400)
+    {
+        // Create the client.
+        SecretManagerServiceClient client = SecretManagerServiceClient.Create();
+
+        // Build the parent resource name.
+        ProjectName projectName = new ProjectName(projectId);
+
+        // Build the secret.
+        Secret secret = new Secret
+        {
+            Replication = new Replication
+            {
+                Automatic = new Replication.Types.Automatic(),
+            },
+            VersionDestroyTtl = new Duration
+            {
+                Seconds = timeToLive,
+            }
+        };
+
+        // Call the API.
+        Secret createdSecret = client.CreateSecret(projectName, secretId, secret);
+        return createdSecret;
+    }
+}
+// [END secretmanager_create_secret_with_delayed_destroy]

--- a/secretmanager/api/SecretManager.Samples/DisableSecretDelayedDestroy.cs
+++ b/secretmanager/api/SecretManager.Samples/DisableSecretDelayedDestroy.cs
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// [START secretmanager_disable_secret_delayed_destroy]
+
+using Google.Cloud.SecretManager.V1;
+using Google.Protobuf.WellKnownTypes;
+
+public class DisableSecretDelayedDestroySample
+{
+    public Secret DisableSecretDelayedDestroy(
+      string projectId = "my-project", string secretId = "my-secret")
+    {
+        // Create the client.
+        SecretManagerServiceClient client = SecretManagerServiceClient.Create();
+
+        // Build the secret with updated fields.
+        Secret secret = new Secret
+        {
+            SecretName = new SecretName(projectId, secretId),
+        };
+
+        // Build the field mask.
+        FieldMask fieldMask = FieldMask.FromString("version_destroy_ttl");
+
+        // Call the API.
+        Secret disabledSecret = client.UpdateSecret(secret, fieldMask);
+        return disabledSecret;
+    }
+}
+// [END secretmanager_disable_secret_delayed_destroy]

--- a/secretmanager/api/SecretManager.Samples/DisableSecretDelayedDestroy.cs
+++ b/secretmanager/api/SecretManager.Samples/DisableSecretDelayedDestroy.cs
@@ -37,8 +37,8 @@ public class DisableSecretDelayedDestroySample
         FieldMask fieldMask = FieldMask.FromString("version_destroy_ttl");
 
         // Call the API.
-        Secret disabledSecret = client.UpdateSecret(secret, fieldMask);
-        return disabledSecret;
+        Secret disabledDelayedDestroySecret = client.UpdateSecret(secret, fieldMask);
+        return disabledDelayedDestroySecret;
     }
 }
 // [END secretmanager_disable_secret_delayed_destroy]

--- a/secretmanager/api/SecretManager.Samples/UpdateSecretWithDelayedDestroy.cs
+++ b/secretmanager/api/SecretManager.Samples/UpdateSecretWithDelayedDestroy.cs
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// [START secretmanager_update_secret_with_delayed_destroy]
+
+using Google.Cloud.SecretManager.V1;
+using Google.Protobuf.WellKnownTypes;
+
+public class UpdateSecretWithDelayedDestroySample
+{
+    public Secret UpdateSecretWithDelayedDestroy(
+      string projectId = "my-project",
+      string secretId = "my-secret",
+      int updatedTimeToLive = 86400
+    )
+    {
+        // Create the client.
+        SecretManagerServiceClient client = SecretManagerServiceClient.Create();
+
+        // Build the secret with updated fields.
+        Secret secret = new Secret
+        {
+            SecretName = new SecretName(projectId, secretId),
+            VersionDestroyTtl = new Duration
+            {
+                Seconds = updatedTimeToLive
+            }
+        };
+
+        // Build the field mask.
+        FieldMask fieldMask = FieldMask.FromString("version_destroy_ttl");
+
+        // Call the API.
+        Secret updatedSecret = client.UpdateSecret(secret, fieldMask);
+        return updatedSecret;
+    }
+}
+// [END secretmanager_update_secret_with_delayed_destroy]


### PR DESCRIPTION
### Changes
- Added the necessary code samples for Delayed Destroy
- Added the test files for the code samples added
- Added the required changes in the fixture file
- Refactored some test cases file that were modified.
    - PS: The test cases added served as service functionality and were removed, but kept the refactoring introduced to the test files to adhere to the best practices.

### Prerequisite

- [X] Make sure to open an issue before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea.
    - https://github.com/GoogleCloudPlatform/dotnet-docs-samples/issues/2984
- [X] Follow the instructions in [CONTRIBUTING](CONTRIBUTING.md). Most importantly, ensure the tests and linter pass by running `dotnet format` in the subdirectories.
- [X] Update code documentation if necessary.

closes: #<2984>