### PR TITLE
feat(PubSub): Add CreateTopicWithKinesisIngestion Sample

### DIFF
--- a/pubsub/api/Pubsub.Samples.Tests/CreateTopicWithKinesisIngestionTest.cs
+++ b/pubsub/api/Pubsub.Samples.Tests/CreateTopicWithKinesisIngestionTest.cs
@@ -1,0 +1,47 @@
+// Copyright 2025 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.PubSub.V1;
+using Xunit;
+
+[Collection(nameof(PubsubFixture))]
+public class CreateTopicWithKinesisIngestionTest
+{
+    private readonly PubsubFixture _pubsubFixture;
+    private readonly CreateTopicWithKinesisIngestionSample _createTopicWithKinesisIngestionSample;
+
+    public CreateTopicWithKinesisIngestionTest(PubsubFixture pubsubFixture)
+    {
+        _pubsubFixture = pubsubFixture;
+        _createTopicWithKinesisIngestionSample = new CreateTopicWithKinesisIngestionSample();
+    }
+
+    [Fact]
+    public void CreateTopicWithKinesisIngestion()
+    {
+        string topicId = _pubsubFixture.RandomTopicId();
+        var (streamArn, consumerArn, awsRoleArn, gcpServiceAccount) = _pubsubFixture.RandomKinesisIngestionParams();
+        Topic createdTopic = _createTopicWithKinesisIngestionSample.CreateTopicWithKinesisIngestion(_pubsubFixture.ProjectId, topicId, streamArn, consumerArn, awsRoleArn, gcpServiceAccount);
+
+        // Confirm that the created topic and topic retrieved by ID are equal
+        Topic retrievedTopic = _pubsubFixture.GetTopic(topicId);
+        Assert.Equal(createdTopic, retrievedTopic);
+
+        // Confirm that all AWSKinesis Ingestion params are equal to expected values
+        Assert.Equal(streamArn, createdTopic.IngestionDataSourceSettings.AwsKinesis.StreamArn);
+        Assert.Equal(consumerArn, createdTopic.IngestionDataSourceSettings.AwsKinesis.ConsumerArn);
+        Assert.Equal(awsRoleArn, createdTopic.IngestionDataSourceSettings.AwsKinesis.AwsRoleArn);
+        Assert.Equal(gcpServiceAccount, createdTopic.IngestionDataSourceSettings.AwsKinesis.GcpServiceAccount);
+    }
+}

--- a/pubsub/api/Pubsub.Samples/CreateTopicWithKinesisIngestion.cs
+++ b/pubsub/api/Pubsub.Samples/CreateTopicWithKinesisIngestion.cs
@@ -1,0 +1,51 @@
+// Copyright 2025 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START pubsub_create_topic_with_kinesis_ingestion]
+
+using Google.Cloud.PubSub.V1;
+using System;
+
+public class CreateTopicWithKinesisIngestionSample
+{
+    public Topic CreateTopicWithKinesisIngestion(string projectId, string topicId, string streamArn, string consumerArn, string awsRoleArn, string gcpServiceAccount)
+    {
+        PublisherServiceApiClient publisher = PublisherServiceApiClient.Create();
+
+        // Define settings for Kinesis ingestion
+        IngestionDataSourceSettings ingestionDataSourceSettings = new IngestionDataSourceSettings
+        {
+            AwsKinesis = new IngestionDataSourceSettings.Types.AwsKinesis
+            {
+                AwsRoleArn = awsRoleArn,
+                ConsumerArn = consumerArn,
+                GcpServiceAccount = gcpServiceAccount,
+                StreamArn = streamArn
+            }
+        };
+
+        Topic topic = new Topic()
+        {
+            Name = TopicName.FormatProjectTopic(projectId, topicId),
+            IngestionDataSourceSettings = ingestionDataSourceSettings
+        };
+
+        Topic createdTopic = publisher.CreateTopic(topic);
+        Console.WriteLine($"Topic {topic.Name} created.");
+
+        return createdTopic;
+    }
+}
+
+// [END pubsub_create_topic_with_kinesis_ingestion]


### PR DESCRIPTION
https://cloud.google.com/pubsub/docs/samples/pubsub-create-topic-with-kinesis-ingestion

PubSub Fixture has a separate PR that this sample depends on: https://github.com/GoogleCloudPlatform/dotnet-docs-samples/pull/3030