### PR TITLE
samples(storage batch operations): add samples and tests for storage batch operations 

### DIFF
--- a/storagebatchoperations/api/README.md
+++ b/storagebatchoperations/api/README.md
@@ -1,0 +1,31 @@
+# Cloud Storage Batch Operations Sample
+
+These samples demonstrate how to interact with the [Google Cloud Storage Batch Operations API][Storage Batch Operations] from C# and
+the .NET client libraries to call the Storage Batch Operations API.
+
+The samples requires [.NET 8][.NET].That means using
+[Visual Studio 2022](https://www.visualstudio.com/), or the command line.
+
+## Setup
+
+1.  Set up a [.NET development environment](https://cloud.google.com/dotnet/docs/setup).
+
+4.  Enable APIs for your project.
+    [Click here][enable-api]
+    to visit Cloud Platform Console and enable the Google Cloud Storage Batch Operations API.
+
+## Contributing changes
+
+* See [CONTRIBUTING.md](../../CONTRIBUTING.md)
+
+## Licensing
+
+* See [LICENSE](../../LICENSE)
+
+## Testing
+
+* See [TESTING.md](../../TESTING.md)
+
+[Storage Batch Operations]: https://cloud.google.com/storage/docs/batch-operations/overview
+[enable-api]: https://console.cloud.google.com/flows/enableapi?apiid=storagebatchoperations_api&showconfirmation=true
+[.NET]: https://dotnet.microsoft.com/en-us/download

--- a/storagebatchoperations/api/StorageBatchOperations.Samples.Tests/CancelBatchJobTest.cs
+++ b/storagebatchoperations/api/StorageBatchOperations.Samples.Tests/CancelBatchJobTest.cs
@@ -15,6 +15,7 @@
 using Google.Api.Gax.ResourceNames;
 using Google.Cloud.StorageBatchOperations.V1;
 using Google.LongRunning;
+using System;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -76,7 +77,6 @@ public class CancelBatchJobTest
         string jobId = "12345678910")
     {
         StorageBatchOperationsClient storageBatchOperationsClient = StorageBatchOperationsClient.Create();
-
         CreateJobRequest request = new CreateJobRequest
         {
             ParentAsLocationName = locationName,
@@ -90,21 +90,23 @@ public class CancelBatchJobTest
         };
 
         Operation<Job, OperationMetadata> response = storageBatchOperationsClient.CreateJob(request);
-
         string operationName = response.Name;
         Operation<Job, OperationMetadata> retrievedResponse = storageBatchOperationsClient.PollOnceCreateJob(operationName);
 
-        if (retrievedResponse.IsCompleted)
-        {
-            string jobName = retrievedResponse.Metadata.Job.Name;
-            return jobName;
-        }
-        else
+        while (true)
         {
             retrievedResponse = retrievedResponse.PollOnce();
-            string jobName = retrievedResponse.Metadata.Job.Name;
-            return jobName;
+            if (string.IsNullOrEmpty(retrievedResponse.Metadata.ToString()))
+            {
+                continue;
+            }
+            else
+            {
+                break;
+            }
         }
+        string jobName = retrievedResponse.Metadata.Job.Name;
+        return jobName;
     }
 
     /// <summary>

--- a/storagebatchoperations/api/StorageBatchOperations.Samples.Tests/CancelBatchJobTest.cs
+++ b/storagebatchoperations/api/StorageBatchOperations.Samples.Tests/CancelBatchJobTest.cs
@@ -1,0 +1,114 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+using Google.Api.Gax.ResourceNames;
+using Google.Cloud.StorageBatchOperations.V1;
+using Google.LongRunning;
+using System.IO;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+[Collection(nameof(StorageFixture))]
+public class CancelBatchJobTest
+{
+    private readonly StorageFixture _fixture;
+    private readonly BucketList.Types.Bucket _bucket = new();
+    private readonly BucketList _bucketList = new();
+    private readonly PrefixList _prefixListObject = new();
+
+    public CancelBatchJobTest(StorageFixture fixture)
+    {
+        int i = 10;
+        _fixture = fixture;
+        var bucketName = _fixture.GenerateBucketName();
+        _fixture.CreateBucket(bucketName, multiVersion: false, softDelete: false, registerForDeletion: true);
+        while (i >= 0)
+        {
+            var objectName = _fixture.GenerateName();
+            var objectContent = _fixture.GenerateContent();
+            byte[] byteObjectContent = Encoding.UTF8.GetBytes(objectContent);
+            MemoryStream streamObjectContent = new MemoryStream(byteObjectContent);
+            _fixture.Client.UploadObject(bucketName, objectName, "application/text", streamObjectContent);
+            i--;
+        }
+        _bucket = new BucketList.Types.Bucket
+        {
+            Bucket_ = bucketName,
+            PrefixList = _prefixListObject
+        };
+        _bucketList.Buckets.Insert(0, _bucket);
+    }
+
+    [Fact]
+    public void CancelBatchJob()
+    {
+        CancelBatchJobSample cancelBatchJob = new CancelBatchJobSample();
+        ListBatchJobsSample listBatchJobs = new ListBatchJobsSample();
+        GetBatchJobSample getBatchJob = new GetBatchJobSample();
+        string filter = "state:canceled";
+        int pageSize = 10;
+        string orderBy = "create_time";
+        var jobId = _fixture.GenerateJobId();
+        var createdJob = CreateBatchJob(_fixture.LocationName, _bucketList, jobId);
+        var jobResponse = cancelBatchJob.CancelBatchJob(createdJob);
+        PollUntilCancelled();
+        var batchJobs = listBatchJobs.ListBatchJobs(_fixture.LocationName, filter, pageSize, orderBy);
+        Assert.Contains(batchJobs, job => job.Name == createdJob);
+        Job cancelledJob = getBatchJob.GetBatchJob(createdJob);
+        Assert.Equal("Canceled", cancelledJob.State.ToString());
+        _fixture.DeleteBatchJob(createdJob);
+    }
+
+    public static string CreateBatchJob(LocationName locationName,
+        BucketList bucketList,
+        string jobId = "12345678910")
+    {
+        StorageBatchOperationsClient storageBatchOperationsClient = StorageBatchOperationsClient.Create();
+
+        CreateJobRequest request = new CreateJobRequest
+        {
+            ParentAsLocationName = locationName,
+            JobId = jobId,
+            Job = new Job
+            {
+                BucketList = bucketList,
+                DeleteObject = new DeleteObject { PermanentObjectDeletionEnabled = true }
+            },
+            RequestId = jobId,
+        };
+
+        Operation<Job, OperationMetadata> response = storageBatchOperationsClient.CreateJob(request);
+
+        string operationName = response.Name;
+        Operation<Job, OperationMetadata> retrievedResponse = storageBatchOperationsClient.PollOnceCreateJob(operationName);
+
+        if (retrievedResponse.IsCompleted)
+        {
+            string jobName = retrievedResponse.Metadata.Job.Name;
+            return jobName;
+        }
+        else
+        {
+            retrievedResponse = retrievedResponse.PollOnce();
+            string jobName = retrievedResponse.Metadata.Job.Name;
+            return jobName;
+        }
+    }
+
+    /// <summary>
+    /// Wait for 15 seconds until completion of cancel batch job operation.
+    /// </summary>
+    private static void PollUntilCancelled() => Thread.Sleep(15000);
+}

--- a/storagebatchoperations/api/StorageBatchOperations.Samples.Tests/CreateBatchJobTest.cs
+++ b/storagebatchoperations/api/StorageBatchOperations.Samples.Tests/CreateBatchJobTest.cs
@@ -58,7 +58,7 @@ public class CreateBatchJobTest
     {
         CreateBatchJobSample createJob = new CreateBatchJobSample();
         var jobId = _fixture.GenerateJobId();
-        var jobTransformationCase = "PutObjectHold";
+        var jobTransformationCase = "DeleteObject";
         var holdState = "EventBasedHoldSet";
         string jobType;
         if (jobTransformationCase == "PutObjectHold")

--- a/storagebatchoperations/api/StorageBatchOperations.Samples.Tests/CreateBatchJobTest.cs
+++ b/storagebatchoperations/api/StorageBatchOperations.Samples.Tests/CreateBatchJobTest.cs
@@ -1,0 +1,82 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+using Google.Cloud.StorageBatchOperations.V1;
+using System;
+using System.IO;
+using System.Text;
+using Xunit;
+
+[Collection(nameof(StorageFixture))]
+public class CreateBatchJobTest
+{
+    private readonly StorageFixture _fixture;
+    private readonly BucketList.Types.Bucket _bucket = new();
+    private readonly BucketList _bucketList = new();
+    private readonly PrefixList _prefixListObject = new();
+
+    public CreateBatchJobTest(StorageFixture fixture)
+    {
+        _fixture = fixture;
+        var bucketName = _fixture.GenerateBucketName();
+        _fixture.CreateBucket(bucketName, multiVersion: false, softDelete: false, registerForDeletion: true);
+        var manifestBucketName = _fixture.GenerateBucketName();
+        _fixture.CreateBucket(manifestBucketName, multiVersion: false, softDelete: false, registerForDeletion: true);
+        var objectName = _fixture.GenerateName();
+        var manifestObjectName = _fixture.GenerateName();
+        var objectContent = _fixture.GenerateContent();
+        var manifestObjectContent = $"bucket,name,generation{Environment.NewLine}{bucketName},{objectName}";
+        byte[] byteObjectContent = Encoding.UTF8.GetBytes(objectContent);
+        MemoryStream streamObjectContent = new MemoryStream(byteObjectContent);
+        _fixture.Client.UploadObject(bucketName, objectName, "application/text", streamObjectContent);
+        byte[] byteManifestObjectContent = Encoding.UTF8.GetBytes(manifestObjectContent);
+        MemoryStream streamManifestObjectContent = new MemoryStream(byteManifestObjectContent);
+        _fixture.Client.UploadObject(manifestBucketName, $"{manifestObjectName}.csv", "text/csv", streamManifestObjectContent);
+
+        _bucket = new BucketList.Types.Bucket
+        {
+            Bucket_ = bucketName,
+            PrefixList = _prefixListObject,
+            Manifest = new Manifest { ManifestLocation = $"gs://{manifestBucketName}/{manifestObjectName}.csv" }
+        };
+        _bucketList.Buckets.Insert(0, _bucket);
+    }
+
+    [Fact]
+    public void CreateBatchJob()
+    {
+        CreateBatchJobSample createJob = new CreateBatchJobSample();
+        var jobId = _fixture.GenerateJobId();
+        var jobTransformationCase = "PutObjectHold";
+        var holdState = "EventBasedHoldSet";
+        string jobType;
+        if (jobTransformationCase == "PutObjectHold")
+        {
+            jobType = $"{jobTransformationCase}{holdState}";
+        }
+        else
+        {
+            jobType = jobTransformationCase;
+        }
+
+        var createdBatchJob = createJob.CreateBatchJob(_fixture.LocationName, _bucketList, jobId, jobType);
+        Assert.Equal(createdBatchJob.BucketList, _bucketList);
+        Assert.Equal(createdBatchJob.TransformationCase.ToString(), jobTransformationCase);
+        Assert.Equal(createdBatchJob.SourceCase.ToString(), _bucketList.GetType().Name);
+        Assert.NotNull(createdBatchJob.Name);
+        Assert.NotNull(createdBatchJob.JobName);
+        Assert.NotNull(createdBatchJob.CreateTime);
+        Assert.NotNull(createdBatchJob.CompleteTime);
+    }
+}

--- a/storagebatchoperations/api/StorageBatchOperations.Samples.Tests/DeleteBatchJobTest.cs
+++ b/storagebatchoperations/api/StorageBatchOperations.Samples.Tests/DeleteBatchJobTest.cs
@@ -1,0 +1,57 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+using Google.Cloud.StorageBatchOperations.V1;
+using Xunit;
+
+[Collection(nameof(StorageFixture))]
+public class DeleteBatchJobTest
+{
+    private readonly StorageFixture _fixture;
+    private readonly BucketList.Types.Bucket _bucket = new();
+    private readonly BucketList _bucketList = new();
+    private readonly PrefixList _prefixListObject = new();
+
+    public DeleteBatchJobTest(StorageFixture fixture)
+    {
+        _fixture = fixture;
+        var bucketName = _fixture.GenerateBucketName();
+        _fixture.CreateBucket(bucketName, multiVersion: false, softDelete: false, registerForDeletion: true);
+        _bucket = new BucketList.Types.Bucket
+        {
+            Bucket_ = bucketName,
+            PrefixList = _prefixListObject
+        };
+        _bucketList.Buckets.Insert(0, _bucket);
+    }
+
+    [Fact]
+    public void DeleteBatchJob()
+    {
+        DeleteBatchJobSample deleteBatchJob = new DeleteBatchJobSample();
+        ListBatchJobsSample listBatchJobs = new ListBatchJobsSample();
+        GetBatchJobSample getBatchJob = new GetBatchJobSample();
+        string filter = "";
+        int pageSize = 10;
+        string orderBy = "create_time";
+        var jobId = _fixture.GenerateJobId();
+        CreateBatchJobSample createBatchJob = new CreateBatchJobSample();
+        var createdJob = createBatchJob.CreateBatchJob(_fixture.LocationName, _bucketList, jobId);
+        deleteBatchJob.DeleteBatchJob(createdJob.Name);
+        var batchJobs = listBatchJobs.ListBatchJobs(_fixture.LocationName, filter, pageSize, orderBy);
+        Assert.DoesNotContain(batchJobs, job => job.JobName == createdJob.JobName);
+        var exception = Assert.Throws<Grpc.Core.RpcException>(() => getBatchJob.GetBatchJob(createdJob.Name));
+        Assert.Equal(Grpc.Core.StatusCode.NotFound, exception.StatusCode);
+    }
+}

--- a/storagebatchoperations/api/StorageBatchOperations.Samples.Tests/GetBatchJobTest.cs
+++ b/storagebatchoperations/api/StorageBatchOperations.Samples.Tests/GetBatchJobTest.cs
@@ -1,0 +1,59 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+using Google.Cloud.StorageBatchOperations.V1;
+using Xunit;
+
+[Collection(nameof(StorageFixture))]
+public class GetBatchJobTest
+{
+    private readonly StorageFixture _fixture;
+    private readonly BucketList.Types.Bucket _bucket = new();
+    private readonly BucketList _bucketList = new();
+    private readonly PrefixList _prefixListObject = new();
+
+    public GetBatchJobTest(StorageFixture fixture)
+    {
+        _fixture = fixture;
+        var bucketName = _fixture.GenerateBucketName();
+        _fixture.CreateBucket(bucketName, multiVersion: false, softDelete: false, registerForDeletion: true);
+        _bucket = new BucketList.Types.Bucket
+        {
+            Bucket_ = bucketName,
+            PrefixList = _prefixListObject
+        };
+        _bucketList.Buckets.Insert(0, _bucket);
+    }
+
+    [Fact]
+    public void GetBatchJob()
+    {
+        GetBatchJobSample getJob = new GetBatchJobSample();
+        var jobId = _fixture.GenerateJobId();
+        CreateBatchJobSample createJob = new CreateBatchJobSample();
+        var createdJob = createJob.CreateBatchJob(_fixture.LocationName, _bucketList, jobId);
+        var getCreatedJob = getJob.GetBatchJob(createdJob.Name);
+        Assert.Equal(createdJob.Name, getCreatedJob.Name);
+        Assert.Equal(createdJob.BucketList, getCreatedJob.BucketList);
+        Assert.Equal(createdJob.TransformationCase.ToString(), getCreatedJob.TransformationCase.ToString());
+        Assert.Equal(createdJob.SourceCase.ToString(), getCreatedJob.SourceCase.ToString());
+        Assert.Equal(createdJob.State, getCreatedJob.State);
+        Assert.Equal(createdJob.Description, getCreatedJob.Description);
+        Assert.Equal(createdJob.ScheduleTime, getCreatedJob.ScheduleTime);
+        Assert.Equal(createdJob.CompleteTime, getCreatedJob.CompleteTime);
+        Assert.Equal(createdJob.CreateTime, getCreatedJob.CreateTime);
+        Assert.Equal(createdJob.Counters, getCreatedJob.Counters);
+        _fixture.DeleteBatchJob(createdJob.Name);
+    }
+}

--- a/storagebatchoperations/api/StorageBatchOperations.Samples.Tests/ListBatchJobsTest.cs
+++ b/storagebatchoperations/api/StorageBatchOperations.Samples.Tests/ListBatchJobsTest.cs
@@ -1,0 +1,64 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+using Google.Cloud.StorageBatchOperations.V1;
+using Xunit;
+
+[Collection(nameof(StorageFixture))]
+public class ListBatchJobsTest
+{
+    private readonly StorageFixture _fixture;
+    private readonly BucketList.Types.Bucket _bucket = new();
+    private readonly BucketList _bucketList = new();
+    private readonly PrefixList _prefixListObject = new();
+
+    public ListBatchJobsTest(StorageFixture fixture)
+    {
+        _fixture = fixture;
+        var bucketName = _fixture.GenerateBucketName();
+        _fixture.CreateBucket(bucketName, multiVersion: false, softDelete: false, registerForDeletion: true);
+        _bucket = new BucketList.Types.Bucket
+        {
+            Bucket_ = bucketName,
+            PrefixList = _prefixListObject
+        };
+        _bucketList.Buckets.Insert(0, _bucket);
+    }
+
+    [Fact]
+    public void ListBatchJobs()
+    {
+        ListBatchJobsSample listBatchJobs = new ListBatchJobsSample();
+        string filter = "state:succeeded";
+        int pageSize = 10;
+        string orderBy = "create_time";
+        var jobId = _fixture.GenerateJobId();
+        CreateBatchJobSample createBatchJob = new CreateBatchJobSample();
+        var createdJob = createBatchJob.CreateBatchJob(_fixture.LocationName, _bucketList, jobId);
+        var batchJobs = listBatchJobs.ListBatchJobs(_fixture.LocationName, filter, pageSize, orderBy);
+        Assert.Contains(batchJobs, job => job.JobName == createdJob.JobName && job.State == createdJob.State && job.SourceCase == createdJob.SourceCase && job.TransformationCase == createdJob.TransformationCase);
+        Assert.All(batchJobs, AssertBatchJob);
+        _fixture.DeleteBatchJob(createdJob.Name);
+    }
+
+    private void AssertBatchJob(Job b)
+    {
+        Assert.NotNull(b.Name);
+        Assert.NotNull(b.JobName);
+        Assert.NotNull(b.CreateTime);
+        Assert.NotNull(b.CompleteTime);
+        Assert.NotNull(b.SourceCase.ToString());
+        Assert.NotNull(b.TransformationCase.ToString());
+    }
+}

--- a/storagebatchoperations/api/StorageBatchOperations.Samples.Tests/StorageBatchOperations.Samples.Tests.csproj
+++ b/storagebatchoperations/api/StorageBatchOperations.Samples.Tests/StorageBatchOperations.Samples.Tests.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\StorageBatchOperations.Samples\StorageBatchOperations.Samples.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/storagebatchoperations/api/StorageBatchOperations.Samples.Tests/StorageFixture.cs
+++ b/storagebatchoperations/api/StorageBatchOperations.Samples.Tests/StorageFixture.cs
@@ -1,0 +1,133 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Api.Gax.ResourceNames;
+using Google.Apis.Auth.OAuth2;
+using Google.Apis.Storage.v1.Data;
+using Google.Cloud.Storage.V1;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Xunit;
+
+[CollectionDefinition(nameof(StorageFixture))]
+public class StorageFixture : IDisposable, ICollectionFixture<StorageFixture>
+{
+    public string ProjectId { get; }
+    public string LocationId { get; } = "global";
+    public IList<string> TempBucketNames { get; } = [];
+    public string ServiceAccountEmail { get; } = "gcs-iam-acl-test@dotnet-docs-samples-tests.iam.gserviceaccount.com";
+    public StorageClient Client { get; }
+    public LocationName LocationName { get; }
+
+    public StorageFixture()
+    {
+        ProjectId = Environment.GetEnvironmentVariable("GOOGLE_PROJECT_ID");
+        if (string.IsNullOrWhiteSpace(ProjectId))
+        {
+            throw new Exception("You need to set the Environment variable 'GOOGLE_PROJECT_ID' with your Google Cloud Project's project id.");
+        }
+        LocationName = LocationName.FromProjectLocation(ProjectId, LocationId);
+        Client = StorageClient.Create();
+    }
+
+    /// <summary>
+    /// Creates a bucket.
+    /// </summary>
+    /// <returns>A bucket.</returns>
+    internal Bucket CreateBucket(string name, bool multiVersion, bool softDelete = false, bool registerForDeletion = true)
+    {
+        var bucket = Client.CreateBucket(ProjectId,
+            new Bucket
+            {
+                Name = name,
+                Versioning = new Bucket.VersioningData { Enabled = multiVersion },
+                // The minimum allowed for soft delete is 7 days.
+                SoftDeletePolicy = softDelete ? new Bucket.SoftDeletePolicyData { RetentionDurationSeconds = (int) TimeSpan.FromDays(7).TotalSeconds } : null,
+            });
+        SleepAfterBucketCreateUpdateDelete();
+        if (registerForDeletion)
+        {
+            TempBucketNames.Add(name);
+        }
+        return bucket;
+    }
+
+    /// <summary>
+    /// Generate the name of the bucket.
+    /// </summary>
+    /// <returns>The bucketName.</returns>
+    internal string GenerateBucketName() => Guid.NewGuid().ToString();
+
+    /// <summary>
+    /// Generate the Id of the job.
+    /// </summary>
+    /// <returns>The jobId.</returns>
+    internal string GenerateJobId() => Guid.NewGuid().ToString();
+
+    /// <summary>
+    /// Generate the name of the object.
+    /// </summary>
+    /// <returns>The objectName.</returns>
+    internal string GenerateName() => Guid.NewGuid().ToString();
+
+    /// <summary>
+    /// Generate the content of the object.
+    /// </summary>
+    /// <returns>The objectContent.</returns>
+    internal string GenerateContent() => Guid.NewGuid().ToString();
+
+    /// <summary>
+    /// Bucket creation/update/deletion is rate-limited. To avoid making the tests flaky, we sleep after each operation.
+    /// </summary>
+    internal void SleepAfterBucketCreateUpdateDelete() => Thread.Sleep(2000);
+
+    internal string GetServiceAccountEmail()
+    {
+        var cred = GoogleCredential.GetApplicationDefault().UnderlyingCredential;
+        switch (cred)
+        {
+            case ServiceAccountCredential sac:
+                return sac.Id;
+            // TODO: We may well need to handle ComputeCredential for Kokoro.
+            default:
+                throw new InvalidOperationException($"Unable to retrieve service account email address for credential type {cred.GetType()}");
+        }
+    }
+
+    /// <summary>
+    /// Deletes the batch job at the end of the test.
+    /// </summary>
+    internal void DeleteBatchJob(string jobName)
+    {
+        DeleteBatchJobSample deleteBatchJob = new DeleteBatchJobSample();
+        deleteBatchJob.DeleteBatchJob(jobName);
+    }
+
+    public void Dispose()
+    {
+        foreach (var bucketName in TempBucketNames)
+        {
+            try
+            {
+                Client.DeleteBucket(bucketName, new DeleteBucketOptions { DeleteObjects = true });
+                SleepAfterBucketCreateUpdateDelete();
+            }
+            catch (Exception)
+            {
+                // Do nothing, we delete on a best effort basis.
+            }
+        }
+    }
+}

--- a/storagebatchoperations/api/StorageBatchOperations.Samples/CancelBatchJob.cs
+++ b/storagebatchoperations/api/StorageBatchOperations.Samples/CancelBatchJob.cs
@@ -1,0 +1,39 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+// [START storage_batch_cancel_job]
+
+using Google.Cloud.StorageBatchOperations.V1;
+using System;
+
+public class CancelBatchJobSample
+{
+    /// <summary>
+    /// Cancels a storage batch operation job.
+    /// </summary>
+    /// <param name="jobName">The name of the job to cancel. Format: projects/{project_id}/locations/{location_id}/jobs/{job_id}.</param>
+    public CancelJobResponse CancelBatchJob(string jobName = "projects/{project_id}/locations/{location_id}/jobs/{job_id}")
+    {
+        StorageBatchOperationsClient storageBatchOperationsClient = StorageBatchOperationsClient.Create();
+        CancelJobRequest request = new CancelJobRequest
+        {
+            Name = jobName,
+            RequestId = jobName
+        };
+        var response = storageBatchOperationsClient.CancelJob(request);
+        Console.WriteLine($"The Storage Batch Operation Job (Name: {jobName}) is cancelled");
+        return response;
+    }
+}
+// [END storage_batch_cancel_job]

--- a/storagebatchoperations/api/StorageBatchOperations.Samples/CreateBatchJob.cs
+++ b/storagebatchoperations/api/StorageBatchOperations.Samples/CreateBatchJob.cs
@@ -1,0 +1,140 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+// [START storage_batch_create_job]
+
+using Google.Api.Gax.ResourceNames;
+using Google.Cloud.StorageBatchOperations.V1;
+using Google.LongRunning;
+using System;
+
+public class CreateBatchJobSample
+{
+    private RewriteObject _rewriteObject;
+    private PutMetadata _putMetadata;
+    private DeleteObject _deleteObject;
+    private PutObjectHold _putObjectHold;
+    private Job _job;
+
+    /// <summary>
+    /// Creates a storage batch operation job.
+    /// </summary>
+    /// <param name="locationName">A resource name with pattern <c>projects/{project}/locations/{location}</c>.</param>
+    /// <param name="bucketList">A bucket list contains list of buckets and their objects to be transformed.</param>
+    /// <param name="jobId">It is id for the job and it should not be more than 128 characters and must include only
+    /// characters available in DNS names, as defined by RFC-1123.</param>
+    /// <param name="jobType">It is type of storage batch operation job.</param>
+    public Job CreateBatchJob(LocationName locationName,
+        BucketList bucketList,
+        string jobId = "12345678910",
+        string jobType = "DeleteObject")
+    {
+        StorageBatchOperationsClient storageBatchOperationsClient = StorageBatchOperationsClient.Create();
+
+        if (jobType == "RewriteObject")
+        {
+            _rewriteObject = new RewriteObject { KmsKey = "projects/{project}/locations/{location}/keyRings/{keyring}/cryptoKeys/{key}" };
+
+            _job = new Job
+            {
+                RewriteObject = _rewriteObject,
+                BucketList = bucketList
+            };
+        }
+        else if (jobType == "PutMetadata")
+        {
+            _putMetadata = new PutMetadata { CacheControl = "", ContentDisposition = "", ContentEncoding = "", ContentLanguage = "", ContentType = "", CustomTime = "" };
+
+            _job = new Job
+            {
+                PutMetadata = _putMetadata,
+                BucketList = bucketList
+            };
+        }
+        else if (jobType == "DeleteObject")
+        {
+            _deleteObject = new DeleteObject { PermanentObjectDeletionEnabled = true };
+
+            _job = new Job
+            {
+                DeleteObject = _deleteObject,
+                BucketList = bucketList
+            };
+        }
+        else if (jobType == "PutObjectHoldEventBasedHoldSet")
+        {
+            _putObjectHold = new PutObjectHold { EventBasedHold = PutObjectHold.Types.HoldStatus.Set };
+
+            _job = new Job
+            {
+                PutObjectHold = _putObjectHold,
+                BucketList = bucketList
+            };
+        }
+        else if (jobType == "PutObjectHoldEventBasedHoldUnSet")
+        {
+            _putObjectHold = new PutObjectHold { EventBasedHold = PutObjectHold.Types.HoldStatus.Unset };
+
+            _job = new Job
+            {
+                PutObjectHold = _putObjectHold,
+                BucketList = bucketList
+            };
+        }
+        else if (jobType == "PutObjectHoldTemporaryHoldSet")
+        {
+            _putObjectHold = new PutObjectHold { TemporaryHold = PutObjectHold.Types.HoldStatus.Set };
+
+            _job = new Job
+            {
+                PutObjectHold = _putObjectHold,
+                BucketList = bucketList
+            };
+        }
+        else if (jobType == "PutObjectHoldTemporaryHoldUnSet")
+        {
+            _putObjectHold = new PutObjectHold { TemporaryHold = PutObjectHold.Types.HoldStatus.Unset };
+
+            _job = new Job
+            {
+                PutObjectHold = _putObjectHold,
+                BucketList = bucketList
+            };
+        }
+
+        CreateJobRequest request = new CreateJobRequest
+        {
+            ParentAsLocationName = locationName,
+            JobId = jobId,
+            Job = _job,
+            RequestId = jobId,
+        };
+
+        Operation<Job, OperationMetadata> response = storageBatchOperationsClient.CreateJob(request);
+        Operation<Job, OperationMetadata> completedResponse = response.PollUntilCompleted();
+
+        Job result = completedResponse.Result;
+        string operationName = response.Name;
+        Operation<Job, OperationMetadata> retrievedResponse = storageBatchOperationsClient.PollOnceCreateJob(operationName);
+
+        if (retrievedResponse.IsCompleted)
+        {
+            Job retrievedResult = retrievedResponse.Result;
+            return retrievedResult;
+        }
+        Console.WriteLine($"The Storage Batch Operation Job (Name: {result.Name}) is created");
+        return result;
+    }
+}
+// [END storage_batch_create_job]

--- a/storagebatchoperations/api/StorageBatchOperations.Samples/DeleteBatchJob.cs
+++ b/storagebatchoperations/api/StorageBatchOperations.Samples/DeleteBatchJob.cs
@@ -1,0 +1,37 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+// [START storage_batch_delete_job]
+
+using Google.Cloud.StorageBatchOperations.V1;
+using System;
+
+public class DeleteBatchJobSample
+{
+    /// <summary>
+    /// Deletes a storage batch operation job.
+    /// </summary>
+    /// <param name="jobName">The name of the job to delete. Format: projects/{project_id}/locations/{location_id}/jobs/{job_id}.</param>
+    public void DeleteBatchJob(string jobName = "projects/{project_id}/locations/{location_id}/jobs/{job_id}")
+    {
+        StorageBatchOperationsClient storageBatchOperationsClient = StorageBatchOperationsClient.Create();
+        DeleteJobRequest request = new DeleteJobRequest
+        {
+            Name = jobName
+        };
+        storageBatchOperationsClient.DeleteJob(request);
+        Console.WriteLine($"The Storage Batch Operation Job (Name : {jobName}) is deleted");
+    }
+}
+// [END storage_batch_delete_job]

--- a/storagebatchoperations/api/StorageBatchOperations.Samples/GetBatchJob.cs
+++ b/storagebatchoperations/api/StorageBatchOperations.Samples/GetBatchJob.cs
@@ -20,7 +20,7 @@ using System;
 public class GetBatchJobSample
 {
     /// <summary>
-    /// Get a storage batch operation job.
+    /// Gets a storage batch operation job.
     /// </summary>
     /// <param name="jobName">The name of the job to get. Format: projects/{project_id}/locations/{location_id}/jobs/{job_id}.</param>
     public Job GetBatchJob(string jobName = "projects/{project_id}/locations/{location_id}/jobs/{job_id}")
@@ -30,7 +30,6 @@ public class GetBatchJobSample
         {
             Name = jobName
         };
-
         var response = storageBatchOperationsClient.GetJob(request);
         Console.WriteLine($"The Name of Storage Batch Operation Job is : {response.Name}");
         return response;

--- a/storagebatchoperations/api/StorageBatchOperations.Samples/GetBatchJob.cs
+++ b/storagebatchoperations/api/StorageBatchOperations.Samples/GetBatchJob.cs
@@ -1,0 +1,39 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+// [START storage_batch_get_job]
+
+using Google.Cloud.StorageBatchOperations.V1;
+using System;
+
+public class GetBatchJobSample
+{
+    /// <summary>
+    /// Get a storage batch operation job.
+    /// </summary>
+    /// <param name="jobName">The name of the job to get. Format: projects/{project_id}/locations/{location_id}/jobs/{job_id}.</param>
+    public Job GetBatchJob(string jobName = "projects/{project_id}/locations/{location_id}/jobs/{job_id}")
+    {
+        StorageBatchOperationsClient storageBatchOperationsClient = StorageBatchOperationsClient.Create();
+        GetJobRequest request = new GetJobRequest
+        {
+            Name = jobName
+        };
+
+        var response = storageBatchOperationsClient.GetJob(request);
+        Console.WriteLine($"The Name of Storage Batch Operation Job is : {response.Name}");
+        return response;
+    }
+}
+// [END storage_batch_get_job]

--- a/storagebatchoperations/api/StorageBatchOperations.Samples/ListBatchJobs.cs
+++ b/storagebatchoperations/api/StorageBatchOperations.Samples/ListBatchJobs.cs
@@ -1,0 +1,64 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+// [START storage_batch_list_jobs]
+
+using Google.Api.Gax;
+using Google.Api.Gax.ResourceNames;
+using Google.Cloud.StorageBatchOperations.V1;
+using System;
+using System.Collections.Generic;
+
+public class ListBatchJobsSample
+{
+    /// <summary>
+    /// List storage batch operation jobs.
+    /// </summary>
+    /// <param name="locationName">A resource name with pattern <c>projects/{project}/locations/{location}</c>.</param>
+    /// <param name="filter">The field to filter the list of storage batch operation jobs.</param>
+    /// <param name="pageSize">The page size to retrieve page of known size.</param>
+    /// <param name="orderBy">The field to sort the list of storage batch operation jobs. Supported fields are name and create_time.</param>
+    public IEnumerable<Job> ListBatchJobs(LocationName locationName,
+        string filter = "state:failed",
+        int pageSize = 100,
+        string orderBy = "name")
+    {
+        StorageBatchOperationsClient storageBatchOperationsClient = StorageBatchOperationsClient.Create();
+
+        ListJobsRequest request = new ListJobsRequest
+        {
+            ParentAsLocationName = locationName,
+            Filter = filter,
+            OrderBy = orderBy
+        };
+        PagedEnumerable<ListJobsResponse, Job> response = storageBatchOperationsClient.ListJobs(request);
+        Console.WriteLine("Storage Batch Operation Jobs are as follows:");
+
+        foreach (var item in response)
+        {
+            Console.WriteLine(item);
+        }
+
+        // Retrieve a single page of known size
+        Page<Job> singlePage = response.ReadPage(pageSize);
+        Console.WriteLine($"A single page of {pageSize} page size of Storage Batch Operation Jobs are as follows:");
+
+        foreach (Job item in singlePage)
+        {
+            Console.WriteLine(item);
+        }
+        return response;
+    }
+}
+// [END storage_batch_list_jobs]

--- a/storagebatchoperations/api/StorageBatchOperations.Samples/ListBatchJobs.cs
+++ b/storagebatchoperations/api/StorageBatchOperations.Samples/ListBatchJobs.cs
@@ -23,7 +23,7 @@ using System.Collections.Generic;
 public class ListBatchJobsSample
 {
     /// <summary>
-    /// List storage batch operation jobs.
+    /// Lists storage batch operation jobs.
     /// </summary>
     /// <param name="locationName">A resource name with pattern <c>projects/{project}/locations/{location}</c>.</param>
     /// <param name="filter">The field to filter the list of storage batch operation jobs.</param>
@@ -35,7 +35,6 @@ public class ListBatchJobsSample
         string orderBy = "name")
     {
         StorageBatchOperationsClient storageBatchOperationsClient = StorageBatchOperationsClient.Create();
-
         ListJobsRequest request = new ListJobsRequest
         {
             ParentAsLocationName = locationName,

--- a/storagebatchoperations/api/StorageBatchOperations.Samples/StorageBatchOperations.Samples.csproj
+++ b/storagebatchoperations/api/StorageBatchOperations.Samples/StorageBatchOperations.Samples.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Cloud.Storage.V1" Version="4.13.0" />
+    <PackageReference Include="Google.Cloud.StorageBatchOperations.V1" Version="1.0.0-beta01" />
+  </ItemGroup>
+
+</Project>

--- a/storagebatchoperations/api/StorageBatchOperations.sln
+++ b/storagebatchoperations/api/StorageBatchOperations.sln
@@ -1,0 +1,50 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.11.35303.130
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StorageBatchOperations.Samples", "StorageBatchOperations.Samples\StorageBatchOperations.Samples.csproj", "{11EFF973-23FE-41B6-82D5-E8A0BA79F21C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StorageBatchOperations.Samples.Tests", "StorageBatchOperations.Samples.Tests\StorageBatchOperations.Samples.Tests.csproj", "{2BB74746-319D-465B-AAD5-C4430322501E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{11EFF973-23FE-41B6-82D5-E8A0BA79F21C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{11EFF973-23FE-41B6-82D5-E8A0BA79F21C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{11EFF973-23FE-41B6-82D5-E8A0BA79F21C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{11EFF973-23FE-41B6-82D5-E8A0BA79F21C}.Debug|x64.Build.0 = Debug|Any CPU
+		{11EFF973-23FE-41B6-82D5-E8A0BA79F21C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{11EFF973-23FE-41B6-82D5-E8A0BA79F21C}.Debug|x86.Build.0 = Debug|Any CPU
+		{11EFF973-23FE-41B6-82D5-E8A0BA79F21C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{11EFF973-23FE-41B6-82D5-E8A0BA79F21C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{11EFF973-23FE-41B6-82D5-E8A0BA79F21C}.Release|x64.ActiveCfg = Release|Any CPU
+		{11EFF973-23FE-41B6-82D5-E8A0BA79F21C}.Release|x64.Build.0 = Release|Any CPU
+		{11EFF973-23FE-41B6-82D5-E8A0BA79F21C}.Release|x86.ActiveCfg = Release|Any CPU
+		{11EFF973-23FE-41B6-82D5-E8A0BA79F21C}.Release|x86.Build.0 = Release|Any CPU
+		{2BB74746-319D-465B-AAD5-C4430322501E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2BB74746-319D-465B-AAD5-C4430322501E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2BB74746-319D-465B-AAD5-C4430322501E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2BB74746-319D-465B-AAD5-C4430322501E}.Debug|x64.Build.0 = Debug|Any CPU
+		{2BB74746-319D-465B-AAD5-C4430322501E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2BB74746-319D-465B-AAD5-C4430322501E}.Debug|x86.Build.0 = Debug|Any CPU
+		{2BB74746-319D-465B-AAD5-C4430322501E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2BB74746-319D-465B-AAD5-C4430322501E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2BB74746-319D-465B-AAD5-C4430322501E}.Release|x64.ActiveCfg = Release|Any CPU
+		{2BB74746-319D-465B-AAD5-C4430322501E}.Release|x64.Build.0 = Release|Any CPU
+		{2BB74746-319D-465B-AAD5-C4430322501E}.Release|x86.ActiveCfg = Release|Any CPU
+		{2BB74746-319D-465B-AAD5-C4430322501E}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {FD4D03FF-F99F-48B7-92EA-B9A73DF78693}
+	EndGlobalSection
+EndGlobal

--- a/storagebatchoperations/api/runTests.ps1
+++ b/storagebatchoperations/api/runTests.ps1
@@ -1,0 +1,16 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+dotnet restore --force
+dotnet test --no-restore --test-adapter-path:. --logger:junit 2>&1 | %{ "$_" }


### PR DESCRIPTION
This PR contains samples and test cases to create, list, get, cancel and delete storage batch job operations.

The region tags used to create samples are as below:-

- [ ] 1. storage_batch_create_job 
- [ ] 2. storage_batch_list_jobs 
- [ ] 3. storage_batch_get_job
- [ ] 4. storage_batch_cancel_job
- [ ] 5. storage_batch_delete_job