### PR TITLE
fix(PubSub): Fix flakiness on CreateSchema tests

### DIFF
--- a/pubsub/api/Pubsub.Samples.Tests/CreateAvroSchemaTest.cs
+++ b/pubsub/api/Pubsub.Samples.Tests/CreateAvroSchemaTest.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Google.Cloud.PubSub.V1;
 using Xunit;
 
 [Collection(nameof(PubsubFixture))]
@@ -32,7 +33,6 @@ public class CreateAvroSchemaTest
         string schemaId = _pubsubFixture.RandomSchemaId();
         var newlyCreatedSchema = _createAvroSchemaSample.CreateAvroSchema(_pubsubFixture.ProjectId, schemaId, _pubsubFixture.AvroSchemaFile);
         _pubsubFixture.TempSchemaIds.Add(schemaId);
-        var schema = _pubsubFixture.GetSchema(schemaId);
-        Assert.Equal(newlyCreatedSchema, schema);
+        Assert.Equal(newlyCreatedSchema.SchemaName, SchemaName.FromProjectSchema(_pubsubFixture.ProjectId, schemaId));
     }
 }

--- a/pubsub/api/Pubsub.Samples.Tests/CreateProtoSchemaTest.cs
+++ b/pubsub/api/Pubsub.Samples.Tests/CreateProtoSchemaTest.cs
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+using Google.Cloud.PubSub.V1;
 using Xunit;
 
 [Collection(nameof(PubsubFixture))]
@@ -32,7 +32,6 @@ public class CreateProtoSchemaTest
         string schemaId = _pubsubFixture.RandomSchemaId();
         var newlyCreatedSchema = _createProtoSchemaSample.CreateProtoSchema(_pubsubFixture.ProjectId, schemaId, _pubsubFixture.ProtoSchemaFile);
         _pubsubFixture.TempSchemaIds.Add(schemaId);
-        var schema = _pubsubFixture.GetSchema(schemaId);
-        Assert.Equal(newlyCreatedSchema, schema);
+        Assert.Equal(newlyCreatedSchema.SchemaName, SchemaName.FromProjectSchema(_pubsubFixture.ProjectId, schemaId));
     }
 }


### PR DESCRIPTION
bug: https://b.corp.google.com/issues/214289281

We think what's happening is that the CreateSchema operation would rarely return a transient error after the schema is created, which causes a retry at library level and lead to an AlreadyExists exception. This results in our sample to return the schema object without the revision parameters, causing the assert.equal to fail. I confirmed with PubSub team that this is an expected behavior and no change is required on the library.

To address the flakiness on these tests, we removed the Get call from our tests and modified the assertion to check the SchemaName of the created schema instead.