### PR TITLE
[SecretManager][Samples]: Add global samples for label & annotation / Fix TestSuite Flakiness

### DIFF
--- a/secretmanager/api/SecretManager.Samples.Tests/AccessSecretVersionTests.cs
+++ b/secretmanager/api/SecretManager.Samples.Tests/AccessSecretVersionTests.cs
@@ -32,9 +32,14 @@ public class AccessSecretVersionTests
     [Fact]
     public void AddsSecretVersions()
     {
+        // Get the SecretVersionName.
         SecretVersionName secretVersionName = _fixture.SecretVersion.SecretVersionName;
+
+        // Run the code sample.
         string result = _sample.AccessSecretVersion(
           projectId: secretVersionName.ProjectId, secretId: secretVersionName.SecretId, secretVersionId: secretVersionName.SecretVersionId);
+
+        // Assert that expected result is observed.
         Assert.Equal("my super secret data", result);
     }
 }

--- a/secretmanager/api/SecretManager.Samples.Tests/AddSecretVersionTests.cs
+++ b/secretmanager/api/SecretManager.Samples.Tests/AddSecretVersionTests.cs
@@ -32,14 +32,26 @@ public class AddSecretVersionTests
     [Fact]
     public void AddsSecretVersions()
     {
+        // Get the payload data.
         string data = "my secret data";
-        SecretName secretName = _fixture.Secret.SecretName;
+
+        // Create the secret resource.
+        Secret secret = _fixture.CreateSecret(_fixture.RandomId());
+
+        // Get the SecretName.
+        SecretName secretName = secret.SecretName;
+
+        // Run the code sample.
         SecretVersion secretVersion = _sample.AddSecretVersion(
           projectId: secretName.ProjectId, secretId: secretName.SecretId,
           data: data);
 
-        SecretManagerServiceClient client = SecretManagerServiceClient.Create();
+        // Assert expected result is observed.
+        SecretManagerServiceClient client = _fixture.Client;
         AccessSecretVersionResponse result = client.AccessSecretVersion(secretVersion.SecretVersionName);
         Assert.Equal(data, result.Payload.Data.ToStringUtf8());
+
+        // Cleanup the created resource.
+        _fixture.DeleteSecret(secretName);
     }
 }

--- a/secretmanager/api/SecretManager.Samples.Tests/CreateSecretTests.cs
+++ b/secretmanager/api/SecretManager.Samples.Tests/CreateSecretTests.cs
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-using Xunit;
 using Google.Cloud.SecretManager.V1;
+using Xunit;
 
 [Collection(nameof(SecretManagerFixture))]
 public class CreateSecretTests
@@ -32,9 +32,17 @@ public class CreateSecretTests
     [Fact]
     public void CreatesSecrets()
     {
-        SecretName secretName = _fixture.SecretToCreateName;
+        // Get the SecretName.
+        SecretName secretName = new SecretName(_fixture.ProjectId, _fixture.RandomId());
+
+        // Run the code sample.
         Secret result = _sample.CreateSecret(
           projectId: secretName.ProjectId, secretId: secretName.SecretId);
+
+        // Assert expected result is observed.
         Assert.Equal(result.SecretName.SecretId, secretName.SecretId);
+
+        // Cleanup the created resource.
+        _fixture.DeleteSecret(secretName);
     }
 }

--- a/secretmanager/api/SecretManager.Samples.Tests/CreateSecretWithAnnotationsTests.cs
+++ b/secretmanager/api/SecretManager.Samples.Tests/CreateSecretWithAnnotationsTests.cs
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Google.Cloud.SecretManager.V1;
+using System;
+using Xunit;
+
+[Collection(nameof(SecretManagerFixture))]
+public class CreateSecretWithAnnotationsTests
+{
+    private readonly SecretManagerFixture _fixture;
+    private readonly CreateSecretWithAnnotationsSample _sample;
+
+    public CreateSecretWithAnnotationsTests(SecretManagerFixture fixture)
+    {
+        _fixture = fixture;
+        _sample = new CreateSecretWithAnnotationsSample();
+    }
+
+    [Fact]
+    public void CreatesSecretsWithAnnotations()
+    {
+        // Get the SecretName to create Secret.
+        SecretName secretName = new SecretName(_fixture.ProjectId, _fixture.RandomId());
+
+        // Get the annotation key & value from the fixture class.
+        string annotationKey = _fixture.AnnotationKey;
+        string annotationValue = _fixture.AnnotationValue;
+
+        // Create the secret with the specificed fields.
+        Secret result = _sample.CreateSecretWithAnnotations(
+          projectId: secretName.ProjectId, secretId: secretName.SecretId, annotationKey: annotationKey, annotationValue: annotationValue);
+
+        // Assert that the secretId is same as expected.
+        Assert.Equal(result.SecretName.SecretId, secretName.SecretId);
+
+        // Assert that the annotation values matches with the expected value.
+        Assert.Equal(result.Annotations[annotationKey], annotationValue);
+
+    }
+}

--- a/secretmanager/api/SecretManager.Samples.Tests/CreateSecretWithAnnotationsTests.cs
+++ b/secretmanager/api/SecretManager.Samples.Tests/CreateSecretWithAnnotationsTests.cs
@@ -50,5 +50,7 @@ public class CreateSecretWithAnnotationsTests
         // Assert that the annotation values matches with the expected value.
         Assert.Equal(result.Annotations[annotationKey], annotationValue);
 
+        // Clean the created secret.
+        _fixture.DeleteSecret(secretName);
     }
 }

--- a/secretmanager/api/SecretManager.Samples.Tests/CreateSecretWithLabelsTests.cs
+++ b/secretmanager/api/SecretManager.Samples.Tests/CreateSecretWithLabelsTests.cs
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Google.Cloud.SecretManager.V1;
+using System;
+using Xunit;
+
+[Collection(nameof(SecretManagerFixture))]
+public class CreateSecretWithLabelsTests
+{
+    private readonly SecretManagerFixture _fixture;
+    private readonly CreateSecretWithLabelsSample _sample;
+
+    public CreateSecretWithLabelsTests(SecretManagerFixture fixture)
+    {
+        _fixture = fixture;
+        _sample = new CreateSecretWithLabelsSample();
+    }
+
+    [Fact]
+    public void CreatesSecretsWithLabels()
+    {
+        // Get the SecretName to create Secret.
+        SecretName secretName = new SecretName(_fixture.ProjectId, _fixture.RandomId());
+
+        // Get the label key & value from the fixture class.
+        string labelKey = _fixture.LabelKey;
+        string labelValue = _fixture.LabelValue;
+
+        // Create the secret with the specificed fields.
+        Secret result = _sample.CreateSecretWithLabels(
+          projectId: secretName.ProjectId, secretId: secretName.SecretId, labelKey: labelKey, labelValue: labelValue);
+
+        // Assert that the secretId is same as expected.
+        Assert.Equal(result.SecretName.SecretId, secretName.SecretId);
+
+        // Assert that the annotation values matches with the expected value.
+        Assert.Equal(result.Labels[labelKey], labelValue);
+
+    }
+}

--- a/secretmanager/api/SecretManager.Samples.Tests/CreateSecretWithLabelsTests.cs
+++ b/secretmanager/api/SecretManager.Samples.Tests/CreateSecretWithLabelsTests.cs
@@ -50,5 +50,7 @@ public class CreateSecretWithLabelsTests
         // Assert that the annotation values matches with the expected value.
         Assert.Equal(result.Labels[labelKey], labelValue);
 
+        // Clean the created secret.
+        _fixture.DeleteSecret(secretName);
     }
 }

--- a/secretmanager/api/SecretManager.Samples.Tests/CreateUserManagedReplicationSecretTests.cs
+++ b/secretmanager/api/SecretManager.Samples.Tests/CreateUserManagedReplicationSecretTests.cs
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-using Xunit;
 using Google.Cloud.SecretManager.V1;
+using Xunit;
 
 [Collection(nameof(SecretManagerFixture))]
 public class CreateUserManagedReplicationSecretTests
@@ -32,13 +32,20 @@ public class CreateUserManagedReplicationSecretTests
     [Fact]
     public void CreatesUmmrSecrets()
     {
-        SecretName secretName = _fixture.UserManagedReplicationSecretName;
-        string[] locations = {"us-east1", "us-east4", "us-west1"};
+        // Get the SecretName.
+        SecretName secretName = new SecretName(_fixture.ProjectId, _fixture.RandomId());
+
+        // Set the locations list for replications.
+        string[] locations = { "us-east1", "us-east4", "us-west1" };
+
+        // Run the code sample.
         Secret result = _sample.CreateUserManagedReplicationSecret(
           projectId: secretName.ProjectId, secretId: secretName.SecretId, locations: locations);
         Assert.Equal(result.SecretName.SecretId, secretName.SecretId);
         Assert.Contains(result.Replication.UserManaged.Replicas, r => r.Location == "us-east1");
         Assert.Contains(result.Replication.UserManaged.Replicas, r => r.Location == "us-east4");
         Assert.Contains(result.Replication.UserManaged.Replicas, r => r.Location == "us-west1");
+
+        _fixture.DeleteSecret(secretName);
     }
 }

--- a/secretmanager/api/SecretManager.Samples.Tests/DeleteSecretTests.cs
+++ b/secretmanager/api/SecretManager.Samples.Tests/DeleteSecretTests.cs
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-using Xunit;
 using Google.Cloud.SecretManager.V1;
+using Xunit;
 
 [Collection(nameof(SecretManagerFixture))]
 public class DeleteSecretTests
@@ -32,10 +32,17 @@ public class DeleteSecretTests
     [Fact]
     public void DeletesSecrets()
     {
-        SecretName secretName = _fixture.SecretToDelete.SecretName;
+        // Create the secret.
+        Secret secret = _fixture.CreateSecret(_fixture.RandomId());
+
+        // Get the secretName from the created secret.
+        SecretName secretName = secret.SecretName;
+
+        // Call the code sample function.
         _sample.DeleteSecret(projectId: secretName.ProjectId, secretId: secretName.SecretId);
 
-        SecretManagerServiceClient client = SecretManagerServiceClient.Create();
+        // Assert expected behavior is seen.
+        SecretManagerServiceClient client = _fixture.Client;
         Assert.Throws<Grpc.Core.RpcException>(() => client.GetSecret(secretName));
     }
 }

--- a/secretmanager/api/SecretManager.Samples.Tests/EditSecretAnnotationsTests.cs
+++ b/secretmanager/api/SecretManager.Samples.Tests/EditSecretAnnotationsTests.cs
@@ -44,7 +44,7 @@ public class EditSecretAnnotationsTests
         string oldAnnotationKey = _fixture.AnnotationKey;
         string oldAnnotationValue = _fixture.AnnotationValue;
 
-        // Create the secret with the specificed fields.
+        // Call the code sample function.
         Secret result = _sample.EditSecretAnnotations(
           projectId: secretName.ProjectId, secretId: secretName.SecretId, annotationKey: newAnnotationKey, annotationValue: newAnnotationValue);
 

--- a/secretmanager/api/SecretManager.Samples.Tests/EditSecretAnnotationsTests.cs
+++ b/secretmanager/api/SecretManager.Samples.Tests/EditSecretAnnotationsTests.cs
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Google.Cloud.SecretManager.V1;
+using System;
+using Xunit;
+
+[Collection(nameof(SecretManagerFixture))]
+public class EditSecretAnnotationsTests
+{
+    private readonly SecretManagerFixture _fixture;
+    private readonly EditSecretAnnotationsSample _sample;
+
+    public EditSecretAnnotationsTests(SecretManagerFixture fixture)
+    {
+        _fixture = fixture;
+        _sample = new EditSecretAnnotationsSample();
+    }
+
+    [Fact]
+    public void EditSecretAnnotations()
+    {
+        // Get the SecretName to create Secret.
+        SecretName secretName = _fixture.Secret.SecretName;
+
+        // New annotation key value.
+        string newAnnotationKey = "new-annotation-key";
+        string newAnnotationValue = "new-annotation-value";
+
+        // Existing annotation key value from the fixture class.
+        string oldAnnotationKey = _fixture.AnnotationKey;
+        string oldAnnotationValue = _fixture.AnnotationValue;
+
+        // Create the secret with the specificed fields.
+        Secret result = _sample.EditSecretAnnotations(
+          projectId: secretName.ProjectId, secretId: secretName.SecretId, annotationKey: newAnnotationKey, annotationValue: newAnnotationValue);
+
+        // Assert that the secretId is same as expected.
+        Assert.Equal(result.SecretName.SecretId, secretName.SecretId);
+
+        // Assert that the new key-value matches with the expected value.
+        Assert.Equal(result.Annotations[newAnnotationKey], newAnnotationValue);
+
+        // Assert that the old key-value matches with the expected value.
+        Assert.Equal(result.Annotations[oldAnnotationKey], oldAnnotationValue);
+    }
+}

--- a/secretmanager/api/SecretManager.Samples.Tests/QuickstartTests.cs
+++ b/secretmanager/api/SecretManager.Samples.Tests/QuickstartTests.cs
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-using Xunit;
 using Google.Cloud.SecretManager.V1;
+using Xunit;
 
 [Collection(nameof(SecretManagerFixture))]
 public class QuickstartTests
@@ -32,7 +32,10 @@ public class QuickstartTests
     [Fact]
     public void Runs()
     {
-        SecretName secretName = _fixture.SecretForQuickstartName;
+        SecretName secretName = new SecretName(_fixture.ProjectId, _fixture.RandomId());
+
         _sample.Quickstart(projectId: secretName.ProjectId, secretId: secretName.SecretId);
+
+        _fixture.DeleteSecret(secretName);
     }
 }

--- a/secretmanager/api/SecretManager.Samples.Tests/SecretManagerFixture.cs
+++ b/secretmanager/api/SecretManager.Samples.Tests/SecretManagerFixture.cs
@@ -28,11 +28,6 @@ public class SecretManagerFixture : IDisposable, ICollectionFixture<SecretManage
     public string ProjectId { get; }
     public ProjectName ProjectName { get; }
     public Secret Secret { get; }
-    public Secret SecretToDelete { get; }
-    public Secret SecretWithVersions { get; }
-    public SecretName SecretForQuickstartName { get; }
-    public SecretName SecretToCreateName { get; }
-    public SecretName UserManagedReplicationSecretName { get; }
     public SecretVersion SecretVersion { get; }
 
     public string AnnotationKey { get; }
@@ -64,23 +59,12 @@ public class SecretManagerFixture : IDisposable, ICollectionFixture<SecretManage
         LabelValue = "my-label-value";
 
         Secret = CreateSecret(RandomId());
-        SecretToDelete = CreateSecret(RandomId());
-        SecretWithVersions = CreateSecret(RandomId());
-        SecretForQuickstartName = new SecretName(ProjectId, RandomId());
-        SecretToCreateName = new SecretName(ProjectId, RandomId());
-        UserManagedReplicationSecretName = new SecretName(ProjectId, RandomId());
-
-        SecretVersion = AddSecretVersion(SecretWithVersions);
+        SecretVersion = AddSecretVersion(Secret);
     }
 
     public void Dispose()
     {
         DeleteSecret(Secret.SecretName);
-        DeleteSecret(SecretForQuickstartName);
-        DeleteSecret(SecretToCreateName);
-        DeleteSecret(UserManagedReplicationSecretName);
-        DeleteSecret(SecretToDelete.SecretName);
-        DeleteSecret(SecretWithVersions.SecretName);
     }
 
     public String RandomId()

--- a/secretmanager/api/SecretManager.Samples.Tests/SecretManagerFixture.cs
+++ b/secretmanager/api/SecretManager.Samples.Tests/SecretManagerFixture.cs
@@ -35,6 +35,11 @@ public class SecretManagerFixture : IDisposable, ICollectionFixture<SecretManage
     public SecretName UserManagedReplicationSecretName { get; }
     public SecretVersion SecretVersion { get; }
 
+    public string AnnotationKey { get; }
+    public string AnnotationValue { get; }
+    public string LabelKey { get; }
+    public string LabelValue { get; }
+
     public SecretManagerFixture()
     {
         // Get the Google Cloud ProjectId.
@@ -49,6 +54,14 @@ public class SecretManagerFixture : IDisposable, ICollectionFixture<SecretManage
 
         // Create the Regional Secret Manager Client
         Client = SecretManagerServiceClient.Create();
+
+        // Setting the AnnotationKey and AnnotationValue
+        AnnotationKey = "my-annotation-key";
+        AnnotationValue = "my-annotation-value";
+
+        // Setting the LabelKey and LabelValue
+        LabelKey = "my-label-key";
+        LabelValue = "my-label-value";
 
         Secret = CreateSecret(RandomId());
         SecretToDelete = CreateSecret(RandomId());
@@ -83,6 +96,14 @@ public class SecretManagerFixture : IDisposable, ICollectionFixture<SecretManage
             {
                 Automatic = new Replication.Types.Automatic(),
             },
+            Labels =
+            {
+                { LabelKey, LabelValue }
+            },
+            Annotations =
+            {
+              { AnnotationKey, AnnotationValue }
+            }
         };
 
         return Client.CreateSecret(ProjectName, secretId, secret);

--- a/secretmanager/api/SecretManager.Samples.Tests/UpdateSecretTests.cs
+++ b/secretmanager/api/SecretManager.Samples.Tests/UpdateSecretTests.cs
@@ -32,8 +32,16 @@ public class UpdateSecretTests
     [Fact]
     public void UpdatesSecrets()
     {
-        SecretName secretName = _fixture.Secret.SecretName;
+        // Get the secret name.
+        SecretName secretName = _fixture.CreateSecret(_fixture.RandomId()).SecretName;
+
+        // Run the code sample.
         Secret result = _sample.UpdateSecret(projectId: secretName.ProjectId, secretId: secretName.SecretId);
+
+        // Verify the result.
         Assert.Equal("rocks", result.Labels["secretmanager"]);
+
+        // Cleanup the created resource.
+        _fixture.DeleteSecret(secretName);
     }
 }

--- a/secretmanager/api/SecretManager.Samples.Tests/UpdateSecretWithAliasTests.cs
+++ b/secretmanager/api/SecretManager.Samples.Tests/UpdateSecretWithAliasTests.cs
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-using Xunit;
 using Google.Cloud.SecretManager.V1;
+using Xunit;
 
 [Collection(nameof(SecretManagerFixture))]
 public class UpdateSecretWithAliasTests
@@ -32,8 +32,13 @@ public class UpdateSecretWithAliasTests
     [Fact]
     public void UpdatesSecrets()
     {
-        SecretName secretName = _fixture.SecretWithVersions.SecretName;
+        // Get the SecretName.
+        SecretName secretName = _fixture.Secret.SecretName;
+
+        // Run the code sample.
         Secret result = _sample.UpdateSecret(projectId: secretName.ProjectId, secretId: secretName.SecretId);
+
+        // Assert that the expected behaviour is seen.
         Assert.Equal(1, result.VersionAliases["test"]);
     }
 }

--- a/secretmanager/api/SecretManager.Samples.Tests/ViewSecretAnnotationsTests.cs
+++ b/secretmanager/api/SecretManager.Samples.Tests/ViewSecretAnnotationsTests.cs
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Google.Cloud.SecretManager.V1;
+using System;
+using Xunit;
+
+
+[Collection(nameof(SecretManagerFixture))]
+public class ViewSecretAnnotationsTests
+{
+    private readonly SecretManagerFixture _fixture;
+    private readonly ViewSecretAnnotationsSample _sample;
+
+    public ViewSecretAnnotationsTests(SecretManagerFixture fixture)
+    {
+        _fixture = fixture;
+        _sample = new ViewSecretAnnotationsSample();
+    }
+
+    [Fact]
+    public void ViewSecretsAnnotations()
+    {
+        // Get the SecretName from the set ProjectId.
+        SecretName secretName = _fixture.Secret.SecretName;
+
+        // Annotation Key-Value from the fixture class.
+        string annotationKey = _fixture.AnnotationKey;
+        string annotationValue = _fixture.AnnotationValue;
+
+        // Run the code sample.
+        Secret result = _sample.ViewSecretAnnotations(
+          projectId: secretName.ProjectId, secretId: secretName.SecretId);
+
+        // Assert that the secretId is equal to the expected value.
+        Assert.Equal(result.SecretName.SecretId, secretName.SecretId);
+
+        // Assert that the annotation key's value matches with the expected value.
+        Assert.Equal(result.Annotations[annotationKey], annotationValue);
+    }
+}

--- a/secretmanager/api/SecretManager.Samples.Tests/ViewSecretLabelsTests.cs
+++ b/secretmanager/api/SecretManager.Samples.Tests/ViewSecretLabelsTests.cs
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Google.Cloud.SecretManager.V1;
+using System;
+using Xunit;
+
+
+[Collection(nameof(SecretManagerFixture))]
+public class ViewSecretLabelsTests
+{
+    private readonly SecretManagerFixture _fixture;
+    private readonly ViewSecretLabelsSample _sample;
+
+    public ViewSecretLabelsTests(SecretManagerFixture fixture)
+    {
+        _fixture = fixture;
+        _sample = new ViewSecretLabelsSample();
+    }
+
+    [Fact]
+    public void ViewSecretsLabels()
+    {
+        // Get the SecretName from the set ProjectId.
+        SecretName secretName = _fixture.Secret.SecretName;
+
+        // Label Key-Value from the fixture class.
+        string labelKey = _fixture.LabelKey;
+        string labelValue = _fixture.LabelValue;
+
+        // Run the code sample.
+        Secret result = _sample.ViewSecretLabels(
+          projectId: secretName.ProjectId, secretId: secretName.SecretId);
+
+        // Assert that the secretId is equal to the expected value.
+        Assert.Equal(result.SecretName.SecretId, secretName.SecretId);
+
+        // Assert that the label key's value matches with the expected value.
+        Assert.Equal(result.Labels[labelKey], labelValue);
+    }
+}

--- a/secretmanager/api/SecretManager.Samples/CreateSecretWithAnnotations.cs
+++ b/secretmanager/api/SecretManager.Samples/CreateSecretWithAnnotations.cs
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// [START secretmanager_create_secret_with_annotations]
+
+using Google.Api.Gax.ResourceNames;
+using Google.Cloud.SecretManager.V1;
+using System.Collections.Generic;
+
+public class CreateSecretWithAnnotationsSample
+{
+    public Secret CreateSecretWithAnnotations(
+      string projectId = "my-project", string secretId = "my-secret", string annotationKey = "my-annotation-key", string annotationValue = "my-annotation-value")
+    {
+        // Create the client.
+        SecretManagerServiceClient client = SecretManagerServiceClient.Create();
+
+        // Build the parent resource name.
+        ProjectName projectName = new ProjectName(projectId);
+
+        // Build the secret.
+        Secret secret = new Secret
+        {
+            Replication = new Replication
+            {
+                Automatic = new Replication.Types.Automatic(),
+            },
+            Annotations =
+            {
+              { annotationKey, annotationValue }
+            },
+        };
+
+        // Call the API.
+        Secret createdSecret = client.CreateSecret(projectName, secretId, secret);
+        return createdSecret;
+    }
+}
+// [END secretmanager_create_secret_with_annotations]

--- a/secretmanager/api/SecretManager.Samples/CreateSecretWithLabels.cs
+++ b/secretmanager/api/SecretManager.Samples/CreateSecretWithLabels.cs
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// [START secretmanager_create_secret_with_labels]
+
+using Google.Api.Gax.ResourceNames;
+using Google.Cloud.SecretManager.V1;
+using System.Collections.Generic;
+
+public class CreateSecretWithLabelsSample
+{
+    public Secret CreateSecretWithLabels(
+      string projectId = "my-project", string secretId = "my-secret", string labelKey = "my-label-key", string labelValue = "my-label-value")
+    {
+        // Create the client.
+        SecretManagerServiceClient client = SecretManagerServiceClient.Create();
+
+        // Build the parent resource name.
+        ProjectName projectName = new ProjectName(projectId);
+
+        // Build the secret.
+        Secret secret = new Secret
+        {
+            Replication = new Replication
+            {
+                Automatic = new Replication.Types.Automatic(),
+            },
+            Labels =
+            {
+              { labelKey, labelValue }
+            },
+        };
+
+        // Call the API.
+        Secret createdSecret = client.CreateSecret(projectName, secretId, secret);
+        return createdSecret;
+    }
+}
+// [END secretmanager_create_secret_with_labels]

--- a/secretmanager/api/SecretManager.Samples/EditSecretAnnotations.cs
+++ b/secretmanager/api/SecretManager.Samples/EditSecretAnnotations.cs
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// [START secretmanager_edit_secret_annotations]
+
+using Google.Api.Gax.ResourceNames;
+using Google.Cloud.SecretManager.V1;
+using Google.Protobuf.Collections;
+using Google.Protobuf.WellKnownTypes;
+
+public class EditSecretAnnotationsSample
+{
+    public Secret EditSecretAnnotations(
+      string projectId = "my-project", string secretId = "my-secret", string annotationKey = "my-annotation-key", string annotationValue = "my-annotation-value")
+    {
+        // Create the client.
+        SecretManagerServiceClient client = SecretManagerServiceClient.Create();
+
+        // Build the secretName with the fields.
+        SecretName secretName = new SecretName(projectId, secretId);
+
+        // Get the exisitng secret.
+        Secret secret = client.GetSecret(secretName);
+
+        // Edit the Secret annotations
+        secret.Annotations[annotationKey] = annotationValue;
+
+        // Build the field mask.
+        FieldMask fieldMask = FieldMask.FromString("annotations");
+
+        // Call the API.
+        Secret updatedSecret = client.UpdateSecret(secret, fieldMask);
+        return updatedSecret;
+    }
+}
+// [END secretmanager_edit_secret_annotations]

--- a/secretmanager/api/SecretManager.Samples/ViewSecretAnnotations.cs
+++ b/secretmanager/api/SecretManager.Samples/ViewSecretAnnotations.cs
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// [START secretmanager_view_secret_annotations]
+
+using Google.Api.Gax.ResourceNames;
+using Google.Cloud.SecretManager.V1;
+using Google.Protobuf.Collections;
+using Google.Protobuf.WellKnownTypes;
+using System;
+
+public class ViewSecretAnnotationsSample
+{
+    public Secret ViewSecretAnnotations(
+      string projectId = "my-project", string secretId = "my-secret")
+    {
+        // Create the client.
+        SecretManagerServiceClient client = SecretManagerServiceClient.Create();
+
+        // Build the resource name.
+        SecretName secretName = new SecretName(projectId, secretId);
+
+        // Fetch the secret.
+        Secret secret = client.GetSecret(secretName);
+
+        // Get the secret's annotations.
+        MapField<string, string> secretAnnotations = secret.Annotations;
+
+        // Print the annotations.
+        foreach (var annotation in secret.Annotations)
+        {
+            Console.WriteLine($"Annotation Key: {annotation.Key}, Annotation Value: {annotation.Value}");
+        }
+        return secret;
+    }
+}
+// [END secretmanager_view_secret_annotations]

--- a/secretmanager/api/SecretManager.Samples/ViewSecretLabels.cs
+++ b/secretmanager/api/SecretManager.Samples/ViewSecretLabels.cs
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// [START secretmanager_view_secret_labels]
+
+using Google.Api.Gax.ResourceNames;
+using Google.Cloud.SecretManager.V1;
+using Google.Protobuf.Collections;
+using Google.Protobuf.WellKnownTypes;
+using System;
+
+public class ViewSecretLabelsSample
+{
+    public Secret ViewSecretLabels(
+      string projectId = "my-project", string secretId = "my-secret")
+    {
+        // Create the client.
+        SecretManagerServiceClient client = SecretManagerServiceClient.Create();
+
+        // Build the resource name.
+        SecretName secretName = new SecretName(projectId, secretId);
+
+        // Fetch the secret.
+        Secret secret = client.GetSecret(secretName);
+
+        // Get the secret's labels.
+        MapField<string, string> secretLabels = secret.Labels;
+
+        // Print the labels.
+        foreach (var label in secret.Labels)
+        {
+            Console.WriteLine($"Annotation Key: {label.Key}, Annotation Value: {label.Value}");
+        }
+        return secret;
+    }
+}
+// [END secretmanager_view_secret_labels]


### PR DESCRIPTION
### Changes
- Added the necessary code samples for labels
- Added the necessary code samples for annotations
- Added the test files for the code samples added
- Fixed the formatting issue
- Add the required changes in the fixture file
- Fixed the flaky suite issue by having individual secret(resource) for each test.

### Testing
- Verified the behaviour of the changes with tests
- Verified the behaviour of the changes locally.

### Prerequisite

- [X] Make sure to open an issue before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea.
    - https://github.com/GoogleCloudPlatform/dotnet-docs-samples/issues/3102
- [X] Follow the instructions in [CONTRIBUTING](CONTRIBUTING.md). Most importantly, ensure the tests and linter pass by running `dotnet format` in the subdirectories.
- [X] Update code documentation if necessary.

closes: #<3102>