### PR TITLE
feat(genai): add count token samples

### DIFF
--- a/genai/api/GenAI.Samples.Tests/CountTokens/CountTokenComputeWithTxtTest.cs
+++ b/genai/api/GenAI.Samples.Tests/CountTokens/CountTokenComputeWithTxtTest.cs
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Google.GenAI.Types;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+[Collection(nameof(GenAIFixture))]
+public class CountTokenComputeWithTxtTest
+{
+    private readonly GenAIFixture _fixture;
+    private readonly CountTokenComputeWithTxt _sample;
+
+    public CountTokenComputeWithTxtTest(GenAIFixture fixture)
+    {
+        _fixture = fixture;
+        _sample = new CountTokenComputeWithTxt();
+    }
+
+    [Fact]
+    public async Task TestCountTokenComputeWithTxt()
+    {
+        List<TokensInfo> tokensInfos = await _sample.ComputeTokens(_fixture.ProjectId);
+        Assert.NotEmpty(tokensInfos);
+    }
+}

--- a/genai/api/GenAI.Samples.Tests/CountTokens/CountTokenRespWithTxtTest.cs
+++ b/genai/api/GenAI.Samples.Tests/CountTokens/CountTokenRespWithTxtTest.cs
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Google.GenAI.Types;
+using System.Threading.Tasks;
+using Xunit;
+
+[Collection(nameof(GenAIFixture))]
+public class CountTokenRespWithTxtTest
+{
+    private readonly GenAIFixture _fixture;
+    private readonly CountTokenRespWithTxt _sample;
+
+    public CountTokenRespWithTxtTest(GenAIFixture fixture)
+    {
+        _fixture = fixture;
+        _sample = new CountTokenRespWithTxt();
+    }
+
+    [Fact]
+    public async Task TestCountTokenRespWithTxt()
+    {
+        GenerateContentResponseUsageMetadata usageMetadata = await _sample.CountTokens(_fixture.ProjectId);
+        Assert.NotNull(usageMetadata);
+    }
+}

--- a/genai/api/GenAI.Samples.Tests/CountTokens/CountTokenWithTxtTest.cs
+++ b/genai/api/GenAI.Samples.Tests/CountTokens/CountTokenWithTxtTest.cs
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Threading.Tasks;
+using Xunit;
+
+[Collection(nameof(GenAIFixture))]
+public class CountTokenWithTxtTest
+{
+    private readonly GenAIFixture _fixture;
+    private readonly CountTokenWithTxt _sample;
+
+    public CountTokenWithTxtTest(GenAIFixture fixture)
+    {
+        _fixture = fixture;
+        _sample = new CountTokenWithTxt();
+    }
+
+    [Fact]
+    public async Task TestCountTokenWithTxt()
+    {
+        int totalTokens = await _sample.CountTokens(_fixture.ProjectId);
+        Assert.True(totalTokens > 0);
+    }
+}

--- a/genai/api/GenAI.Samples.Tests/CountTokens/CountTokenWithTxtVidTest.cs
+++ b/genai/api/GenAI.Samples.Tests/CountTokens/CountTokenWithTxtVidTest.cs
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Threading.Tasks;
+using Xunit;
+
+[Collection(nameof(GenAIFixture))]
+public class CountTokenWithTxtVidTest
+{
+    private readonly GenAIFixture _fixture;
+    private readonly CountTokenWithTxtVid _sample;
+
+    public CountTokenWithTxtVidTest(GenAIFixture fixture)
+    {
+        _fixture = fixture;
+        _sample = new CountTokenWithTxtVid();
+    }
+
+    [Fact]
+    public async Task TestCountTokenWithTxtVid()
+    {
+        int totalTokens = await _sample.CountTokens(_fixture.ProjectId);
+        Assert.True(totalTokens > 0);
+    }
+}

--- a/genai/api/GenAI.Samples/CountTokens/CountTokenComputeWithTxt.cs
+++ b/genai/api/GenAI.Samples/CountTokens/CountTokenComputeWithTxt.cs
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// [START googlegenaisdk_counttoken_compute_with_txt]
+
+using Google.GenAI;
+using Google.GenAI.Types;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+public class CountTokenComputeWithTxt
+{
+    public async Task<List<TokensInfo>> ComputeTokens(
+        string projectId = "your-project-id",
+        string location = "global",
+        string model = "gemini-2.5-flash")
+    {
+        await using var client = new Client(
+            project: projectId,
+            location: location,
+            vertexAI: true,
+            httpOptions: new HttpOptions { ApiVersion = "v1" });
+
+        ComputeTokensResponse response = await client.Models.ComputeTokensAsync(
+            model: model,
+            contents: "What's the longest word in the English language?");
+
+        List<TokensInfo> tokensInfo = response.TokensInfo ?? new List<TokensInfo>();
+
+        foreach (TokensInfo tokenInfo in tokensInfo)
+        {
+            Console.WriteLine($"Role: {tokenInfo.Role}");
+            Console.WriteLine($"Token Ids: {string.Join(", ", tokenInfo.TokenIds)}");
+
+            Console.WriteLine("Tokens:");
+            foreach (byte[] token in tokenInfo.Tokens)
+            {
+                Console.WriteLine(Encoding.UTF8.GetString(token));
+            }
+        }
+        // Example output:
+        // Role: user
+        // Token Ids: 3689, 236789, 236751, 506, 27801, 3658, 528, 506, 5422, 5192, 236881
+        // Tokens:
+        // What
+        // '
+        // s
+        //  the
+        //  longest
+        // ...
+        // ?
+        return tokensInfo;
+    }
+}
+// [END googlegenaisdk_counttoken_compute_with_txt]

--- a/genai/api/GenAI.Samples/CountTokens/CountTokenRespWithTxt.cs
+++ b/genai/api/GenAI.Samples/CountTokens/CountTokenRespWithTxt.cs
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// [START googlegenaisdk_counttoken_resp_with_txt]
+
+using Google.GenAI;
+using Google.GenAI.Types;
+using System;
+using System.Threading.Tasks;
+
+public class CountTokenRespWithTxt
+{
+    public async Task<GenerateContentResponseUsageMetadata> CountTokens(
+        string projectId = "your-project-id",
+        string location = "global",
+        string model = "gemini-2.5-flash")
+    {
+        await using var client = new Client(
+            project: projectId,
+            location: location,
+            vertexAI: true,
+            httpOptions: new HttpOptions { ApiVersion = "v1" });
+
+        GenerateContentResponse response = await client.Models.GenerateContentAsync(
+            model: model,
+            contents: "Why is the sky blue?");
+
+        GenerateContentResponseUsageMetadata usageMetadata = response.UsageMetadata;
+        Console.WriteLine(usageMetadata);
+        // Example response:
+        // GenerateContentResponseUsageMetadata { CacheTokensDetails = ,
+        // CachedContentTokenCount = , CandidatesTokenCount = 589,
+        // ...
+        // ThoughtsTokenCount = 945, ToolUsePromptTokenCount = ,
+        // ToolUsePromptTokensDetails = , TotalTokenCount = 1540,
+        // TrafficType = ON_DEMAND }
+        return usageMetadata;
+    }
+}
+// [END googlegenaisdk_counttoken_resp_with_txt]

--- a/genai/api/GenAI.Samples/CountTokens/CountTokenWithTxt.cs
+++ b/genai/api/GenAI.Samples/CountTokens/CountTokenWithTxt.cs
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// [START googlegenaisdk_counttoken_with_txt]
+
+using Google.GenAI;
+using Google.GenAI.Types;
+using System;
+using System.Threading.Tasks;
+
+public class CountTokenWithTxt
+{
+    public async Task<int> CountTokens(
+        string projectId = "your-project-id",
+        string location = "global",
+        string model = "gemini-2.5-flash")
+    {
+        await using var client = new Client(
+            project: projectId,
+            location: location,
+            vertexAI: true,
+            httpOptions: new HttpOptions { ApiVersion = "v1" });
+
+        CountTokensResponse response = await client.Models.CountTokensAsync(
+            model: model,
+            contents: "What's the highest mountain in Africa?");
+
+        int totalTokens = response.TotalTokens ?? 0;
+        Console.WriteLine($"Total tokens: {totalTokens}");
+        // Example response:
+        // Total tokens: 9
+        return totalTokens;
+    }
+}
+// [END googlegenaisdk_counttoken_with_txt]

--- a/genai/api/GenAI.Samples/CountTokens/CountTokenWithTxtVid.cs
+++ b/genai/api/GenAI.Samples/CountTokens/CountTokenWithTxtVid.cs
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// [START googlegenaisdk_counttoken_with_txt_vid]
+
+using Google.GenAI;
+using Google.GenAI.Types;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+public class CountTokenWithTxtVid
+{
+    public async Task<int> CountTokens(
+        string projectId = "your-project-id",
+        string location = "global",
+        string model = "gemini-2.5-flash")
+    {
+        await using var client = new Client(
+            project: projectId,
+            location: location,
+            vertexAI: true,
+            httpOptions: new HttpOptions { ApiVersion = "v1" });
+
+        var contents = new List<Content>
+        {
+            new Content
+            {
+                Parts = new List<Part>
+                {
+                    new Part
+                    {
+                        FileData = new FileData
+                        {
+                            FileUri = "gs://cloud-samples-data/generative-ai/video/pixel8.mp4",
+                            MimeType = "video/mp4"
+                        }
+                    },
+                    new Part { Text = "Provide a description of the video." }
+                }
+            }
+        };
+
+        CountTokensResponse response = await client.Models.CountTokensAsync(
+            model: model,
+            contents: contents);
+
+        int totalTokens = response.TotalTokens ?? 0;
+        Console.WriteLine($"Total tokens: {totalTokens}");
+        // Example response:
+        // Total tokens: 16708
+        return totalTokens;
+    }
+}
+// [END googlegenaisdk_counttoken_with_txt_vid]

--- a/genai/api/GenAI.Samples/GenAI.Samples.csproj
+++ b/genai/api/GenAI.Samples/GenAI.Samples.csproj
@@ -4,6 +4,6 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Google.GenAI" Version="0.3.0" />
+    <PackageReference Include="Google.GenAI" Version="0.9.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Add new genai samples:

- Compute tokens with text input.
- Count tokens with text input.
- Count tokens response usage metadata.
- Count tokens with video input.

**All local tests have passed**
