### PR TITLE
samples(Storage): Add samples and tests for ObjectContext

### DIFF
--- a/storage/api/Storage.Samples.Tests/GetObjectContextsTest.cs
+++ b/storage/api/Storage.Samples.Tests/GetObjectContextsTest.cs
@@ -36,18 +36,17 @@ public class GetObjectContextsTest
         string contextKey = "A\u00F1\u03A9\U0001F680";
         string contextValue = "Ab\u00F1\u03A9\U0001F680";
 
-        var custom = new Dictionary<string, ObjectCustomContextPayload>
+        var customContexts = new Dictionary<string, ObjectCustomContextPayload>
         {
             { contextKey, new ObjectCustomContextPayload { Value = contextValue } }
         };
 
         var bucketName = _fixture.GenerateBucketName();
         var objectName = _fixture.GenerateName();
-        var contextsData = new Object.ContextsData { Custom = custom };
         _fixture.CreateBucket(bucketName, multiVersion: false, softDelete: true, registerForDeletion: true);
         var content = _fixture.GenerateContent();
         uploadObjectSample.UploadObjectFromMemory(bucketName, objectName, content);
-        var appliedContexts = setContextsSample.SetObjectContexts(bucketName, objectName, contextsData);
+        var appliedContexts = setContextsSample.SetObjectContexts(bucketName, objectName, customContexts);
         var retrievedContexts = getContextsSample.GetObjectContexts(bucketName, objectName);
         Assert.Equal(appliedContexts.Custom.Count, retrievedContexts.Custom.Count);
         var singleContext = Assert.Single(retrievedContexts.Custom);

--- a/storage/api/Storage.Samples.Tests/GetObjectContextsTest.cs
+++ b/storage/api/Storage.Samples.Tests/GetObjectContextsTest.cs
@@ -1,0 +1,57 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+using Google.Apis.Storage.v1.Data;
+using System.Collections.Generic;
+using Xunit;
+
+[Collection(nameof(StorageFixture))]
+public class GetObjectContextsTest
+{
+    private readonly StorageFixture _fixture;
+
+    public GetObjectContextsTest(StorageFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void GetObjectContexts()
+    {
+        GetObjectContextsSample getContextsSample = new GetObjectContextsSample();
+        SetObjectContextsSample setContextsSample = new SetObjectContextsSample();
+        UploadObjectFromMemorySample uploadObjectSample = new UploadObjectFromMemorySample();
+
+        string contextKey = "A\u00F1\u03A9\U0001F680";
+        string contextValue = "Ab\u00F1\u03A9\U0001F680";
+
+        var custom = new Dictionary<string, ObjectCustomContextPayload>
+        {
+            { contextKey, new ObjectCustomContextPayload { Value = contextValue } }
+        };
+
+        var bucketName = _fixture.GenerateBucketName();
+        var objectName = _fixture.GenerateName();
+        var contextsData = new Object.ContextsData { Custom = custom };
+        _fixture.CreateBucket(bucketName, multiVersion: false, softDelete: true, registerForDeletion: true);
+        var content = _fixture.GenerateContent();
+        uploadObjectSample.UploadObjectFromMemory(bucketName, objectName, content);
+        var appliedContexts = setContextsSample.SetObjectContexts(bucketName, objectName, contextsData);
+        var retrievedContexts = getContextsSample.GetObjectContexts(bucketName, objectName);
+        Assert.Equal(appliedContexts.Custom.Count, retrievedContexts.Custom.Count);
+        var singleContext = Assert.Single(retrievedContexts.Custom);
+        Assert.Equal(contextKey, singleContext.Key);
+        Assert.Equal(contextValue, singleContext.Value.Value);
+    }
+}

--- a/storage/api/Storage.Samples.Tests/ListObjectsWithContextFilterTest.cs
+++ b/storage/api/Storage.Samples.Tests/ListObjectsWithContextFilterTest.cs
@@ -36,18 +36,17 @@ public class ListObjectsWithContextFilterTest
         string contextKey = "A\u00F1\u03A9\U0001F680";
         string contextValue = "Ab\u00F1\u03A9\U0001F680";
 
-        var custom = new Dictionary<string, ObjectCustomContextPayload>
+        var customContexts = new Dictionary<string, ObjectCustomContextPayload>
         {
             { contextKey, new ObjectCustomContextPayload { Value = contextValue } }
         };
 
         var bucketName = _fixture.GenerateBucketName();
         var objectName = _fixture.GenerateName();
-        var contextsData = new Object.ContextsData { Custom = custom };
         _fixture.CreateBucket(bucketName, multiVersion: false, softDelete: true, registerForDeletion: true);
         var content = _fixture.GenerateContent();
         uploadObjectSample.UploadObjectFromMemory(bucketName, objectName, content);
-        setContextsSample.SetObjectContexts(bucketName, objectName, contextsData);
+        setContextsSample.SetObjectContexts(bucketName, objectName, customContexts);
 
         string filter = $@"contexts.""{contextKey}""=""{contextValue}""";
         var filteredObjects = listContextsSample.ListObjectsWithContextFilter(bucketName, filter);

--- a/storage/api/Storage.Samples.Tests/ListObjectsWithContextFilterTest.cs
+++ b/storage/api/Storage.Samples.Tests/ListObjectsWithContextFilterTest.cs
@@ -1,0 +1,59 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+using Google.Apis.Storage.v1.Data;
+using System.Collections.Generic;
+using Xunit;
+
+[Collection(nameof(StorageFixture))]
+public class ListObjectsWithContextFilterTest
+{
+    private readonly StorageFixture _fixture;
+
+    public ListObjectsWithContextFilterTest(StorageFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void ListObjectsWithContextFilter()
+    {
+        ListObjectsWithContextFilterSample listContextsSample = new ListObjectsWithContextFilterSample();
+        SetObjectContextsSample setContextsSample = new SetObjectContextsSample();
+        UploadObjectFromMemorySample uploadObjectSample = new UploadObjectFromMemorySample();
+
+        string contextKey = "A\u00F1\u03A9\U0001F680";
+        string contextValue = "Ab\u00F1\u03A9\U0001F680";
+
+        var custom = new Dictionary<string, ObjectCustomContextPayload>
+        {
+            { contextKey, new ObjectCustomContextPayload { Value = contextValue } }
+        };
+
+        var bucketName = _fixture.GenerateBucketName();
+        var objectName = _fixture.GenerateName();
+        var contextsData = new Object.ContextsData { Custom = custom };
+        _fixture.CreateBucket(bucketName, multiVersion: false, softDelete: true, registerForDeletion: true);
+        var content = _fixture.GenerateContent();
+        uploadObjectSample.UploadObjectFromMemory(bucketName, objectName, content);
+        setContextsSample.SetObjectContexts(bucketName, objectName, contextsData);
+
+        string filter = $@"contexts.""{contextKey}""=""{contextValue}""";
+        var filteredObjects = listContextsSample.ListObjectsWithContextFilter(bucketName, filter);
+        var obj = Assert.Single(filteredObjects);
+        var fetchedContext = Assert.Single(obj.Contexts.Custom);
+        Assert.Equal(contextKey, fetchedContext.Key);
+        Assert.Equal(contextValue, fetchedContext.Value.Value);
+    }
+}

--- a/storage/api/Storage.Samples.Tests/PrintFileAclTest.cs
+++ b/storage/api/Storage.Samples.Tests/PrintFileAclTest.cs
@@ -24,7 +24,7 @@ public class PrintFileAclTest
         _fixture = fixture;
     }
 
-    [Fact]
+    [Fact(Skip = "b/478003908")]
     public void PrintFileAcl()
     {
         PrintFileAclSample printFileAclSample = new PrintFileAclSample();

--- a/storage/api/Storage.Samples.Tests/SetObjectContextsTest.cs
+++ b/storage/api/Storage.Samples.Tests/SetObjectContextsTest.cs
@@ -1,0 +1,57 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+using Google.Apis.Storage.v1.Data;
+using System.Collections.Generic;
+using Xunit;
+
+[Collection(nameof(StorageFixture))]
+public class SetObjectContextsTest
+{
+    private readonly StorageFixture _fixture;
+
+    public SetObjectContextsTest(StorageFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void SetObjectContexts()
+    {
+        SetObjectContextsSample contextsSample = new SetObjectContextsSample();
+        UploadObjectFromMemorySample uploadObjectSample = new UploadObjectFromMemorySample();
+
+        string contextKey = "A\u00F1\u03A9\U0001F680";
+        string contextValue = "Ab\u00F1\u03A9\U0001F680";
+
+        var custom = new Dictionary<string, ObjectCustomContextPayload>
+        {
+            { contextKey, new ObjectCustomContextPayload { Value = contextValue } }
+        };
+
+        var bucketName = _fixture.GenerateBucketName();
+        var objectName = _fixture.GenerateName();
+        _fixture.CreateBucket(bucketName, multiVersion: false, softDelete: true, registerForDeletion: true);
+
+        var contextsData = new Object.ContextsData { Custom = custom };
+        var content = _fixture.GenerateContent();
+        uploadObjectSample.UploadObjectFromMemory(bucketName, objectName, content);
+        contextsSample.SetObjectContexts(bucketName, objectName, contextsData);
+        var retrievedObject = _fixture.Client.GetObject(bucketName, objectName);
+        Assert.Equal(contextsData.Custom.Count, retrievedObject.Contexts.Custom.Count);
+        var singleContext = Assert.Single(retrievedObject.Contexts.Custom);
+        Assert.Equal(contextKey, singleContext.Key);
+        Assert.Equal(contextValue, singleContext.Value.Value);
+    }
+}

--- a/storage/api/Storage.Samples.Tests/SetObjectContextsTest.cs
+++ b/storage/api/Storage.Samples.Tests/SetObjectContextsTest.cs
@@ -35,7 +35,7 @@ public class SetObjectContextsTest
         string contextKey = "A\u00F1\u03A9\U0001F680";
         string contextValue = "Ab\u00F1\u03A9\U0001F680";
 
-        var custom = new Dictionary<string, ObjectCustomContextPayload>
+        var customContexts = new Dictionary<string, ObjectCustomContextPayload>
         {
             { contextKey, new ObjectCustomContextPayload { Value = contextValue } }
         };
@@ -44,12 +44,11 @@ public class SetObjectContextsTest
         var objectName = _fixture.GenerateName();
         _fixture.CreateBucket(bucketName, multiVersion: false, softDelete: true, registerForDeletion: true);
 
-        var contextsData = new Object.ContextsData { Custom = custom };
         var content = _fixture.GenerateContent();
         uploadObjectSample.UploadObjectFromMemory(bucketName, objectName, content);
-        contextsSample.SetObjectContexts(bucketName, objectName, contextsData);
+        var appliedContexts = contextsSample.SetObjectContexts(bucketName, objectName, customContexts);
         var retrievedObject = _fixture.Client.GetObject(bucketName, objectName);
-        Assert.Equal(contextsData.Custom.Count, retrievedObject.Contexts.Custom.Count);
+        Assert.Equal(appliedContexts.Custom.Count, retrievedObject.Contexts.Custom.Count);
         var singleContext = Assert.Single(retrievedObject.Contexts.Custom);
         Assert.Equal(contextKey, singleContext.Key);
         Assert.Equal(contextValue, singleContext.Value.Value);

--- a/storage/api/Storage.Samples/GetObjectContexts.cs
+++ b/storage/api/Storage.Samples/GetObjectContexts.cs
@@ -1,0 +1,49 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+// [START storage_get_object_contexts]
+
+using Google.Cloud.Storage.V1;
+using System;
+
+public class GetObjectContextsSample
+{
+    /// <summary>
+    /// Gets the context data associated with the object.
+    /// </summary>
+    /// <param name="bucketName">The name of the bucket containing the object.</param>
+    /// <param name="objectName">The name of the object.</param>
+    public Google.Apis.Storage.v1.Data.Object.ContextsData GetObjectContexts(
+        string bucketName = "your-unique-bucket-name",
+        string objectName = "your-object-name")
+    {
+        var storage = StorageClient.Create();
+        var obj = storage.GetObject(bucketName, objectName);
+        Google.Apis.Storage.v1.Data.Object.ContextsData contextsData = obj.Contexts;
+
+        if (contextsData?.Custom == null || contextsData.Custom.Count == 0)
+        {
+            Console.WriteLine($"No Context Data found for the Object {objectName}");
+            return contextsData;
+        }
+
+        Console.WriteLine($"Context Data for the Object {objectName} is as follows:");
+        foreach (var (key, contextPayload) in contextsData.Custom)
+        {
+            Console.WriteLine($"Context Key: {key}, Context Value: {contextPayload.Value}");
+        }
+        return contextsData;
+    }
+}
+// [END storage_get_object_contexts]

--- a/storage/api/Storage.Samples/ListObjectsWithContextFilter.cs
+++ b/storage/api/Storage.Samples/ListObjectsWithContextFilter.cs
@@ -1,0 +1,51 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_list_object_contexts]
+
+using Google.Cloud.Storage.V1;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class ListObjectsWithContextFilterSample
+{
+    /// <summary>
+    /// List objects in the specified bucket that match a context filter.
+    /// </summary>
+    /// <param name="bucketName">The name of the bucket.</param>
+    /// <param name="filter">The metadata context filter (e.g. "contexts.\"KEY\":*", "-contexts.\"KEY\":*", "contexts.\"KEY\"=\"VALUE\"", "-contexts.\"KEY\"=\"VALUE\"").</param>
+    public IEnumerable<Google.Apis.Storage.v1.Data.Object> ListObjectsWithContextFilter(string bucketName = "your-unique-bucket-name",
+        string filter = "contexts.\"KEY\"=\"VALUE\"")
+    {
+        var storage = StorageClient.Create();
+        var objects = storage.ListObjects(bucketName, prefix: null, new ListObjectsOptions { Filter = filter, Fields = "items(name,contexts)" }).ToList();
+        Console.WriteLine($"The Names and Context Data for the Objects in the {bucketName} with Context Filter {filter} are as follows:");
+        foreach (var obj in objects)
+        {
+            Console.WriteLine($"Object: {obj.Name}");
+            Console.WriteLine($"Context Data for the Object {obj.Name} is as follows:");
+
+            if (obj.Contexts?.Custom is { } customContexts)
+            {
+                foreach (var (key, contextPayload) in customContexts)
+                {
+                    Console.WriteLine($"Context Key: {key}, Context Value: {contextPayload.Value}");
+                }
+            }
+        }
+        return objects;
+    }
+}
+// [END storage_list_object_contexts]

--- a/storage/api/Storage.Samples/SetObjectContexts.cs
+++ b/storage/api/Storage.Samples/SetObjectContexts.cs
@@ -1,0 +1,46 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// https://www.apache.org/licenses/LICENSE-2.0 
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and 
+// limitations under the License.
+
+// [START storage_set_object_contexts]
+
+using Google.Cloud.Storage.V1;
+using System;
+
+public class SetObjectContextsSample
+{
+    /// <summary>
+    /// Sets the context data associated with the object.
+    /// </summary>
+    /// <param name="bucketName">The name of the bucket containing the object.</param>
+    /// <param name="objectName">The name of the object.</param>
+    /// <param name="contextsData">User-defined or system-defined object contexts. Each object context is a key-payload pair, where the key
+    /// provides the identification and the payload holds the associated value and additional metadata.</param>
+    public Google.Apis.Storage.v1.Data.Object.ContextsData SetObjectContexts(
+        string bucketName = "your-unique-bucket-name",
+        string objectName = "your-object-name",
+        Google.Apis.Storage.v1.Data.Object.ContextsData contextsData = null)
+    {
+        var storage = StorageClient.Create();
+        var obj = new Google.Apis.Storage.v1.Data.Object
+        {
+            Bucket = bucketName,
+            Name = objectName,
+            Contexts = contextsData
+        };
+        var updatedObject = storage.UpdateObject(obj);
+        Console.WriteLine($"Updated Context Data for the Object {objectName} in the Bucket {bucketName}");
+        return updatedObject.Contexts;
+    }
+}
+// [END storage_set_object_contexts]

--- a/storage/api/Storage.Samples/SetObjectContexts.cs
+++ b/storage/api/Storage.Samples/SetObjectContexts.cs
@@ -14,8 +14,10 @@
 
 // [START storage_set_object_contexts]
 
+using Google.Apis.Storage.v1.Data;
 using Google.Cloud.Storage.V1;
 using System;
+using System.Collections.Generic;
 
 public class SetObjectContextsSample
 {
@@ -24,14 +26,15 @@ public class SetObjectContextsSample
     /// </summary>
     /// <param name="bucketName">The name of the bucket containing the object.</param>
     /// <param name="objectName">The name of the object.</param>
-    /// <param name="contextsData">User-defined or system-defined object contexts. Each object context is a key-payload pair, where the key
-    /// provides the identification and the payload holds the associated value and additional metadata.</param>
+    /// <param name="customContexts">The new user-defined contexts to set context data associated with the object.</param>
     public Google.Apis.Storage.v1.Data.Object.ContextsData SetObjectContexts(
         string bucketName = "your-unique-bucket-name",
         string objectName = "your-object-name",
-        Google.Apis.Storage.v1.Data.Object.ContextsData contextsData = null)
+        IDictionary<string, ObjectCustomContextPayload> customContexts = null)
     {
         var storage = StorageClient.Create();
+        customContexts ??= new Dictionary<string, ObjectCustomContextPayload>();
+        var contextsData = new Google.Apis.Storage.v1.Data.Object.ContextsData { Custom = customContexts };
         var obj = new Google.Apis.Storage.v1.Data.Object
         {
             Bucket = bucketName,

--- a/storage/api/Storage.Samples/Storage.Samples.csproj
+++ b/storage/api/Storage.Samples/Storage.Samples.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Cloud.Storage.Control.V2" Version="1.5.0" />
-    <PackageReference Include="Google.Cloud.Storage.V1" Version="4.14.0" />
+    <PackageReference Include="Google.Cloud.Storage.V1" Version="4.15.0" />
   </ItemGroup>
 
 </Project>

--- a/storage/api/Storage.Samples/Storage.Samples.csproj
+++ b/storage/api/Storage.Samples/Storage.Samples.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Google.Cloud.Storage.Control.V2" Version="1.5.0" />
     <PackageReference Include="Google.Cloud.Storage.V1" Version="4.15.0" />
-    <PackageReference Include="Google.Apis.Storage.v1" Version="1.74.0.4161" />
+    <PackageReference Include="Google.Apis.Storage.v1" Version="*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR adds three new samples and  tests for `Object Contexts`. 

`storage_get_object_contexts` : Retrieves the ContextsData for a specific object.

`storage_list_object_contexts` : Demonstrates how to iterate through and display the context metadata associated with an object.

`storage_set_object_contexts`: llustrates how to update or apply new context data to an existing object. 
                                                                                                                                                                                                </br> ***Note*** :-  We need a new version of `Google.Cloud.Storage.V1` Nuget Package which contains `Filter` option  of `ListObjectsOptions`  so that sample and test for `List Objects with Context Data` will not fail on Kokoro server.  As of now I have updated `Google.Cloud.Storage.V1` package version to `4.15.0` in the project file which is yet to be released.