### PR TITLE
feat(Pub/Sub): Add samples for creating and updating Topics and Subscriptions with SMT

### DIFF
--- a/pubsub/api/Pubsub.Samples.Tests/CreateSubscriptionWithSingleMessageTransformTest.cs
+++ b/pubsub/api/Pubsub.Samples.Tests/CreateSubscriptionWithSingleMessageTransformTest.cs
@@ -1,0 +1,42 @@
+// Copyright 2026 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+
+[Collection(nameof(PubsubFixture))]
+public class CreateSubscriptionWithSingleMessageTransformTest
+{
+    private readonly PubsubFixture _pubsubFixture;
+    private readonly CreateSubscriptionWithSingleMessageTransformSample _createSubscriptionSample;
+
+    public CreateSubscriptionWithSingleMessageTransformTest(PubsubFixture pubsubFixture)
+    {
+        _pubsubFixture = pubsubFixture;
+        _createSubscriptionSample = new CreateSubscriptionWithSingleMessageTransformSample();
+    }
+
+    [Fact]
+    public void CreateSubscriptionWithSingleMessageTransform()
+    {
+        var (topicId, subscriptionId) = _pubsubFixture.RandomNameTopicSubscriptionId();
+        _pubsubFixture.TempTopicIds.Add(topicId);
+        _pubsubFixture.TempSubscriptionIds.Add(subscriptionId);
+
+        _pubsubFixture.CreateTopic(topicId);
+
+        _createSubscriptionSample.CreateSubscriptionWithSingleMessageTransform(_pubsubFixture.ProjectId, topicId, subscriptionId);
+        var subscription = _pubsubFixture.GetSubscription(subscriptionId);
+        Assert.Equal("redactSsn", subscription.MessageTransforms[0].JavascriptUdf.FunctionName);
+    }
+}

--- a/pubsub/api/Pubsub.Samples.Tests/CreateTopicWithSingleMessageTransformTest.cs
+++ b/pubsub/api/Pubsub.Samples.Tests/CreateTopicWithSingleMessageTransformTest.cs
@@ -1,0 +1,41 @@
+// Copyright 2026 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Cloud.PubSub.V1;
+using System.Collections.Generic;
+using Xunit;
+
+[Collection(nameof(PubsubFixture))]
+public class CreateTopicWithSingleMessageTransformTest
+{
+    private readonly PubsubFixture _pubsubFixture;
+    private readonly CreateTopicWithSingleMessageTransformSample _createTopicWithSingleMessageTransformSample;
+
+    public CreateTopicWithSingleMessageTransformTest(PubsubFixture pubsubFixture)
+    {
+        _pubsubFixture = pubsubFixture;
+        _createTopicWithSingleMessageTransformSample = new CreateTopicWithSingleMessageTransformSample();
+    }
+
+    [Fact]
+    public void CreateTopic()
+    {
+        string topicId = _pubsubFixture.RandomTopicId();
+        _pubsubFixture.TempTopicIds.Add(topicId);
+
+        _createTopicWithSingleMessageTransformSample.CreateTopicWithSingleMessageTransform(_pubsubFixture.ProjectId, topicId);
+        var topic = _pubsubFixture.GetTopic(topicId);
+        Assert.Equal("redactSsn", topic.MessageTransforms[0].JavascriptUdf.FunctionName);
+    }
+}

--- a/pubsub/api/Pubsub.Samples/CreateSubscriptionWithSingleMessageTransform.cs
+++ b/pubsub/api/Pubsub.Samples/CreateSubscriptionWithSingleMessageTransform.cs
@@ -1,0 +1,53 @@
+// Copyright 2026 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START pubsub_create_subscription_with_smt]
+
+using Google.Cloud.PubSub.V1;
+using System;
+
+public class CreateSubscriptionWithSingleMessageTransformSample
+{
+    public Subscription CreateSubscriptionWithSingleMessageTransform(string projectId, string topicId, string subscriptionId)
+    {
+        SubscriberServiceApiClient subscriber = SubscriberServiceApiClient.Create();
+        TopicName topicName = TopicName.FromProjectTopic(projectId, topicId);
+
+        SubscriptionName subscriptionName = SubscriptionName.FromProjectSubscription(projectId, subscriptionId);
+        MessageTransform removeSSNTransform = new MessageTransform
+        {
+            JavascriptUdf = new JavaScriptUDF
+            {
+                FunctionName = "redactSsn",
+                Code = "function redactSsn(message, metadata) {"
+                + "   const data = JSON.parse(message.data);"
+                + "   delete data['ssn'];"
+                + "   message.data = JSON.stringify(data);"
+                + "   return message;"
+                + "}"
+            },
+        };
+
+        var subscription = subscriber.CreateSubscription(new Subscription
+        {
+            SubscriptionName = subscriptionName,
+            TopicAsTopicName = topicName,
+            MessageTransforms = { removeSSNTransform },
+        });
+        Console.WriteLine($"Subscription {subscription.Name} created with SMT.");
+
+        return subscription;
+    }
+}
+// [END pubsub_create_subscription_with_smt]

--- a/pubsub/api/Pubsub.Samples/CreateTopicWithSingleMessageTransform.cs
+++ b/pubsub/api/Pubsub.Samples/CreateTopicWithSingleMessageTransform.cs
@@ -1,0 +1,51 @@
+// Copyright 2026 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START pubsub_create_topic_with_smt]
+
+using Google.Cloud.PubSub.V1;
+using System;
+
+public class CreateTopicWithSingleMessageTransformSample
+{
+    public Topic CreateTopicWithSingleMessageTransform(string projectId, string topicId)
+    {
+        PublisherServiceApiClient publisher = PublisherServiceApiClient.Create();
+        var topicName = TopicName.FromProjectTopic(projectId, topicId);
+
+        MessageTransform removeSSNTransform = new MessageTransform
+        {
+            JavascriptUdf = new JavaScriptUDF
+            {
+                FunctionName = "redactSsn",
+                Code = "function redactSsn(message, metadata) {"
+                + "   const data = JSON.parse(message.data);"
+                + "   delete data['ssn'];"
+                + "   message.data = JSON.stringify(data);"
+                + "   return message;"
+                + "}"
+            },
+        };
+
+        Topic topic = publisher.CreateTopic(new Topic()
+        {
+            TopicName = topicName,
+            MessageTransforms = { removeSSNTransform }
+        });
+        Console.WriteLine($"Topic {topic.Name} created with SMT.");
+
+        return topic;
+    }
+}
+// [END pubsub_create_topic_with_smt]


### PR DESCRIPTION
b/427316649
Adds four new samples to demonstrate creating and updating topics and Subscriptions with SMT using JavaScript UDF.
`CreateTopicWithSingleMessageTransformSample`
`CreateSubscriptionWithSingleMessageTransformSample`

`UpdateSubscriptionSingleMessageTransformSample`
`UpdateTopicSingleMessageTransformSample`