### PR TITLE
samples(Storage): Update sample and test for compose object with delete source objects

### DIFF
--- a/storage/api/Storage.Samples.Tests/ComposeObjectTest.cs
+++ b/storage/api/Storage.Samples.Tests/ComposeObjectTest.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.IO;
+using System.Linq;
 using Xunit;
 
 [Collection(nameof(StorageFixture))]
@@ -45,7 +46,7 @@ public class ComposeObjectTest
 
         composeObjectSample.ComposeObject(_fixture.BucketNameGeneric, firstObject, secondObject, _fixture.Collect(targetObject), shouldDeleteSources);
 
-        var files = listFilesSample.ListFiles(_fixture.BucketNameGeneric);
+        var files = listFilesSample.ListFiles(_fixture.BucketNameGeneric).ToList();
 
         if (shouldDeleteSources)
         {

--- a/storage/api/Storage.Samples.Tests/ComposeObjectTest.cs
+++ b/storage/api/Storage.Samples.Tests/ComposeObjectTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2021 Google Inc.
+// Copyright 2021 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,12 +25,15 @@ public class ComposeObjectTest
         _fixture = fixture;
     }
 
-    [Fact]
-    public void ComposeObject()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ComposeObject(bool shouldDeleteSources)
     {
         UploadFileSample uploadFileSample = new UploadFileSample();
         ComposeObjectSample composeObjectSample = new ComposeObjectSample();
         DownloadFileSample downloadFileSample = new DownloadFileSample();
+        ListFilesSample listFilesSample = new ListFilesSample();
 
         var firstObject = "HelloComposeObject.txt";
         var secondObject = "HelloComposeObjectAdditional.txt";
@@ -40,7 +43,20 @@ public class ComposeObjectTest
 
         uploadFileSample.UploadFile(_fixture.BucketNameGeneric, "Resources/HelloDownloadCompleteByteRange.txt", _fixture.Collect(secondObject));
 
-        composeObjectSample.ComposeObject(_fixture.BucketNameGeneric, firstObject, secondObject, _fixture.Collect(targetObject));
+        composeObjectSample.ComposeObject(_fixture.BucketNameGeneric, firstObject, secondObject, _fixture.Collect(targetObject), shouldDeleteSources);
+
+        var files = listFilesSample.ListFiles(_fixture.BucketNameGeneric);
+
+        if (shouldDeleteSources)
+        {
+            Assert.DoesNotContain(files, c => c.Name == firstObject);
+            Assert.DoesNotContain(files, c => c.Name == secondObject);
+        }
+        else
+        {
+            Assert.Contains(files, c => c.Name == firstObject);
+            Assert.Contains(files, c => c.Name == secondObject);
+        }
 
         // Download the composed file
         downloadFileSample.DownloadFile(_fixture.BucketNameGeneric, targetObject, targetObject);

--- a/storage/api/Storage.Samples/ComposeObject.cs
+++ b/storage/api/Storage.Samples/ComposeObject.cs
@@ -22,8 +22,8 @@ using System.Collections.Generic;
 public class ComposeObjectSample
 {
     /// <summary>
-    /// Combines multiple source objects into a single target object within a specified bucket
-    /// and deletes the original source objects upon successful composition.
+    /// Combines multiple source objects into a single target object within a specified bucket,
+    /// with the option to delete the original source objects upon successful composition.
     /// </summary>
     /// <param name="bucketName">The name of the bucket containing the source objects.</param>
     /// <param name="firstObjectName">The name of the first source object to be composed.</param>
@@ -54,9 +54,9 @@ public class ComposeObjectSample
             Destination = new Google.Apis.Storage.v1.Data.Object { ContentType = "text/plain" }
         }, bucketName, targetObjectName).Execute();
 
-        string deletionMessage = deleteSourceObjects ? "and the source objects were deleted." : "";
+        string deletionMessage = deleteSourceObjects ? " and the source objects were deleted." : ".";
         Console.WriteLine($"New composite file {targetObjectName} was created in bucket {bucketName}" +
-            $" by combining {firstObjectName} and {secondObjectName} {deletionMessage}");
+            $" by combining {firstObjectName} and {secondObjectName}{deletionMessage}");
     }
 }
 // [END storage_compose_file]

--- a/storage/api/Storage.Samples/ComposeObject.cs
+++ b/storage/api/Storage.Samples/ComposeObject.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2021 Google Inc.
+// Copyright 2021 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,11 +21,22 @@ using System.Collections.Generic;
 
 public class ComposeObjectSample
 {
+    /// <summary>
+    /// Combines multiple source objects into a single target object within a specified bucket
+    /// and deletes the original source objects upon successful composition.
+    /// </summary>
+    /// <param name="bucketName">The name of the bucket containing the source objects.</param>
+    /// <param name="firstObjectName">The name of the first source object to be composed.</param>
+    /// <param name="secondObjectName">The name of the second source object to be composed.</param>
+    /// <param name="targetObjectName">The name for the newly created composite object.</param>
+    /// <param name="deleteSourceObjects">If set to <c>true</c>, the method will automatically delete <paramref name="firstObjectName"/> and <paramref name="secondObjectName"/> upon successful composition.
+    /// Defaults to <c>false</c>.</param>
     public void ComposeObject(
         string bucketName = "your-bucket-name",
         string firstObjectName = "your-first-object-name",
         string secondObjectName = "your-second-object-name",
-        string targetObjectName = "new-composite-object-name")
+        string targetObjectName = "new-composite-object-name",
+        bool deleteSourceObjects = false)
     {
         var storage = StorageClient.Create();
 
@@ -38,12 +49,14 @@ public class ComposeObjectSample
 
         storage.Service.Objects.Compose(new ComposeRequest
         {
+            DeleteSourceObjects = deleteSourceObjects,
             SourceObjects = sourceObjects,
             Destination = new Google.Apis.Storage.v1.Data.Object { ContentType = "text/plain" }
         }, bucketName, targetObjectName).Execute();
 
+        string deletionMessage = deleteSourceObjects ? "and the source objects were deleted." : "";
         Console.WriteLine($"New composite file {targetObjectName} was created in bucket {bucketName}" +
-            $" by combining {firstObjectName} and {secondObjectName}.");
+            $" by combining {firstObjectName} and {secondObjectName} {deletionMessage}");
     }
 }
 // [END storage_compose_file]

--- a/storage/api/Storage.Samples/Storage.Samples.csproj
+++ b/storage/api/Storage.Samples/Storage.Samples.csproj
@@ -6,7 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Cloud.Storage.Control.V2" Version="1.5.0" />
-    <PackageReference Include="Google.Cloud.Storage.V1" Version="4.14.0" />
+    <PackageReference Include="Google.Cloud.Storage.V1" Version="4.15.0" />
+    <PackageReference Include="Google.Apis.Storage.v1" Version="1.74.0.4161" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR contains  updation of the sample and test  for  `ComposeObject` with the introduction of  boolean `deleteSourceObjects` parameter. 