### PR TITLE
feat(storage): add dotnet deleteFolderRecursive sample

### DIFF
--- a/storage/api/Storage.Samples.Tests/StorageControlDeleteFolderRecursiveTest.cs
+++ b/storage/api/Storage.Samples.Tests/StorageControlDeleteFolderRecursiveTest.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Linq;
 using Xunit;
 
 namespace Storage.Samples.Tests;
@@ -39,6 +40,6 @@ public class StorageControlDeleteFolderRecursiveTest
         StorageControlListFoldersSample listFoldersSample = new StorageControlListFoldersSample();
         var folders = listFoldersSample.StorageControlListFolders(_fixture.BucketNameHns);
 
-        Assert.DoesNotContain(folders, f => f.Name == folder.Name);
+        Assert.False(folders.Any(f => f.Name == folder.Name));
     }
 }

--- a/storage/api/Storage.Samples.Tests/StorageControlDeleteFolderRecursiveTest.cs
+++ b/storage/api/Storage.Samples.Tests/StorageControlDeleteFolderRecursiveTest.cs
@@ -1,0 +1,43 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+
+namespace Storage.Samples.Tests;
+
+[Collection(nameof(StorageFixture))]
+public class StorageControlDeleteFolderRecursiveTest
+{
+    private readonly StorageFixture _fixture;
+
+    public StorageControlDeleteFolderRecursiveTest(StorageFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void TestStorageControlDeleteFolderRecursive()
+    {
+        StorageControlCreateFolderSample createSample = new StorageControlCreateFolderSample();
+        var folder = createSample.StorageControlCreateFolder(_fixture.BucketNameHns, "deleteRecursiveTestFolder");
+
+        StorageControlDeleteFolderRecursiveSample deleteSample = new StorageControlDeleteFolderRecursiveSample();
+        deleteSample.StorageControlDeleteFolderRecursive(_fixture.BucketNameHns, "deleteRecursiveTestFolder");
+
+        StorageControlListFoldersSample listFoldersSample = new StorageControlListFoldersSample();
+        var folders = listFoldersSample.StorageControlListFolders(_fixture.BucketNameHns);
+
+        Assert.DoesNotContain(folder, folders);
+    }
+}

--- a/storage/api/Storage.Samples.Tests/StorageControlDeleteFolderRecursiveTest.cs
+++ b/storage/api/Storage.Samples.Tests/StorageControlDeleteFolderRecursiveTest.cs
@@ -29,15 +29,16 @@ public class StorageControlDeleteFolderRecursiveTest
     [Fact]
     public void TestStorageControlDeleteFolderRecursive()
     {
+        string folderName = _fixture.GenerateName();
         StorageControlCreateFolderSample createSample = new StorageControlCreateFolderSample();
-        var folder = createSample.StorageControlCreateFolder(_fixture.BucketNameHns, "deleteRecursiveTestFolder");
+        var folder = createSample.StorageControlCreateFolder(_fixture.BucketNameHns, folderName);
 
         StorageControlDeleteFolderRecursiveSample deleteSample = new StorageControlDeleteFolderRecursiveSample();
-        deleteSample.StorageControlDeleteFolderRecursive(_fixture.BucketNameHns, "deleteRecursiveTestFolder");
+        deleteSample.StorageControlDeleteFolderRecursive(_fixture.BucketNameHns, folderName);
 
         StorageControlListFoldersSample listFoldersSample = new StorageControlListFoldersSample();
         var folders = listFoldersSample.StorageControlListFolders(_fixture.BucketNameHns);
 
-        Assert.DoesNotContain(folder, folders);
+        Assert.DoesNotContain(folders, f => f.Name == folder.Name);
     }
 }

--- a/storage/api/Storage.Samples.Tests/StorageControlDeleteFolderRecursiveTest.cs
+++ b/storage/api/Storage.Samples.Tests/StorageControlDeleteFolderRecursiveTest.cs
@@ -30,16 +30,19 @@ public class StorageControlDeleteFolderRecursiveTest
     [Fact]
     public void TestStorageControlDeleteFolderRecursive()
     {
-        string folderName = _fixture.GenerateName();
+        string parentFolderName = _fixture.GenerateName();
+        string subfolderName = $"{parentFolderName}/{_fixture.GenerateName()}";
         StorageControlCreateFolderSample createSample = new StorageControlCreateFolderSample();
-        var folder = createSample.StorageControlCreateFolder(_fixture.BucketNameHns, folderName);
+        var parentFolder = createSample.StorageControlCreateFolder(_fixture.BucketNameHns, parentFolderName);
+        var subfolder = createSample.StorageControlCreateFolder(_fixture.BucketNameHns, subfolderName);
 
         StorageControlDeleteFolderRecursiveSample deleteSample = new StorageControlDeleteFolderRecursiveSample();
-        deleteSample.StorageControlDeleteFolderRecursive(_fixture.BucketNameHns, folderName);
+        deleteSample.StorageControlDeleteFolderRecursive(_fixture.BucketNameHns, parentFolderName);
 
         StorageControlListFoldersSample listFoldersSample = new StorageControlListFoldersSample();
         var folders = listFoldersSample.StorageControlListFolders(_fixture.BucketNameHns);
 
-        Assert.False(folders.Any(f => f.Name == folder.Name));
+        Assert.False(folders.Any(f => f.Name == parentFolder.Name));
+        Assert.False(folders.Any(f => f.Name == subfolder.Name));
     }
 }

--- a/storage/api/Storage.Samples/Storage.Samples.csproj
+++ b/storage/api/Storage.Samples/Storage.Samples.csproj
@@ -1,11 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Cloud.Storage.Control.V2" Version="1.5.0" />
+    <PackageReference Include="Google.Cloud.Storage.Control.V2" Version="1.8.0" />
     <PackageReference Include="Google.Cloud.Storage.V1" Version="4.15.0" />
     <PackageReference Include="Google.Apis.Storage.v1" Version="*" />
   </ItemGroup>

--- a/storage/api/Storage.Samples/StorageControlDeleteFolderRecursive.cs
+++ b/storage/api/Storage.Samples/StorageControlDeleteFolderRecursive.cs
@@ -1,0 +1,34 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_control_delete_folder_recursive]
+using Google.Cloud.Storage.Control.V2;
+using System;
+
+public class StorageControlDeleteFolderRecursiveSample
+{
+    public void StorageControlDeleteFolderRecursive(string bucketName = "your-unique-bucket-name", string folderName = "your_folder_name")
+    {
+        StorageControlClient storageControl = StorageControlClient.Create();
+
+        // Set project to "_" to signify globally scoped bucket
+        string folderResourceName = FolderName.FormatProjectBucketFolder("_", bucketName, folderName);
+
+        // Execute the long-running operation and wait for completion
+        storageControl.DeleteFolderRecursive(folderResourceName).PollUntilCompleted();
+
+        Console.WriteLine($"Deleted folder {folderResourceName}");
+    }
+}
+// [END storage_control_delete_folder_recursive]


### PR DESCRIPTION
Adds a .NET code sample demonstrating hierarchical namespace recursive folder delete.

Fixes: b/530059315