### PR TITLE
fix(storage): resolve race conditions in archived generation tests

### DIFF
--- a/storage/api/Storage.Samples.Tests/CopyFileArchivedGenerationTest.cs
+++ b/storage/api/Storage.Samples.Tests/CopyFileArchivedGenerationTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2021 Google Inc.
+// Copyright 2021 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,40 +30,34 @@ public class CopyFileArchivedGenerationTest
     public void CopyFileArchivedGeneration()
     {
         UploadFileSample uploadFileSample = new UploadFileSample();
-        BucketEnableVersioningSample bucketEnableVersioningSample = new BucketEnableVersioningSample();
         GetMetadataSample getMetadataSample = new GetMetadataSample();
         DownloadFileSample downloadFileSample = new DownloadFileSample();
         CopyFileArchivedGenerationSample copyFileArchivedGenerationSample = new CopyFileArchivedGenerationSample();
-        BucketDisableVersioningSample bucketDisableVersioningSample = new BucketDisableVersioningSample();
 
-        var objectName = Guid.NewGuid().ToString() +".txt";
-        var copiedObjectName = Guid.NewGuid().ToString() + ".txt";
-
-        // Enable bucket versioning
-        bucketEnableVersioningSample.BucketEnableVersioning(_fixture.BucketNameGeneric);
+        var objectName = _fixture.GenerateName();
+        var copiedObjectName = _fixture.GenerateName();
 
         // Uploaded for the first time
-        uploadFileSample.UploadFile(_fixture.BucketNameGeneric, _fixture.FilePath, objectName);
+        uploadFileSample.UploadFile(_fixture.BucketNameVersioned, _fixture.FilePath, objectName);
 
         // Get generation of first version of the file
-        var obj = getMetadataSample.GetMetadata(_fixture.BucketNameGeneric, objectName);
+        var obj = getMetadataSample.GetMetadata(_fixture.BucketNameVersioned, objectName);
         var fileArchivedGeneration = obj.Generation;
 
         // Upload again to archive previous generation.
-        uploadFileSample.UploadFile(_fixture.BucketNameGeneric, "Resources/HelloDownloadCompleteByteRange.txt", objectName);
+        uploadFileSample.UploadFile(_fixture.BucketNameVersioned, "Resources/HelloDownloadCompleteByteRange.txt", objectName);
 
         // Get generation of second version of the file
-        obj = getMetadataSample.GetMetadata(_fixture.BucketNameGeneric, objectName);
+        obj = getMetadataSample.GetMetadata(_fixture.BucketNameVersioned, objectName);
         var fileCurrentGeneration = obj.Generation;
 
-
-        _fixture.CollectArchivedFiles(_fixture.BucketNameGeneric, objectName, fileArchivedGeneration);
-        _fixture.CollectArchivedFiles(_fixture.BucketNameGeneric, objectName, fileCurrentGeneration);
+        _fixture.CollectArchivedFiles(_fixture.BucketNameVersioned, objectName, fileArchivedGeneration);
+        _fixture.CollectArchivedFiles(_fixture.BucketNameVersioned, objectName, fileCurrentGeneration);
 
         try
         {
             // Copy first version of the file to new bucket.
-            copyFileArchivedGenerationSample.CopyFileArchivedGeneration(_fixture.BucketNameGeneric, objectName,
+            copyFileArchivedGenerationSample.CopyFileArchivedGeneration(_fixture.BucketNameVersioned, objectName,
                 _fixture.BucketNameRegional, _fixture.CollectRegionalObject(copiedObjectName), fileArchivedGeneration);
 
             // Download copied file
@@ -75,9 +69,6 @@ public class CopyFileArchivedGenerationTest
         finally
         {
             File.Delete(copiedObjectName);
-
-            // Disable bucket versioning
-            bucketDisableVersioningSample.BucketDisableVersioning(_fixture.BucketNameGeneric);
         }
     }
 }

--- a/storage/api/Storage.Samples.Tests/DeleteFileArchivedGenerationTest.cs
+++ b/storage/api/Storage.Samples.Tests/DeleteFileArchivedGenerationTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2021 Google Inc.
+// Copyright 2021 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,53 +29,35 @@ public class DeleteFileArchivedGenerationTest
     public void DeleteFileArchivedGeneration()
     {
         UploadFileSample uploadFileSample = new UploadFileSample();
-        ListFilesSample listFilesSample = new ListFilesSample();
-        BucketEnableVersioningSample bucketEnableVersioningSample = new BucketEnableVersioningSample();
-        GetMetadataSample getMetadataSample = new GetMetadataSample();
-        DownloadFileSample downloadFileSample = new DownloadFileSample();
         ListFileArchivedGenerationSample listFileArchivedGenerationSample = new ListFileArchivedGenerationSample();
         DeleteFileArchivedGenerationSample deleteFileArchivedGenerationSample = new DeleteFileArchivedGenerationSample();
-        BucketDisableVersioningSample bucketDisableVersioningSample = new BucketDisableVersioningSample();
 
-        var objectName = "HelloDeleteFileArchivedGeneration.txt";
+        var objectName = _fixture.GenerateName();
 
-        // Enable bucket versioning
-        bucketEnableVersioningSample.BucketEnableVersioning(_fixture.BucketNameGeneric);
-
-        // Uploaded for the first time
-        uploadFileSample.UploadFile(_fixture.BucketNameGeneric, _fixture.FilePath, objectName);
+        uploadFileSample.UploadFile(_fixture.BucketNameVersioned, _fixture.FilePath, objectName);
 
         // Upload again to archive previous generation.
-        uploadFileSample.UploadFile(_fixture.BucketNameGeneric, "Resources/HelloDownloadCompleteByteRange.txt", objectName);
+        uploadFileSample.UploadFile(_fixture.BucketNameVersioned, "Resources/HelloDownloadCompleteByteRange.txt", objectName);
 
+        var objects = listFileArchivedGenerationSample.ListFileArchivedGeneration(_fixture.BucketNameVersioned);
 
-        try
-        {
-            var objects = listFileArchivedGenerationSample.ListFileArchivedGeneration(_fixture.BucketNameGeneric);
+        Assert.Equal(2, objects.Count(a => a.Name == objectName));
 
-            Assert.Equal(2, objects.Count(a => a.Name == objectName));
+        // Get Generations
+        var testFiles = objects.Where(a => a.Name == objectName).ToList();
+        long? fileArchivedGeneration = testFiles[0].Generation;
+        long? fileCurrentGeneration = testFiles[1].Generation;
 
-            // Get Generations
-            var testFiles = objects.Where(a => a.Name == objectName).ToList();
-            long? fileArchivedGeneration = testFiles[0].Generation;
-            long? fileCurrentGeneration = testFiles[1].Generation;
+        // Delete first generation of the file
+        deleteFileArchivedGenerationSample.DeleteFileArchivedGeneration(_fixture.BucketNameVersioned, objectName, fileArchivedGeneration);
 
-            // Delete first generation of the file
-            deleteFileArchivedGenerationSample.DeleteFileArchivedGeneration(_fixture.BucketNameGeneric, objectName, fileArchivedGeneration);
+        objects = listFileArchivedGenerationSample.ListFileArchivedGeneration(_fixture.BucketNameVersioned);
+        Assert.Equal(1, objects.Count(a => a.Name == objectName));
 
-            objects = listFileArchivedGenerationSample.ListFileArchivedGeneration(_fixture.BucketNameGeneric);
-            Assert.Equal(1, objects.Count(a => a.Name == objectName));
+        // Delete second generation of the file
+        deleteFileArchivedGenerationSample.DeleteFileArchivedGeneration(_fixture.BucketNameVersioned, objectName, fileCurrentGeneration);
 
-            // Delete second generation of the file
-            deleteFileArchivedGenerationSample.DeleteFileArchivedGeneration(_fixture.BucketNameGeneric, objectName, fileCurrentGeneration);
-
-            objects = listFileArchivedGenerationSample.ListFileArchivedGeneration(_fixture.BucketNameGeneric);
-            Assert.Equal(0, objects.Count(a => a.Name == objectName));
-        }
-        finally
-        {
-            // Disable bucket versioning
-            bucketDisableVersioningSample.BucketDisableVersioning(_fixture.BucketNameGeneric);
-        }
+        objects = listFileArchivedGenerationSample.ListFileArchivedGeneration(_fixture.BucketNameVersioned);
+        Assert.Equal(0, objects.Count(a => a.Name == objectName));
     }
 }

--- a/storage/api/Storage.Samples.Tests/ListFileArchivedGenerationTest.cs
+++ b/storage/api/Storage.Samples.Tests/ListFileArchivedGenerationTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2021 Google Inc.
+// Copyright 2021 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,39 +29,22 @@ public class ListFileArchivedGenerationTest
     public void ListFileArchivedGeneration()
     {
         UploadFileSample uploadFileSample = new UploadFileSample();
-        ListFilesSample listFilesSample = new ListFilesSample();
-        BucketEnableVersioningSample bucketEnableVersioningSample = new BucketEnableVersioningSample();
-        GetMetadataSample getMetadataSample = new GetMetadataSample();
-        DownloadFileSample downloadFileSample = new DownloadFileSample();
         ListFileArchivedGenerationSample listFileArchivedGenerationSample = new ListFileArchivedGenerationSample();
-        DeleteFileArchivedGenerationSample deleteFileArchivedGenerationSample = new DeleteFileArchivedGenerationSample();
-        BucketDisableVersioningSample bucketDisableVersioningSample = new BucketDisableVersioningSample();
 
-        var objectName = "HelloListFileArchivedGeneration.txt";
-
-        // Enable bucket versioning
-        bucketEnableVersioningSample.BucketEnableVersioning(_fixture.BucketNameGeneric);
+        var objectName = _fixture.GenerateName();
 
         // Uploaded for the first time
-        uploadFileSample.UploadFile(_fixture.BucketNameGeneric, _fixture.FilePath, objectName);
+        uploadFileSample.UploadFile(_fixture.BucketNameVersioned, _fixture.FilePath, objectName);
 
         // Upload again to archive previous generation.
-        uploadFileSample.UploadFile(_fixture.BucketNameGeneric, "Resources/HelloDownloadCompleteByteRange.txt", objectName);
+        uploadFileSample.UploadFile(_fixture.BucketNameVersioned, "Resources/HelloDownloadCompleteByteRange.txt", objectName);
 
-        try
-        {
-            var objects = listFileArchivedGenerationSample.ListFileArchivedGeneration(_fixture.BucketNameGeneric);
+        var objects = listFileArchivedGenerationSample.ListFileArchivedGeneration(_fixture.BucketNameVersioned);
 
-            var testFiles = objects.Where(a => a.Name == objectName).ToList();
-            
-            Assert.Equal(2, testFiles.Count);            
-            _fixture.CollectArchivedFiles(_fixture.BucketNameGeneric, objectName, testFiles[0].Generation);
-            _fixture.CollectArchivedFiles(_fixture.BucketNameGeneric, objectName, testFiles[1].Generation);
-        }
-        finally
-        {
-            // Disable bucket versioning
-            bucketDisableVersioningSample.BucketDisableVersioning(_fixture.BucketNameGeneric);
-        }
+        var testFiles = objects.Where(a => a.Name == objectName).ToList();
+
+        Assert.Equal(2, testFiles.Count);
+        _fixture.CollectArchivedFiles(_fixture.BucketNameVersioned, objectName, testFiles[0].Generation);
+        _fixture.CollectArchivedFiles(_fixture.BucketNameVersioned, objectName, testFiles[1].Generation);
     }
 }

--- a/storage/api/Storage.Samples.Tests/StorageFixture.cs
+++ b/storage/api/Storage.Samples.Tests/StorageFixture.cs
@@ -39,6 +39,7 @@ public class StorageFixture : IDisposable, ICollectionFixture<StorageFixture>
     public string BucketNameRegional { get; } = Guid.NewGuid().ToString();
 
     public string BucketNameHns { get; } = Guid.NewGuid().ToString();
+    public string BucketNameVersioned { get; } = Guid.NewGuid().ToString();
     public string TestLocation { get; } = "us-west1";
     public string FileName { get; } = "Hello.txt";
     public string FilePath { get; } = "Resources/Hello.txt";
@@ -68,7 +69,8 @@ public class StorageFixture : IDisposable, ICollectionFixture<StorageFixture>
         Client = StorageClient.Create();
         // create simple bucket
         CreateBucket(BucketNameGeneric);
-
+        // Create versioned bucket
+        CreateBucket(BucketNameVersioned, multiVersion: true, softDelete: false, registerForDeletion: true);
         // create regional bucket
         CreateRegionalBucketSample createRegionalBucketSample = new CreateRegionalBucketSample();
         createRegionalBucketSample.CreateRegionalBucket(ProjectId, BucketNameRegional, TestLocation, StorageClasses.Regional);


### PR DESCRIPTION
This PR provides a fix to the [issue](https://github.com/GoogleCloudPlatform/dotnet-docs-samples/issues/1563) and 
resolves the test flakiness observed in the archived generation tests (such as `CopyFileArchivedGenerationTest` , `ListFileArchivedGenerationTest` and `DeleteFileArchivedGenerationTest`).

Previously, these tests were failing intermittently with `404 No such object` or assertion errors (`Expected: 2, Actual: 1`).

Because the tests were creating, deleting objects immediately after enabling versioning on the bucket, GCS had not always propagated the versioning state, resulting in objects being permanently deleted instead of archived.

This PR removes bucket versioning toggling from generation tests and introduces `BucketNameVersioned` (shared  versioned bucket) in the `StorageFixture`  and utilized shared versioned bucket across all generation tests eliminating race conditions.