### PR TITLE
fix(aiplatform): update Gemini model from 2.0-flash to gemini-2.5-flash

### DIFF
--- a/aiplatform/api/AIPlatform.Samples/AudioInputSummarization.cs
+++ b/aiplatform/api/AIPlatform.Samples/AudioInputSummarization.cs
@@ -26,7 +26,7 @@ public class AudioInputSummarization
         string projectId = "your-project-id",
         string location = "us-central1",
         string publisher = "google",
-        string model = "gemini-2.0-flash-001")
+        string model = "gemini-2.5-flash")
     {
         var predictionServiceClient = new PredictionServiceClientBuilder
         {

--- a/aiplatform/api/AIPlatform.Samples/AudioInputTranscription.cs
+++ b/aiplatform/api/AIPlatform.Samples/AudioInputTranscription.cs
@@ -26,7 +26,7 @@ public class AudioInputTranscription
         string projectId = "your-project-id",
         string location = "us-central1",
         string publisher = "google",
-        string model = "gemini-2.0-flash-001")
+        string model = "gemini-2.5-flash")
     {
 
         var predictionServiceClient = new PredictionServiceClientBuilder

--- a/aiplatform/api/AIPlatform.Samples/ContextCaching/CreateContextCache.cs
+++ b/aiplatform/api/AIPlatform.Samples/ContextCaching/CreateContextCache.cs
@@ -35,7 +35,7 @@ public class CreateContextCache
             Parent = $"projects/{projectId}/locations/us-central1",
             CachedContent = new CachedContent
             {
-                Model = $"projects/{projectId}/locations/us-central1/publishers/google/models/gemini-2.0-flash-001",
+                Model = $"projects/{projectId}/locations/us-central1/publishers/google/models/gemini-2.5-flash",
                 SystemInstruction = new Content
                 {
                     Parts =

--- a/aiplatform/api/AIPlatform.Samples/ContextCaching/UseContextCache.cs
+++ b/aiplatform/api/AIPlatform.Samples/ContextCaching/UseContextCache.cs
@@ -32,7 +32,7 @@ public class UseContextCache
         var generateContentRequest = new GenerateContentRequest
         {
             CachedContentAsCachedContentName = name,
-            Model = $"projects/{projectId}/locations/us-central1/publishers/google/models/gemini-2.0-flash-001",
+            Model = $"projects/{projectId}/locations/us-central1/publishers/google/models/gemini-2.5-flash",
             Contents =
             {
                 new Content

--- a/aiplatform/api/AIPlatform.Samples/ControlledGeneration.cs
+++ b/aiplatform/api/AIPlatform.Samples/ControlledGeneration.cs
@@ -26,7 +26,7 @@ public class ControlledGeneration
         string projectId = "your-project-id",
         string location = "us-central1",
         string publisher = "google",
-        string model = "gemini-2.0-flash-001")
+        string model = "gemini-2.5-flash")
     {
 
         var predictionServiceClient = new PredictionServiceClientBuilder
@@ -73,7 +73,7 @@ public class ControlledGeneration
         string projectId = "your-project-id",
         string location = "us-central1",
         string publisher = "google",
-        string model = "gemini-2.0-flash-001")
+        string model = "gemini-2.5-flash")
     {
 
         var predictionServiceClient = new PredictionServiceClientBuilder
@@ -130,7 +130,7 @@ public class ControlledGeneration
         string projectId = "your-project-id",
         string location = "us-central1",
         string publisher = "google",
-        string model = "gemini-2.0-flash-001")
+        string model = "gemini-2.5-flash")
     {
 
         var predictionServiceClient = new PredictionServiceClientBuilder
@@ -194,7 +194,7 @@ public class ControlledGeneration
         string projectId = "your-project-id",
         string location = "us-central1",
         string publisher = "google",
-        string model = "gemini-2.0-flash-001")
+        string model = "gemini-2.5-flash")
     {
 
         var predictionServiceClient = new PredictionServiceClientBuilder
@@ -270,7 +270,7 @@ public class ControlledGeneration
         string projectId = "your-project-id",
         string location = "us-central1",
         string publisher = "google",
-        string model = "gemini-2.0-flash-001")
+        string model = "gemini-2.5-flash")
     {
 
         var predictionServiceClient = new PredictionServiceClientBuilder
@@ -362,7 +362,7 @@ public class ControlledGeneration
         string projectId = "your-project-id",
         string location = "us-central1",
         string publisher = "google",
-        string model = "gemini-2.0-flash-001")
+        string model = "gemini-2.5-flash")
     {
 
         var predictionServiceClient = new PredictionServiceClientBuilder

--- a/aiplatform/api/AIPlatform.Samples/FunctionCalling.cs
+++ b/aiplatform/api/AIPlatform.Samples/FunctionCalling.cs
@@ -28,7 +28,7 @@ public class FunctionCalling
         string projectId = "your-project-id",
         string location = "us-central1",
         string publisher = "google",
-        string model = "gemini-2.0-flash-001")
+        string model = "gemini-2.5-flash")
     {
         var predictionServiceClient = new PredictionServiceClientBuilder
         {

--- a/aiplatform/api/AIPlatform.Samples/GeminiQuickstart.cs
+++ b/aiplatform/api/AIPlatform.Samples/GeminiQuickstart.cs
@@ -27,7 +27,7 @@ public class GeminiQuickstart
         string projectId = "your-project-id",
         string location = "us-central1",
         string publisher = "google",
-        string model = "gemini-2.0-flash-001"
+        string model = "gemini-2.5-flash"
     )
     {
         // Create client

--- a/aiplatform/api/AIPlatform.Samples/GetTokenCount.cs
+++ b/aiplatform/api/AIPlatform.Samples/GetTokenCount.cs
@@ -27,7 +27,7 @@ public class GetTokenCount
         string projectId = "your-project-id",
         string location = "us-central1",
         string publisher = "google",
-        string model = "gemini-2.0-flash-001"
+        string model = "gemini-2.5-flash"
     )
     {
         var client = new LlmUtilityServiceClientBuilder

--- a/aiplatform/api/AIPlatform.Samples/GroundingVertexAiSearchSample.cs
+++ b/aiplatform/api/AIPlatform.Samples/GroundingVertexAiSearchSample.cs
@@ -26,7 +26,7 @@ public class GroundingVertexAiSearchSample
         string projectId = "your-project-id",
         string location = "us-central1",
         string publisher = "google",
-        string model = "gemini-2.0-flash-001",
+        string model = "gemini-2.5-flash",
         string dataStoreLocation = "global",
         string dataStoreId = "your-datastore-id")
     {

--- a/aiplatform/api/AIPlatform.Samples/GroundingWebSample.cs
+++ b/aiplatform/api/AIPlatform.Samples/GroundingWebSample.cs
@@ -27,7 +27,7 @@ public class GroundingWebSample
         string projectId = "your-project-id",
         string location = "us-central1",
         string publisher = "google",
-        string model = "gemini-2.0-flash-001"
+        string model = "gemini-2.5-flash"
     )
     {
         var predictionServiceClient = new PredictionServiceClientBuilder

--- a/aiplatform/api/AIPlatform.Samples/MultiTurnChatSample.cs
+++ b/aiplatform/api/AIPlatform.Samples/MultiTurnChatSample.cs
@@ -27,7 +27,7 @@ public class MultiTurnChatSample
         string projectId = "your-project-id",
         string location = "us-central1",
         string publisher = "google",
-        string model = "gemini-2.0-flash-001"
+        string model = "gemini-2.5-flash"
     )
     {
         // Create a chat session to keep track of the context

--- a/aiplatform/api/AIPlatform.Samples/MultimodalAllInput.cs
+++ b/aiplatform/api/AIPlatform.Samples/MultimodalAllInput.cs
@@ -26,7 +26,7 @@ public class MultimodalAllInput
         string projectId = "your-project-id",
         string location = "us-central1",
         string publisher = "google",
-        string model = "gemini-2.0-flash-001")
+        string model = "gemini-2.5-flash")
     {
 
         var predictionServiceClient = new PredictionServiceClientBuilder

--- a/aiplatform/api/AIPlatform.Samples/MultimodalMultiImage.cs
+++ b/aiplatform/api/AIPlatform.Samples/MultimodalMultiImage.cs
@@ -29,7 +29,7 @@ public class MultimodalMultiImage
         string projectId = "your-project-id",
         string location = "us-central1",
         string publisher = "google",
-        string model = "gemini-2.0-flash-001"
+        string model = "gemini-2.5-flash"
     )
     {
         var predictionServiceClient = new PredictionServiceClientBuilder

--- a/aiplatform/api/AIPlatform.Samples/MultimodalVideoInput.cs
+++ b/aiplatform/api/AIPlatform.Samples/MultimodalVideoInput.cs
@@ -27,7 +27,7 @@ public class MultimodalVideoInput
         string projectId = "your-project-id",
         string location = "us-central1",
         string publisher = "google",
-        string model = "gemini-2.0-flash-001"
+        string model = "gemini-2.5-flash"
     )
     {
         var predictionServiceClient = new PredictionServiceClientBuilder

--- a/aiplatform/api/AIPlatform.Samples/PdfInput.cs
+++ b/aiplatform/api/AIPlatform.Samples/PdfInput.cs
@@ -26,7 +26,7 @@ public class PdfInput
         string projectId = "your-project-id",
         string location = "us-central1",
         string publisher = "google",
-        string model = "gemini-2.0-flash-001")
+        string model = "gemini-2.5-flash")
     {
 
         var predictionServiceClient = new PredictionServiceClientBuilder

--- a/aiplatform/api/AIPlatform.Samples/SystemInstruction.cs
+++ b/aiplatform/api/AIPlatform.Samples/SystemInstruction.cs
@@ -26,7 +26,7 @@ public class SystemInstruction
         string projectId = "your-project-id",
         string location = "us-central1",
         string publisher = "google",
-        string model = "gemini-2.0-flash-001")
+        string model = "gemini-2.5-flash")
     {
 
         var predictionServiceClient = new PredictionServiceClientBuilder

--- a/aiplatform/api/AIPlatform.Samples/TextInputSample.cs
+++ b/aiplatform/api/AIPlatform.Samples/TextInputSample.cs
@@ -26,7 +26,7 @@ public class TextInputSample
         string projectId = "your-project-id",
         string location = "us-central1",
         string publisher = "google",
-        string model = "gemini-2.0-flash-001")
+        string model = "gemini-2.5-flash")
     {
 
         var predictionServiceClient = new PredictionServiceClientBuilder

--- a/aiplatform/api/AIPlatform.Samples/VideoInputWithAudio.cs
+++ b/aiplatform/api/AIPlatform.Samples/VideoInputWithAudio.cs
@@ -26,7 +26,7 @@ public class VideoInputWithAudio
         string projectId = "your-project-id",
         string location = "us-central1",
         string publisher = "google",
-        string model = "gemini-2.0-flash-001")
+        string model = "gemini-2.5-flash")
     {
 
         var predictionServiceClient = new PredictionServiceClientBuilder

--- a/aiplatform/api/AIPlatform.Samples/WithSafetySettings.cs
+++ b/aiplatform/api/AIPlatform.Samples/WithSafetySettings.cs
@@ -28,7 +28,7 @@ public class WithSafetySettings
         string projectId = "your-project-id",
         string location = "us-central1",
         string publisher = "google",
-        string model = "gemini-2.0-flash-001"
+        string model = "gemini-2.5-flash"
     )
     {
         var predictionServiceClient = new PredictionServiceClientBuilder


### PR DESCRIPTION
# fix(aiplatform): update Gemini model references to gemini-2.5-flash

## Description
This PR updates the default Gemini model references used across the .NET AI Platform samples (`aiplatform/api/AIPlatform.Samples`) and integration tests from `gemini-2.0-flash-001` to `gemini-2.5-flash`.

**Reason for Update:**
`gemini-2.0-flash-001` was decommissioned on June 1, 2026. Continued use of the decommissioned model results in service disruptions and `NotFound` RPC errors during sample execution. Upgrading to `gemini-2.5-flash` ensures active service availability, resolves API errors, and aligns the .NET samples with current Vertex AI model support.

Fixes Internal: b/542706371